### PR TITLE
Add macOS PTY fix release note

### DIFF
--- a/.tegami/fix-macos-pty-end-to-end.md
+++ b/.tegami/fix-macos-pty-end-to-end.md
@@ -1,0 +1,14 @@
+---
+packages:
+  et: patch
+---
+
+## Fix macOS reconnect and PTY end-to-end failures
+
+Fix the remaining macOS portability failures in reconnect, terminal shutdown,
+and background process-group cleanup.
+
+The terminal launcher now resolves busybox-style symlinks before re-exec,
+client and router loops detect Darwin socket closure reliably, and the PTY
+fixtures no longer depend on interactive-shell timing. macOS CI now runs the
+affected reconnect and PTY/process integration tests explicitly.


### PR DESCRIPTION
## Summary

- add the missing Tegami patch changelog for the macOS reconnect and PTY fixes merged in #6
- queue `et` for the next patch release (`0.0.5`)

## Validation

- `npm run tegami -- check-publish`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a missing Tegami release note for macOS reconnect and PTY fixes, and queue `et` for the 0.0.5 patch release. This documents symlink resolution before re-exec, reliable Darwin socket closure detection, and timing-independent PTY fixtures so the fixes ship in the next patch.

<sup>Written for commit 87953d0819d877de6f471b6cef154c6fedb16e5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

