### PR TITLE
Fix daemon re-exec through etserver symlink

### DIFF
--- a/crates/et-bin/src/server_daemon.rs
+++ b/crates/et-bin/src/server_daemon.rs
@@ -22,8 +22,14 @@ pub const DEFAULT_PID_FILE: &str = "etserver.pid";
 /// The child receives the original arguments with `--daemon` replaced by the
 /// internal `--daemon-child` marker so it knows to finish detaching.
 pub fn spawn_detached(args: &[std::ffi::OsString]) -> Result<(), String> {
+    // `current_exe()` can preserve the `etserver` busybox-style symlink on
+    // macOS. Re-executing that path with the explicit `server` subcommand
+    // would then parse as `etserver server …`; use the real binary so the
+    // explicit role selection below is unambiguous on every Unix platform.
     let executable = std::env::current_exe()
-        .map_err(|error| format!("could not locate etserver executable: {error}"))?;
+        .map_err(|error| format!("could not locate etserver executable: {error}"))?
+        .canonicalize()
+        .map_err(|error| format!("could not resolve etserver executable: {error}"))?;
     let mut child = Command::new(executable);
     child.arg("server");
     for argument in args {


### PR DESCRIPTION
Fixes the macOS daemon e2e failure in issue #4.

`std::env::current_exe()` can retain the busybox-style `etserver` symlink on macOS. The detached child was then invoked as `etserver server --daemon-child …`, so Clap rejected the extra `server` argument before it could write the pid file.

Canonicalize the executable before explicitly re-executing it as `et server …`.

Validated on Apple Silicon macOS with:

`cargo test -p et --test server_runtime daemon_mode_detaches_and_writes_a_pid_file -- --exact`

The separate PTY/reconnect failures from #4 remain open and are not masked by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix macOS daemon re-exec so the detached child starts correctly and writes the PID file. Addresses the daemon e2e failure in issue #4.

- **Bug Fixes**
  - Canonicalize `std::env::current_exe()` to resolve the busybox-style `etserver` symlink before re-exec.
  - Avoid `clap` rejecting an extra `server` token by invoking the real binary with the explicit `server` subcommand.

<sup>Written for commit f22eb6184cfc064438312deb583f1e2568784267. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

