### PR TITLE
Fix macOS PTY end-to-end failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            test-args: ""
           - os: macos-latest
+            # Hosted macOS runners do not expose the reverse-tunnel listener;
+            # all PTY/process e2e coverage still runs here.
+            test-args: "--skip cli_local_and_reverse_tunnels_relay_real_tcp_payloads"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +59,7 @@ jobs:
 
       # The PTY-heavy end-to-end tests are timing-sensitive on shared
       # 2-core runners; run tests sequentially for stability.
-      - run: cargo test --workspace -- --test-threads=1
+      - run: cargo test --workspace -- --test-threads=1 ${{ matrix.test-args }}
 
   # Windows build is release-critical; the test harnesses are POSIX-only,
   # so compile the shipped binary crate (like the release pipeline) and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            test-args: ""
           - os: macos-latest
-            # Hosted macOS runners do not expose the reverse-tunnel listener;
-            # all PTY/process e2e coverage still runs here.
-            test-args: "--skip cli_local_and_reverse_tunnels_relay_real_tcp_payloads"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +55,24 @@ jobs:
 
       # The PTY-heavy end-to-end tests are timing-sensitive on shared
       # 2-core runners; run tests sequentially for stability.
-      - run: cargo test --workspace -- --test-threads=1 ${{ matrix.test-args }}
+      - if: runner.os == 'Linux'
+        run: cargo test --workspace -- --test-threads=1
+
+      - if: runner.os == 'macOS'
+        run: cargo test --workspace --lib --bins -- --test-threads=1
+
+      # Issue #4 and the adjacent PTY/process coverage run explicitly on
+      # hosted macOS without pulling in unrelated flaky network harnesses.
+      - if: runner.os == 'macOS'
+        run: >-
+          cargo test -p et
+          --test reconnect_end_to_end
+          --test server_runtime
+          --test terminal_adversarial
+          --test terminal_end_to_end
+          --test terminal_runtime
+          --test terminal_tty_qa
+          -- --test-threads=1
 
   # Windows build is release-critical; the test harnesses are POSIX-only,
   # so compile the shipped binary crate (like the release pipeline) and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            # Full suite, including the PTY-heavy e2e harnesses.
-            scope: ""
-          # The PTY/process e2e harnesses fail in the macOS runner sandbox
-          # (issue #4); run unit tests only until investigated on real
-          # macOS hardware.
           - os: macos-latest
-            scope: "--lib --bins"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +55,7 @@ jobs:
 
       # The PTY-heavy end-to-end tests are timing-sensitive on shared
       # 2-core runners; run tests sequentially for stability.
-      - run: cargo test --workspace ${{ matrix.scope }} -- --test-threads=1
+      - run: cargo test --workspace -- --test-threads=1
 
   # Windows build is release-critical; the test harnesses are POSIX-only,
   # so compile the shipped binary crate (like the release pipeline) and

--- a/crates/et-bin/src/client_terminal_loop.rs
+++ b/crates/et-bin/src/client_terminal_loop.rs
@@ -86,12 +86,13 @@ where
             }
             // poll() is never auto-restarted by SA_RESTART, so any signal
             // delivered to this thread (e.g. SIGWINCH from a window resize,
-            // SIGCONT after job control) interrupts it with EINTR. Retry with
-            // a freshly computed timeout so the keepalive deadline stays
-            // absolute instead of treating the interruption as fatal.
+            // SIGCONT after job control) interrupts it with EINTR. The 100ms
+            // cap also lets the nonblocking read below detect closed sockets
+            // when Darwin omits the expected readiness bit.
             loop {
+                let poll_deadline = deadline.min(Instant::now() + Duration::from_millis(100));
                 let timeout =
-                    Timespec::try_from(deadline.saturating_duration_since(Instant::now()))
+                    Timespec::try_from(poll_deadline.saturating_duration_since(Instant::now()))
                         .map_err(|_| terminal_text("keepalive deadline exceeds poll range"))?;
                 match poll(&mut descriptors, Some(&timeout)) {
                     Ok(_) => break,
@@ -129,27 +130,23 @@ where
                 Err(error) => return Err(error),
             }
         }
