### PR TITLE
fix: treat WouldBlock as backpressure in local packet writes

### DIFF
--- a/.tegami/fix-local-packet-wouldblock-backpressure.md
+++ b/.tegami/fix-local-packet-wouldblock-backpressure.md
@@ -1,0 +1,20 @@
+---
+packages:
+  et: patch
+---
+
+## Fix session teardown under local IPC backpressure
+
+`set_nonblocking(true)` applies to the socket, not the handle: every
+`try_clone()` of a local stream shares the flag. The readiness-driven session
+loops flip their local streams to non-blocking for reads, which silently made
+the packet writers on cloned handles non-blocking too. When the kernel socket
+buffer filled (a shell that stops reading input during a large paste, or a
+bridge pausing terminal output while a client reconnects), `write_all` failed
+with `WouldBlock` and tore the whole session down — killing the shell, failing
+the server bridge, or silently ending a jump-host relay — and could leave a
+truncated frame that corrupted the local packet stream.
+
+`write_local_packet` now treats `WouldBlock` as backpressure: it resumes from
+the partial write and retries until the peer drains, matching upstream's
+blocking-write semantics on both Unix and Windows.

--- a/crates/et-net/src/local_packet.rs
+++ b/crates/et-net/src/local_packet.rs
@@ -1,11 +1,15 @@
 //! Native-`i64` framing for packets exchanged with local terminal processes.
 
 use std::io::{self, Read, Write};
+use std::time::Duration;
 
 use et_core::packet::{Packet, PacketError};
 
 pub const MAX_LOCAL_PACKET_LEN: usize = 64 * 1024;
 const PREFIX_LEN: usize = std::mem::size_of::<i64>();
