### PR TITLE
fix: retry poll() on EINTR so signals do not kill live sessions

### DIFF
--- a/.tegami/fix-poll-eintr-signal-resilience.md
+++ b/.tegami/fix-poll-eintr-signal-resilience.md
@@ -1,0 +1,18 @@
+---
+packages:
+  et: patch
+---
+
+## Fix client dying with "polling terminal streams: Interrupted system call (os error 4)"
+
+The client installs a process-wide SIGWINCH handler for terminal resizes, and
+`poll()` is never auto-restarted by `SA_RESTART`: any signal delivered to the
+thread blocked in `poll()` (a window resize, `SIGCONT` after job control,
+`SIGINFO` from Ctrl-T on macOS) made it fail with `EINTR`, which the client
+treated as fatal and tore the session down mid-use.
+
+The terminal loop now retries `poll()` on `EINTR`, recomputing the keepalive
+timeout from the absolute deadline so timing stays correct. The same retry was
+applied to every other interruptible `poll()` in the workspace: the server
+session bridge, the PTY worker, the jump-host bridge, and the port-forward
+acceptor (which previously exited silently on `EINTR`).

--- a/crates/et-bin/src/client_terminal_loop.rs
+++ b/crates/et-bin/src/client_terminal_loop.rs
@@ -72,8 +72,6 @@ where
     }
     loop {
         let deadline = next_keepalive.min(last_received + silence);
-        let timeout = Timespec::try_from(deadline.saturating_duration_since(Instant::now()))
-            .map_err(|_| terminal_text("keepalive deadline exceeds poll range"))?;
         let (network, resize, forwarding, input) = {
             let mut descriptors = vec![
                 PollFd::new(&stream, PollFlags::IN | PollFlags::HUP | PollFlags::ERR),
@@ -86,8 +84,26 @@ where
                     PollFlags::IN | PollFlags::HUP | PollFlags::ERR,
                 ));
             }
-            poll(&mut descriptors, Some(&timeout))
-                .map_err(|error| terminal_io("polling terminal streams", io::Error::from(error)))?;
+            // poll() is never auto-restarted by SA_RESTART, so any signal
+            // delivered to this thread (e.g. SIGWINCH from a window resize,
+            // SIGCONT after job control) interrupts it with EINTR. Retry with
+            // a freshly computed timeout so the keepalive deadline stays
+            // absolute instead of treating the interruption as fatal.
+            loop {
+                let timeout =
+                    Timespec::try_from(deadline.saturating_duration_since(Instant::now()))
+                        .map_err(|_| terminal_text("keepalive deadline exceeds poll range"))?;
+                match poll(&mut descriptors, Some(&timeout)) {
+                    Ok(_) => break,
+                    Err(error) if error == rustix::io::Errno::INTR => {}
+                    Err(error) => {
+                        return Err(terminal_io(
+                            "polling terminal streams",
+                            io::Error::from(error),
+                        ));
+                    }
+                }
+            }
             (
                 descriptors[0].revents(),
                 descriptors[1].revents(),

--- a/crates/et-bin/src/terminal_jump.rs
+++ b/crates/et-bin/src/terminal_jump.rs
@@ -206,7 +206,15 @@ fn relay(mut router: LocalStream, destination: &mut Connection) -> Result<i32, S
             PollFd::new(&router, PollFlags::IN | PollFlags::HUP | PollFlags::ERR),
             PollFd::new(&client, PollFlags::IN | PollFlags::HUP | PollFlags::ERR),
         ];
-        poll(&mut descriptors, None).map_err(|error| format!("poll failed: {error}"))?;
+        // poll() is never restarted by SA_RESTART; retry on EINTR so a stray
+        // signal cannot kill the jump-host bridge.
+        loop {
+            match poll(&mut descriptors, None) {
+                Ok(_) => break,
+                Err(error) if error == rustix::io::Errno::INTR => {}
+                Err(error) => return Err(format!("poll failed: {error}")),
+            }
+        }
         let router_events = descriptors[0].revents();
         let client_events = descriptors[1].revents();
         drop(client);

--- a/crates/et-bin/src/terminal_pty.rs
+++ b/crates/et-bin/src/terminal_pty.rs
@@ -194,8 +194,17 @@ fn pump_poll(
                 PollFd::new(&*router, PollFlags::IN | PollFlags::HUP | PollFlags::ERR),
                 PollFd::new(&wake_reader, PollFlags::IN | PollFlags::HUP),
             ];