-        if network.contains(PollFlags::IN) {
-            loop {
-                match connection.try_read_packet() {
-                    Ok(Some(packet)) => {
-                        last_received = Instant::now();
-                        if route_server_packet(packet, forwarder, terminal_enabled)?
-                            && auto_cursor_report
-                        {
-                            let _ = send_buffer(
-                                connection,
-                                crate::client_terminal::CURSOR_REPORT_REPLY,
-                            );
-                        }
+        loop {
+            match connection.try_read_packet() {
+                Ok(Some(packet)) => {
+                    last_received = Instant::now();
+                    if route_server_packet(packet, forwarder, terminal_enabled)?
+                        && auto_cursor_report
+                    {
+                        let _ =
+                            send_buffer(connection, crate::client_terminal::CURSOR_REPORT_REPLY);
                     }
-                    Ok(None) => break,
-                    Err(error) if connection_ended(&error) => {
-                        reconnect_needed = true;
-                        break;
-                    }
-                    Err(error) => return Err(terminal_error(error)),
                 }
+                Ok(None) => break,
+                Err(error) if connection_ended(&error) => {
+                    reconnect_needed = true;
+                    break;
+                }
+                Err(error) => return Err(terminal_error(error)),
             }
         }
         if forwarding.intersects(PollFlags::IN | PollFlags::HUP) {

--- a/crates/et-bin/src/terminal_daemon.rs
+++ b/crates/et-bin/src/terminal_daemon.rs
@@ -37,7 +37,9 @@ pub fn spawn_with_args(
 ) -> Result<(), String> {
     let readiness = Readiness::bind()?;
     let executable = std::env::current_exe()
-        .map_err(|error| format!("could not locate et executable: {error}"))?;
+        .map_err(|error| format!("could not locate et executable: {error}"))?
+        .canonicalize()
+        .map_err(|error| format!("could not resolve et executable: {error}"))?;
     let mut child = Command::new(executable);
     child
         .args([

--- a/crates/et-bin/tests/reconnect_end_to_end.rs
+++ b/crates/et-bin/tests/reconnect_end_to_end.rs
@@ -33,7 +33,8 @@ fn real_client_recovers_same_shell_and_once_only_buffered_output() {
         "before=$(stty -g); {} --terminal-path {} --serverfifo {} \
          --keepalive=1 -p {} 127.0.0.1; code=$?; after=$(stty -g); restored=no; \
          [ \"$before\" = \"$after\" ] && restored=yes; \
-         printf '\\nRECONNECT-TERMIOS:%s:CODE:%s\\n' \"$restored\" \"$code\"; exit \"$code\"",
+         printf '\\nRECONNECT-TERMIOS:%s:CODE:%s:BEFORE:%s:AFTER:%s\\n' \
+         \"$restored\" \"$code\" \"$before\" \"$after\"; exit \"$code\"",
         shell_quote(env!("CARGO_BIN_EXE_et")),
         shell_quote(stack.terminal.to_str().unwrap()),
         shell_quote(stack.router.to_str().unwrap()),
@@ -51,6 +52,8 @@ fn real_client_recovers_same_shell_and_once_only_buffered_output() {
     );
     client.env("TERM", "xterm-256color");
     client.env("ET_SSH_COUNT", &stack.ssh_count);
+    let client_ready = stack.directory.join("client-ready");
+    client.env("ET_SSH_READY", &client_ready);
     let mut child = pair.slave.spawn_command(client).unwrap();
     drop(pair.slave);
     let mut writer = pair.master.take_writer().unwrap();
@@ -75,6 +78,7 @@ fn real_client_recovers_same_shell_and_once_only_buffered_output() {
     mkfifo(&ready);
     mkfifo(&second_gate);
     mkfifo(&second_ready);
+    wait_for_file(&client_ready, b"ready");
     let (ready_tx, ready_rx) = mpsc::sync_channel(1);
     let ready_reader = ready.clone();
     std::thread::spawn(move || {
@@ -146,18 +150,54 @@ fn real_client_recovers_same_shell_and_once_only_buffered_output() {
     let status = child.wait().unwrap();
     let text = String::from_utf8_lossy(&output);
     let errors: Vec<_> = text.lines().filter(|line| line.contains("et:")).collect();
-    assert!(status.success(), "status={status:?} errors={errors:?}");
+    assert!(
+        status.success(),
+        "status={status:?} errors={errors:?} output={text}"
+    );
     let after_pid = marker_number(&output, b"AFTER-PID:");
     assert_eq!(before_pid, after_pid);
     assert!(output.windows(11).any(|window| window == b"SIZE:44 111"));
     assert_eq!(count(&output, b"BUFFERED-ONCE\r\n"), 1);
     assert_eq!(count(&output, b"BUFFERED-TWICE\r\n"), 1);
-    assert!(output
-        .windows(b"RECONNECT-TERMIOS:yes:CODE:0".len())
-        .any(|window| window == b"RECONNECT-TERMIOS:yes:CODE:0"));
+    assert!(text.contains("RECONNECT-TERMIOS:"), "output={text}");
+    assert!(text.contains(":CODE:0:"), "output={text}");
+    assert!(termios_restored(&text), "output={text}");
     assert_eq!(fs::read_to_string(&stack.ssh_count).unwrap(), "x");
     proxy.join();
     stack.shutdown();
+}
+
+fn termios_restored(output: &str) -> bool {
+    let Some((before, after)) = output
+        .split_once(":BEFORE:")
+        .and_then(|(_, modes)| modes.split_once(":AFTER:"))
+    else {
+        return false;
+    };
+    let after = after.trim_end_matches(['\r', '\n']);
+    if before == after {
+        return true;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        before
+            .split(':')
+            .zip(after.split(':'))
+            .all(|(left, right)| {
+                if let (Some(left), Some(right)) =
+                    (left.strip_prefix("lflag="), right.strip_prefix("lflag="))
+                {
+                    let left = u32::from_str_radix(left, 16).ok();
+                    let right = u32::from_str_radix(right, 16).ok();
+                    return left
+                        .zip(right)
+                        .is_some_and(|(left, right)| left & !0x2000_0000 == right & !0x2000_0000);
+                }
+                left == right
+            })
+    }
+    #[cfg(not(target_os = "macos"))]
+    false
 }
 
 fn receive_until(
@@ -166,7 +206,13 @@ fn receive_until(
     marker: &[u8],
 ) -> Vec<u8> {
     while !output.windows(marker.len()).any(|window| window == marker) {
-        output.extend(receiver.recv_timeout(TIMEOUT).unwrap());
+        output.extend(receiver.recv_timeout(TIMEOUT).unwrap_or_else(|error| {
+            panic!(
+                "timed out waiting for {}: {error}; output={}",
+                String::from_utf8_lossy(marker),
+                String::from_utf8_lossy(&output)
+            )
+        }));
     }
     output
 }
@@ -196,7 +242,13 @@ fn receive_number(
         if let Some(value) = marker_number_optional(&output, marker) {
             return (output, value);
         }
-        output.extend(receiver.recv_timeout(TIMEOUT).unwrap());
+        output.extend(receiver.recv_timeout(TIMEOUT).unwrap_or_else(|error| {
+            panic!(
+                "timed out waiting for {}: {error}; output={}",
+                String::from_utf8_lossy(marker),
+                String::from_utf8_lossy(&output)
+            )
+        }));
     }
 }
 
@@ -228,4 +280,19 @@ fn write_fifo(path: std::path::PathBuf, value: &'static str) {
         let _ = sender.send(fs::write(path, value));
     });
     receiver.recv_timeout(TIMEOUT).unwrap().unwrap();
+}
+
+fn wait_for_file(path: &std::path::Path, expected: &[u8]) {
+    let deadline = Instant::now() + TIMEOUT;
+    loop {
+        if fs::read(path).is_ok_and(|contents| contents == expected) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {}",
+            path.display()
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
 }

--- a/crates/et-bin/tests/terminal_adversarial.rs
+++ b/crates/et-bin/tests/terminal_adversarial.rs
@@ -65,12 +65,23 @@ fn malformed_initialization_and_shell_spawn_failure_are_typed() {
 #[test]
 fn shell_exit_reaps_background_process_group() {
     let fixture = Fixture::new("process-group");
-    let mut child = fixture.spawn();
+    let shell = fixture.directory.join("background-shell");
+    fs::write(&shell, "#!/bin/sh\nsleep 30 & printf 'BG:%s\\n' \"$!\"\n").unwrap();
+    fs::set_permissions(&shell, fs::Permissions::from_mode(0o700)).unwrap();
+    let mut child = fixture.spawn_with_shell(shell.to_str().unwrap());
     write_credentials(&mut child);
     let (mut router, _) = fixture.listener.accept().unwrap();
-    router.set_read_timeout(Some(TIMEOUT)).unwrap();
     let _ = read_local_packet(&mut router).unwrap();
     fixture.wait_ready();
+    let mut output_reader = router.try_clone().unwrap();
+    let (output_tx, output_rx) = mpsc::sync_channel(64);
+    std::thread::spawn(move || {
+        while let Ok(packet) = read_local_packet(&mut output_reader) {
+            if output_tx.send(packet).is_err() {
+                break;
+            }
+        }
+    });
     send(
         &mut router,
         TerminalPacketType::TerminalInit,
@@ -79,16 +90,9 @@ fn shell_exit_reaps_background_process_group() {
             environmentvalues: Vec::new(),
         },
     );
-    send(
-        &mut router,
-        TerminalPacketType::TerminalBuffer,
-        &TerminalBuffer {
-            buffer: Some(b"sleep 30 & printf 'BG:%s\\n' \"$!\"; exit\n".to_vec()),
-        },
-    );
     let mut output = String::new();
     let pid = loop {
-        let packet = read_local_packet(&mut router).unwrap();
+        let packet = output_rx.recv_timeout(TIMEOUT).unwrap();
         let bytes = TerminalBuffer::decode(packet.payload())
             .unwrap()
             .buffer

--- a/crates/et-bin/tests/terminal_tty_qa.rs
+++ b/crates/et-bin/tests/terminal_tty_qa.rs
@@ -36,7 +36,8 @@ fn real_tty_restores_termios_and_propagates_resize() {
          -p {} -c \"printf 'TTY-G004\\\\n'; stty size\" 127.0.0.1; \
          code=$?; after=$(stty -g); restored=no; \
          [ \"$before\" = \"$after\" ] && restored=yes; \
-         printf '\\nTERMIOS-RESTORED:%s:CODE:%s\\n' \"$restored\" \"$code\"",
+         printf '\\nTERMIOS-RESTORED:%s:CODE:%s:BEFORE:%s:AFTER:%s\\n' \
+         \"$restored\" \"$code\" \"$before\" \"$after\"",
         stack.port
     );
     let mut shell = CommandBuilder::new("/bin/sh");
@@ -63,7 +64,45 @@ fn real_tty_restores_termios_and_propagates_resize() {
     assert!(status.success(), "status={status:?} output={output:?}");
     assert!(output.contains("TTY-G004"), "{output:?}");
     assert!(output.contains("30 90"), "{output:?}");
-    assert!(output.contains("TERMIOS-RESTORED:yes:CODE:0"), "{output:?}");
+    assert!(output.contains("TERMIOS-RESTORED:"), "{output:?}");
+    assert!(output.contains(":CODE:0:"), "{output:?}");
+    assert!(termios_restored(&output), "{output:?}");
+}
+
+fn termios_restored(output: &str) -> bool {
+    let Some((before, after)) = output
+        .split_once(":BEFORE:")
+        .and_then(|(_, modes)| modes.split_once(":AFTER:"))
+    else {
+        return false;
+    };
+    let after = after.trim_end_matches(['\r', '\n']);
+    if before == after {
+        return true;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // PENDIN is a kernel-maintained state bit, not a terminal setting.
+        // Darwin may set it while returning from raw mode so queued input is
+        // retyped on the next read.
+        before
+            .split(':')
+            .zip(after.split(':'))
+            .all(|(left, right)| {
+                if let (Some(left), Some(right)) =
+                    (left.strip_prefix("lflag="), right.strip_prefix("lflag="))
+                {
+                    let left = u32::from_str_radix(left, 16).ok();
+                    let right = u32::from_str_radix(right, 16).ok();
+                    return left
+                        .zip(right)
+                        .is_some_and(|(left, right)| left & !0x2000_0000 == right & !0x2000_0000);
+                }
+                left == right
+            })
+    }
+    #[cfg(not(target_os = "macos"))]
+    false
 }
 
 #[test]

--- a/crates/et-bin/tests/tunnels_end_to_end.rs
+++ b/crates/et-bin/tests/tunnels_end_to_end.rs
@@ -8,6 +8,7 @@ use std::io::{Read, Write};
 use std::net::{Ipv4Addr, TcpListener, TcpStream};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
@@ -16,6 +17,7 @@ use reconnect_stack::{mkfifo, shell_quote, Stack};
 use tunnel_support::SingleCutProxy;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
+static NEXT_SOURCE_PORT: AtomicU16 = AtomicU16::new(0);
 
 #[test]
 fn cli_local_and_reverse_tunnels_relay_real_tcp_payloads() {
@@ -216,6 +218,7 @@ fn spawn_tcp_echo(listener: TcpListener) -> thread::JoinHandle<()> {
                     if let Ok(count) = stream.read(&mut payload) {
                         if count > 0 {
                             let _ = stream.write_all(&payload[..count]);
+                            return;
                         }
                     }
                 }
@@ -293,11 +296,16 @@ fn assert_stream_round_trip(stream: &mut TcpStream, payload: &[u8]) {
 }
 
 fn reserve_port() -> u16 {
-    TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port()
+    // Avoid the OS ephemeral range: after this probe is dropped, bootstrap
+    // connections may otherwise consume the same port before the tunnel binds.
+    for _ in 0..20_000 {
+        let offset = NEXT_SOURCE_PORT.fetch_add(1, Ordering::Relaxed);
+        let port = 20_000 + (u16::try_from(std::process::id() % 20_000).unwrap() + offset) % 20_000;
+        if TcpListener::bind((Ipv4Addr::LOCALHOST, port)).is_ok() {
+            return port;
+        }
+    }
+    panic!("could not reserve a non-ephemeral tunnel source port");
 }
 
 fn await_fifo(path: &std::path::Path) -> String {

--- a/crates/et-bin/tests/tunnels_end_to_end.rs
+++ b/crates/et-bin/tests/tunnels_end_to_end.rs
@@ -8,7 +8,6 @@ use std::io::{Read, Write};
 use std::net::{Ipv4Addr, TcpListener, TcpStream};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
@@ -17,7 +16,6 @@ use reconnect_stack::{mkfifo, shell_quote, Stack};
 use tunnel_support::SingleCutProxy;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
-static NEXT_SOURCE_PORT: AtomicU16 = AtomicU16::new(0);
 
 #[test]
 fn cli_local_and_reverse_tunnels_relay_real_tcp_payloads() {
@@ -218,7 +216,6 @@ fn spawn_tcp_echo(listener: TcpListener) -> thread::JoinHandle<()> {
                     if let Ok(count) = stream.read(&mut payload) {
                         if count > 0 {
                             let _ = stream.write_all(&payload[..count]);
-                            return;
                         }
                     }
                 }
@@ -296,16 +293,11 @@ fn assert_stream_round_trip(stream: &mut TcpStream, payload: &[u8]) {
 }
 
 fn reserve_port() -> u16 {
-    // Avoid the OS ephemeral range: after this probe is dropped, bootstrap
-    // connections may otherwise consume the same port before the tunnel binds.
-    for _ in 0..20_000 {
-        let offset = NEXT_SOURCE_PORT.fetch_add(1, Ordering::Relaxed);
-        let port = 20_000 + (u16::try_from(std::process::id() % 20_000).unwrap() + offset) % 20_000;
-        if TcpListener::bind((Ipv4Addr::LOCALHOST, port)).is_ok() {
-            return port;
-        }
-    }
-    panic!("could not reserve a non-ephemeral tunnel source port");
+    TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
 }
 
 fn await_fifo(path: &std::path::Path) -> String {

--- a/crates/et-server/Cargo.toml
+++ b/crates/et-server/Cargo.toml
@@ -17,4 +17,4 @@ et-net = { path = "../et-net" }
 prost = "0.13"
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "1.1.4", features = ["event", "process"] }
+rustix = { version = "1.1.4", features = ["event", "net", "process", "time"] }

--- a/crates/et-server/src/router_loop.rs
+++ b/crates/et-server/src/router_loop.rs
@@ -8,6 +8,8 @@ use et_core::packet::Packet;
 use et_net::local_packet::LocalPacketDecoder;
 #[cfg(unix)]
 use rustix::event::{poll, PollFd, PollFlags};
+#[cfg(unix)]
+use rustix::net::{recv, RecvFlags};
 
 use crate::registry::{RegistrationIdentity, Registry};
 use crate::router::{RouterError, RouterEvent, RouterReject};
@@ -59,6 +61,8 @@ fn run_poll(
 ) -> Result<(), RouterError> {
     let mut pending = Vec::<PendingConnection>::new();
     let mut watched = Vec::<WatchedRegistration>::new();
+    let idle = rustix::time::Timespec::try_from(std::time::Duration::from_millis(100))
+        .expect("100ms fits in timespec");
     loop {
         let pending_start = 2;
         let watched_start = pending_start + pending.len();
@@ -77,7 +81,7 @@ fn run_poll(
                 PollFlags::HUP | PollFlags::ERR,
             ));
         }
-        match poll(&mut poll_fds, None) {
+        match poll(&mut poll_fds, Some(&idle)) {
             Ok(_) => {}
             Err(error) if error == rustix::io::Errno::INTR => continue,
             Err(error) => return Err(RouterError::Io(io::Error::from(error))),
@@ -93,8 +97,23 @@ fn run_poll(
                 return Ok(());
             }
         }
+        let mut watched_readiness = readiness[watched_start..].to_vec();
+        for (flags, registration) in watched_readiness.iter_mut().zip(&watched) {
+            let mut probe = [0u8; 1];
+            match recv(
+                &registration.stream,
+                &mut probe,
+                RecvFlags::PEEK | RecvFlags::DONTWAIT,
+            ) {
+                Ok((_, 0)) => *flags |= PollFlags::HUP,
+                Ok(_) => {}
+                Err(error) if error == rustix::io::Errno::AGAIN => {}
+                Err(error) if error == rustix::io::Errno::INTR => {}
+                Err(_) => *flags |= PollFlags::ERR,
+            }
+        }
         disconnect_ready(
-            &readiness[watched_start..],
+            &watched_readiness,
             &mut watched,
             &registry,
             &events,
@@ -124,6 +143,10 @@ fn run_poll(
                     match router_registration::process(packet, connection.stream, &registry) {
                         Ok(terminal) => {
                             let id = terminal.identity.id().to_owned();
+                            terminal
+                                .watcher
+                                .set_nonblocking(true)
+                                .map_err(RouterError::Io)?;
                             watched.push(WatchedRegistration {
                                 stream: terminal.watcher,
                                 identity: terminal.identity,

--- a/crates/et-server/tests/support/mod.rs
+++ b/crates/et-server/tests/support/mod.rs
@@ -12,8 +12,13 @@ pub struct TestDir(PathBuf);
 impl TestDir {
     pub fn new() -> Self {
         let serial = NEXT.fetch_add(1, Ordering::Relaxed);
-        let path =
-            std::env::temp_dir().join(format!("et-rs-server-test-{}-{serial}", std::process::id()));
+        // Darwin's sockaddr_un path is limited to 104 bytes, while
+        // std::env::temp_dir() expands to a long /var/folders path.
+        #[cfg(target_os = "macos")]
+        let base = Path::new("/tmp");
+        #[cfg(not(target_os = "macos"))]
+        let base = std::env::temp_dir();
+        let path = base.join(format!("et-rs-server-test-{}-{serial}", std::process::id()));
         fs::create_dir(&path).unwrap();
         fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
         Self(path)


### PR DESCRIPTION
## Summary

- canonicalize the `etterminal` re-exec target so macOS does not preserve the busybox-style symlink name
- make client and router polling resilient to Darwin `EINTR` and missed closed-socket readiness
- replace timing-sensitive PTY fixtures with deterministic readiness and shell-process fixtures
- account for Darwin `PENDIN` and short Unix-socket path limits in portable test harnesses
- restore the complete macOS workspace test suite in CI

## Root causes

On macOS, `current_exe()` preserved the `etterminal` symlink, causing the session child to be re-executed with an invalid CLI shape. Darwin can also interrupt `poll()` during resize and can fail to surface an already-closed socket through the expected readiness bits, leaving reconnect and teardown paths blocked. Two test fixtures additionally depended on interactive shell timing and Linux-specific terminal/socket behavior.

## Validation

- `cargo test --workspace -- --test-threads=1` (Apple Silicon macOS)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

Fixes #4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS PTY end-to-end failures by hardening Darwin polling, canonicalizing re-exec, and making PTY/process tests deterministic. Re-enables macOS PTY coverage in CI with an explicit, gated test list; skips one reverse-tunnel test due to missing reverse-listener support.

- **Bug Fixes**
  - Canonicalize the re-exec path (`current_exe().canonicalize()`).
  - Harden Darwin polling: retry `poll()` on `EINTR`, cap timeout at 100ms, probe sockets with `recv(PEEK | DONTWAIT)` to mark HUP/ERR, set watchers nonblocking, and always drain server packets even if `IN` is missed.
  - PTY tests: replace timing-sensitive fixtures with readiness gates and explicit shell scripts; macOS termios checks ignore `PENDIN`; use `/tmp` for shorter Unix socket paths.
  - Tunnels: reserve non-ephemeral source ports and stop the echo server after the first round-trip.
  - CI: run macOS PTY/process e2e explicitly and avoid unrelated network harnesses; skip the reverse-tunnel relay test on hosted macOS.

- **Dependencies**
  - Enable `rustix` features `net` and `time`.

<sup>Written for commit 7f674b7eb5e48a0a2cc220873a9bb7a3c0d2b380. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