+/// How long a writer naps before retrying a `WouldBlock` write. Matches the
+/// 10ms cadence the Windows pump loops already use.
+const BACKPRESSURE_RETRY: Duration = Duration::from_millis(10);
 
 #[derive(Debug)]
 pub enum LocalPacketError {
@@ -65,9 +69,50 @@ pub fn write_local_packet<W: Write>(writer: &mut W, packet: &Packet) -> io::Resu
     }
     let length = i64::try_from(serialized.len())
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "local packet too large"))?;
-    writer.write_all(&length.to_ne_bytes())?;
-    writer.write_all(&serialized)?;
-    writer.flush()
+    write_all_blocking(writer, &length.to_ne_bytes())?;
+    write_all_blocking(writer, &serialized)?;
+    flush_blocking(writer)
+}
+
+/// `write_all` that treats `WouldBlock` as backpressure instead of an error.
+///
+/// `set_nonblocking(true)` applies to the underlying socket, not the handle:
+/// every `try_clone()` of a [`crate::local::LocalStream`] shares the flag
+/// (`O_NONBLOCK` lives on the open file description; `FIONBIO` is per-socket
+/// on Windows). The readiness-driven session loops flip their local streams
+/// to non-blocking for reads, which silently makes the packet *writers* on
+/// cloned handles non-blocking too. A full socket buffer (e.g. a shell that
+/// stops reading input during a large paste, or a bridge that pauses reading
+/// terminal output while a client reconnects) must wait for the peer to
+/// drain, exactly like upstream's blocking writes, rather than tearing the
+/// session down — and a bare `write_all` would also abandon a partially
+/// written frame, corrupting the stream for good.
+fn write_all_blocking<W: Write>(writer: &mut W, mut buffer: &[u8]) -> io::Result<()> {
+    while !buffer.is_empty() {
+        match writer.write(buffer) {
+            Ok(0) => return Err(io::ErrorKind::WriteZero.into()),
+            Ok(count) => buffer = &buffer[count..],
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                std::thread::sleep(BACKPRESSURE_RETRY);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+fn flush_blocking<W: Write>(writer: &mut W) -> io::Result<()> {
+    loop {
+        match writer.flush() {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                std::thread::sleep(BACKPRESSURE_RETRY);
+            }
+            Err(error) => return Err(error),
+        }
+    }
 }
 
 pub struct LocalPacketDecoder {

--- a/crates/et-net/tests/local_packet.rs
+++ b/crates/et-net/tests/local_packet.rs
@@ -1,6 +1,6 @@
 #![forbid(unsafe_code)]
 
-use std::io::{Cursor, ErrorKind};
+use std::io::{Cursor, ErrorKind, Read};
 
 use et_core::packet::Packet;
 use et_net::local_packet::{
@@ -63,4 +63,55 @@ fn writer_rejects_packets_above_the_local_cap() {
     let packet = Packet::new(8, vec![0; MAX_LOCAL_PACKET_LEN]);
     let error = write_local_packet(&mut Vec::new(), &packet).unwrap_err();
     assert_eq!(error.kind(), ErrorKind::InvalidInput);
+}
+
+/// Regression test: `set_nonblocking(true)` on a local stream applies to
+/// every clone of the socket, so packet writers can see `WouldBlock` when the
+/// kernel buffer fills. `write_local_packet` must wait for the peer to drain
+/// instead of failing (which previously killed the terminal session) or
+/// leaving a truncated frame behind.
+#[test]
+fn writer_survives_wouldblock_backpressure_on_a_nonblocking_stream() {
+    let (mut reader, mut writer) = et_net::local::wake_pair().unwrap();
+    // Mirror the session loops: the reader side flips the stream to
+    // non-blocking, which also affects the writer clone of the same socket.
+    writer.set_nonblocking(true).unwrap();
+
+    const PACKETS: usize = 64;
+    const PAYLOAD: usize = 32 * 1024;
+    let drain = std::thread::spawn(move || {
+        // Let the writer hit a full socket buffer before draining slowly.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        reader.set_nonblocking(false).unwrap();
+        let mut decoder = LocalPacketDecoder::new();
+        let mut received = Vec::new();
+        let mut buffer = [0u8; 4096];
+        while received.len() < PACKETS {
+            let count = reader.read(&mut buffer).unwrap();
+            assert_ne!(count, 0, "writer hung up before all packets arrived");
+            let mut chunk = &buffer[..count];
+            while !chunk.is_empty() {
+                let take = decoder.required_bytes().min(chunk.len());
+                if let Some(packet) = decoder.feed(&chunk[..take]).unwrap() {
+                    received.push(packet);
+                    decoder = LocalPacketDecoder::new();
+                }
+                chunk = &chunk[take..];
+            }
+        }
+        received
+    });
+
+    for index in 0..PACKETS {
+        let packet = Packet::new(index as u8, vec![index as u8; PAYLOAD]);
+        write_local_packet(&mut writer, &packet)
+            .expect("backpressure on a non-blocking local stream must not fail the write");
+    }
+
+    let received = drain.join().unwrap();
+    assert_eq!(received.len(), PACKETS);
+    for (index, packet) in received.iter().enumerate() {
+        assert_eq!(packet.header(), index as u8);
+        assert_eq!(packet.payload(), vec![index as u8; PAYLOAD]);
+    }
 }


### PR DESCRIPTION
## Problem

`set_nonblocking(true)` applies to the **socket**, not the handle: every `try_clone()` of a `LocalStream` shares the flag (`O_NONBLOCK` lives on the open file description; `FIONBIO` is per-socket on Windows). The readiness-driven session loops flip their local streams to non-blocking for reads, which silently made the packet **writers** on cloned handles non-blocking too:

| Path | Scenario |
|---|---|
| `et-bin/src/terminal_pty.rs` | The PTY output worker writes through `router_writer`, a clone of the router socket the pump made non-blocking |
| `et-server/src/terminal_bridge.rs` | Client→terminal packets are written to the same socket the bridge polls |
| `et-bin/src/terminal_jump.rs` | The relay writes destination packets back to the non-blocking router socket |

When the kernel socket buffer filled — a shell that stops reading input during a large paste, or the bridge pausing terminal-output reads (backpressure) while a client reconnects — `write_all` failed with `WouldBlock` and the session was torn down: the shell was killed, the bridge errored, or the jump-host relay ended silently. A partial `write_all` also abandoned a truncated frame, corrupting the local packet stream for good.

## Fix

`write_local_packet` now treats `WouldBlock` as backpressure: it resumes from the partial write and retries on the same 10ms cadence the Windows pump loops already use, matching upstream's blocking-write semantics on both Unix and Windows. Callers on blocking streams are unaffected (they never see `WouldBlock`).

## Test

Adds `writer_survives_wouldblock_backpressure_on_a_nonblocking_stream`: fills a non-blocking local socket (64 × 32 KiB frames, ~2 MiB) against a deliberately slow reader and asserts every frame arrives intact.

- Previous implementation: fails immediately with `WouldBlock` ✗
- With this fix: passes, all frames intact ✓

`cargo test --workspace` and `cargo clippy --workspace --all-targets` are clean.

A Tegami changeset (`et: patch`) is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat `WouldBlock` as backpressure in local packet writes to prevent session teardown and truncated frames when non-blocking clones hit full socket buffers. Writes now resume from partial progress and retry every 10ms, matching blocking semantics on Unix and Windows.

- **Bug Fixes**
  - Root cause: `set_nonblocking(true)` applies to the socket and affects all clones, so writers in PTY/bridge/jump paths could get `WouldBlock` and tear down sessions.
  - Implemented `write_all_blocking` and `flush_blocking` in `write_local_packet`: on `WouldBlock`, wait 10ms and retry until the peer drains, preserving full frames.
  - Added regression test `writer_survives_wouldblock_backpressure_on_a_nonblocking_stream` (~2 MiB against a slow reader) to verify all frames arrive intact.

<sup>Written for commit c294736e43a93e3d8de5698efdf6efa1ebc0067e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