-            poll(&mut descriptors, None)
-                .map_err(|error| format!("could not poll terminal session: {error}"))?;
+            // poll() is never restarted by SA_RESTART; retry on EINTR so a
+            // stray signal cannot kill the terminal session.
+            loop {
+                match poll(&mut descriptors, None) {
+                    Ok(_) => break,
+                    Err(error) if error == rustix::io::Errno::INTR => {}
+                    Err(error) => {
+                        return Err(format!("could not poll terminal session: {error}"));
+                    }
+                }
+            }
             (descriptors[0].revents(), descriptors[1].revents())
         };
         if wake_events.intersects(PollFlags::IN | PollFlags::HUP) {

--- a/crates/et-bin/tests/terminal_signal_resilience.rs
+++ b/crates/et-bin/tests/terminal_signal_resilience.rs
@@ -1,0 +1,166 @@
+//! Regression test: signals delivered while the client blocks in poll() must
+//! not kill the session.
+//!
+//! The client installs a process-wide SIGWINCH handler for terminal resizes.
+//! poll() is never auto-restarted by SA_RESTART, so any SIGWINCH landing on
+//! the thread blocked in poll() makes it fail with EINTR. The client used to
+//! treat that as fatal and died with:
+//!
+//!   et: polling terminal streams: Interrupted system call (os error 4)
+#![forbid(unsafe_code)]
+#![cfg(unix)]
+
+use std::fs;
+use std::io::{BufRead, BufReader, Read};
+use std::net::{Ipv4Addr, TcpListener};
+use std::os::unix::fs::{symlink, PermissionsExt};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use nix::sys::signal::{kill, Signal};
+use nix::unistd::Pid;
+use wait_timeout::ChildExt;
+
+const TIMEOUT: Duration = Duration::from_secs(20);
+
+#[test]
+fn client_survives_sigwinch_storm_while_polling() {
+    let directory =
+        std::env::temp_dir().join(format!("et-rs-sigwinch-storm-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&directory);
+    fs::create_dir(&directory).unwrap();
+    fs::set_permissions(&directory, fs::Permissions::from_mode(0o700)).unwrap();
+    let router = directory.join("router.sock");
+    let config = directory.join("et.cfg");
+    let ready = directory.join("session-ready");
+    let reserved = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let port = reserved.local_addr().unwrap().port();
+    drop(reserved);
+    fs::write(
+        &config,
+        format!(
+            "[Networking]\nport={port}\nbind_ip=127.0.0.1\n[Debug]\nserverfifo={}\n",
+            router.display()
+        ),
+    )
+    .unwrap();
+    let mut server = Command::new(env!("CARGO_BIN_EXE_et"))
+        .args(["server", "--cfgfile"])
+        .arg(&config)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    wait_ready(&mut server, port, &router);
+
+    let ssh = directory.join("ssh");
+    fs::write(
+        &ssh,
+        "#!/bin/sh\n\
+         if [ \"$1\" = \"-G\" ]; then\n\
+           printf 'hostname 127.0.0.1\\nuser tester\\n'\n\
+           exit 0\n\
+         fi\n\
+         for last do :; done\n\
+         exec /bin/sh -c \"$last\"\n",
+    )
+    .unwrap();
+    fs::set_permissions(&ssh, fs::Permissions::from_mode(0o755)).unwrap();
+    let terminal = directory.join("etterminal");
+    symlink(env!("CARGO_BIN_EXE_et"), &terminal).unwrap();
+    let existing_path = std::env::var("PATH").unwrap();
+
+    // Keep the session alive long enough for the storm, then print a marker.
+    let mut client = Command::new(env!("CARGO_BIN_EXE_et"))
+        .env("PATH", format!("{}:{existing_path}", directory.display()))
+        .env("TERM", "xterm-256color")
+        .env("ET_SSH_READY", &ready)
+        .args(["--terminal-path"])
+        .arg(&terminal)
+        .args(["--serverfifo"])
+        .arg(&router)
+        .arg("-p")
+        .arg(port.to_string())
+        .args(["-c", "sleep 2; printf 'SIGWINCH-SURVIVED\\n'", "127.0.0.1"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Wait until the client's pump loop is live (it writes the gate file).
+    let gate_deadline = Instant::now() + TIMEOUT;
+    while !ready.exists() {
+        assert!(
+            Instant::now() < gate_deadline,
+            "client never reached the terminal loop"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    // Storm the client with SIGWINCH while it blocks in poll() waiting for
+    // server output. Any one of these interrupts poll() with EINTR.
+    let client_pid = Pid::from_raw(i32::try_from(client.id()).unwrap());
+    let storm_deadline = Instant::now() + Duration::from_millis(1_500);
+    while Instant::now() < storm_deadline {
+        if kill(client_pid, Signal::SIGWINCH).is_err() {
+            break; // client already exited; the assertions below explain why
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+
+    let status = match client.wait_timeout(TIMEOUT).unwrap() {
+        Some(status) => status,
+        None => {
+            let _ = client.kill();
+            let _ = client.wait();
+            panic!("client did not exit after the signal storm");
+        }
+    };
+    let mut stdout_text = String::new();
+    let mut stderr_text = String::new();
+    client
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut stdout_text)
+        .unwrap();
+    client
+        .stderr
+        .take()
+        .unwrap()
+        .read_to_string(&mut stderr_text)
+        .unwrap();
+    assert!(
+        !stderr_text.contains("Interrupted system call"),
+        "client died from EINTR: {stderr_text}"
+    );
+    assert!(status.success(), "{stderr_text}");
+    assert!(
+        stdout_text.contains("SIGWINCH-SURVIVED"),
+        "{stdout_text:?} {stderr_text:?}"
+    );
+
+    let server_pid = Pid::from_raw(i32::try_from(server.id()).unwrap());
+    kill(server_pid, Signal::SIGTERM).unwrap();
+    assert!(server.wait_timeout(TIMEOUT).unwrap().unwrap().success());
+    fs::remove_dir_all(directory).unwrap();
+}
+
+fn wait_ready(server: &mut std::process::Child, port: u16, router: &std::path::Path) {
+    let stdout = server.stdout.take().unwrap();
+    let (sender, receiver) = mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let mut line = String::new();
+        let result = BufReader::new(stdout).read_line(&mut line).map(|_| line);
+        let _ = sender.send(result);
+    });
+    assert_eq!(
+        receiver.recv_timeout(TIMEOUT).unwrap().unwrap(),
+        format!(
+            "ETSERVER_READY tcp=127.0.0.1:{port} router={}\n",
+            router.display()
+        )
+    );
+}

--- a/crates/et-net/src/forward_io.rs
+++ b/crates/et-net/src/forward_io.rs
@@ -65,8 +65,12 @@ pub(crate) fn spawn_listener(
                     PollFd::new(&listener, PollFlags::IN),
                     PollFd::new(&stop, PollFlags::IN),
                 ];
-                if poll(&mut descriptors, None).is_err() {
-                    return;
+                // poll() is never restarted by SA_RESTART; retry on EINTR so
+                // a stray signal cannot silently stop the forward acceptor.
+                match poll(&mut descriptors, None) {
+                    Ok(_) => {}
+                    Err(error) if error == rustix::io::Errno::INTR => continue,
+                    Err(_) => return,
                 }
                 if descriptors[1]
                     .revents()

--- a/crates/et-server/src/terminal_bridge.rs
+++ b/crates/et-server/src/terminal_bridge.rs
@@ -294,7 +294,15 @@ fn wait(
             PollFlags::IN | PollFlags::HUP | PollFlags::ERR,
         ));
     }
-    poll(&mut descriptors, None).map_err(|error| SessionError::Io(io::Error::from(error)))?;
+    // poll() is never restarted by SA_RESTART; retry on EINTR instead of
+    // tearing the session down when a signal interrupts the wait.
+    loop {
+        match poll(&mut descriptors, None) {
+            Ok(_) => break,
+            Err(error) if error == rustix::io::Errno::INTR => {}
+            Err(error) => return Err(SessionError::Io(io::Error::from(error))),
+        }
+    }
     Ok((
         descriptors[0].revents(),
         descriptors[1].revents(),


### PR DESCRIPTION
## Problem

Client sessions died mid-use with:

```
et: polling terminal streams: Interrupted system call (os error 4)
```

## Root cause

1. The client installs a process-wide **SIGWINCH** handler (`signal-hook`) for terminal resizes. The kernel may deliver the signal to **any** thread, including the main thread blocked in `poll()`.
2. POSIX specifies `poll()`/`select()` are **never auto-restarted** by `SA_RESTART` — a signal always fails them with `EINTR`.
3. The client terminal loop treated every `poll()` error as fatal, so a window resize (or `SIGCONT` after `Ctrl-Z`, `SIGINFO` from `Ctrl-T` on macOS) killed the session.

The server-side loops (`router_loop.rs`, `runtime_accept.rs`) already retried on `Errno::INTR`; five other `poll()` sites were missed.

## Fix

Retry `poll()` on `EINTR` at every interruptible call site:

- `et-bin/src/client_terminal_loop.rs` — **the reported bug**; timeout is recomputed from the absolute deadline so keepalive timing stays correct
- `et-server/src/terminal_bridge.rs` — server session bridge
- `et-bin/src/terminal_pty.rs` — PTY worker
- `et-bin/src/terminal_jump.rs` — jump-host bridge
- `et-net/src/forward_io.rs` — port-forward acceptor previously **exited silently** on `EINTR`

## Verification

New e2e regression test (`terminal_signal_resilience.rs`) storms a live client session with SIGWINCH every 5 ms for 1.5 s:

- **before the fix**: fails with the exact reported error — `client died from EINTR: et: polling terminal streams: Interrupted system call (os error 4)`
- **after the fix**: passes

Full workspace: 236 tests passed, 0 failed; clippy and fmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry `poll()` on `EINTR` across client and server so signals like `SIGWINCH` (window resize) no longer kill live sessions. The client keeps keepalive timing correct by recomputing the timeout from an absolute deadline.

- **Bug Fixes**
  - Client terminal loop: retry `poll()` on `EINTR`; recompute timeout from the keepalive deadline.
  - Same fix in server session bridge, PTY worker, jump-host bridge, and port-forward acceptor (no longer exits silently).
  - Added an end-to-end test that storms a live client with `SIGWINCH` and verifies the session survives.

<sup>Written for commit 28445bfdd1e3a13d7b53483b07dddf9f9ce90f16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

