### PR TITLE
fix: break the forwarder channel deadlock cycle in session loops

### DIFF
--- a/.tegami/fix-forwarder-channel-deadlock.md
+++ b/.tegami/fix-forwarder-channel-deadlock.md
@@ -1,0 +1,19 @@
+---
+packages:
+  et: patch
+---
+
+## Fix a port-forwarding deadlock under bidirectional load
+
+The session loops handed inbound tunnel packets to the forwarding worker with
+a blocking send, while the worker hands outbound tunnel packets back through a
+bounded queue that only those same session loops drain. Under sustained
+bulk transfers in both directions the two bounded queues could fill at the
+same time, leaving the session loop and the worker each waiting on the other —
+a permanent wedge that also stopped keepalives and made reconnects impossible.
+
+Session loops (client, server bridge, on both Unix and Windows) now hand
+packets to the worker without blocking: when the worker is at capacity the
+packet is held, no further session packets are read (preserving order), and
+the loop keeps draining the worker's outbound queue — which is exactly what
+frees the worker — retrying on a 10ms cadence.

--- a/crates/et-bin/src/client_terminal_loop.rs
+++ b/crates/et-bin/src/client_terminal_loop.rs
@@ -162,8 +162,7 @@ where
                         pending_forward = forwarder
                             .try_receive(packet)
                             .map_err(|error| terminal_text(error.to_string()))?;
-                    } else if route_server_packet(packet, terminal_enabled)? && auto_cursor_report
-                    {
+                    } else if route_server_packet(packet, terminal_enabled)? && auto_cursor_report {
                         let _ =
                             send_buffer(connection, crate::client_terminal::CURSOR_REPORT_REPLY);
                     }

--- a/crates/et-bin/src/client_terminal_loop.rs
+++ b/crates/et-bin/src/client_terminal_loop.rs
@@ -62,6 +62,10 @@ where
     let mut last_received = Instant::now();
     let mut next_keepalive = last_received + interval;
     let mut stream = connection.try_clone_stream().map_err(terminal_error)?;
+    // A forwarding packet the worker had no room for. While it is held, no
+    // further session packets are read (ordering) and the network fd is not
+    // watched for readability (a readable socket would busy-loop the poll).
+    let mut pending_forward: Option<et_core::packet::Packet> = None;
     let forward_wake = forwarder
         .wake()
         .map_err(|error| terminal_text(error.to_string()))?;
@@ -71,10 +75,23 @@ where
         let _ = std::fs::write(path, b"ready");
     }
     loop {
+        // Retry a held forwarding packet first: draining the forwarder's
+        // outbound queue below is what frees worker capacity, so this makes
+        // progress every iteration instead of deadlocking on a blocking send.
+        if let Some(packet) = pending_forward.take() {
+            pending_forward = forwarder
+                .try_receive(packet)
+                .map_err(|error| terminal_text(error.to_string()))?;
+        }
+        let network_flags = if pending_forward.is_none() {
+            PollFlags::IN | PollFlags::HUP | PollFlags::ERR
+        } else {
+            PollFlags::HUP | PollFlags::ERR
+        };
         let deadline = next_keepalive.min(last_received + silence);
         let (network, resize, forwarding, input) = {
             let mut descriptors = vec![
-                PollFd::new(&stream, PollFlags::IN | PollFlags::HUP | PollFlags::ERR),
+                PollFd::new(&stream, network_flags),
                 PollFd::new(&*wake, PollFlags::IN | PollFlags::HUP),
                 PollFd::new(forward_wake, PollFlags::IN | PollFlags::HUP),
             ];
@@ -90,7 +107,14 @@ where
             // cap also lets the nonblocking read below detect closed sockets
             // when Darwin omits the expected readiness bit.
             loop {
-                let poll_deadline = deadline.min(Instant::now() + Duration::from_millis(100));
+                // Cap at 10ms while a forwarding packet is held so the retry
+                // above runs even when nothing else becomes ready.
+                let poll_cap = if pending_forward.is_some() {
+                    Duration::from_millis(10)
+                } else {
+                    Duration::from_millis(100)
+                };
+                let poll_deadline = deadline.min(Instant::now() + poll_cap);
                 let timeout =
                     Timespec::try_from(poll_deadline.saturating_duration_since(Instant::now()))
                         .map_err(|_| terminal_text("keepalive deadline exceeds poll range"))?;
@@ -130,12 +154,15 @@ where
                 Err(error) => return Err(error),
             }
         }
-        loop {
+        while pending_forward.is_none() {
             match connection.try_read_packet() {
                 Ok(Some(packet)) => {
                     last_received = Instant::now();
-                    if route_server_packet(packet, forwarder, terminal_enabled)?
-                        && auto_cursor_report
+                    if is_forward_packet(packet.header()) {
+                        pending_forward = forwarder
+                            .try_receive(packet)
+                            .map_err(|error| terminal_text(error.to_string()))?;
+                    } else if route_server_packet(packet, terminal_enabled)? && auto_cursor_report
                     {
                         let _ =
                             send_buffer(connection, crate::client_terminal::CURSOR_REPORT_REPLY);
@@ -218,15 +245,8 @@ where
 #[cfg(unix)]
 fn route_server_packet(
     packet: et_core::packet::Packet,
-    forwarder: &Forwarder,
     terminal_enabled: bool,
 ) -> Result<bool, ClientError> {
-    if is_forward_packet(packet.header()) {
-        return forwarder
-            .receive(packet)
-            .map(|()| false)
-            .map_err(|error| terminal_text(error.to_string()));
-    }
     if terminal_enabled || packet.header() == TerminalPacketType::KeepAlive as u8 {
         return display_packet(packet);
     }

--- a/crates/et-bin/src/client_terminal_windows.rs
+++ b/crates/et-bin/src/client_terminal_windows.rs
@@ -106,8 +106,7 @@ where
                         pending_forward = forwarder
                             .try_receive(packet)
                             .map_err(|error| terminal_text(error.to_string()))?;
-                    } else if route_server_packet(packet, terminal_enabled)? && auto_cursor_report
-                    {
+                    } else if route_server_packet(packet, terminal_enabled)? && auto_cursor_report {
                         let _ =
                             send_buffer(connection, crate::client_terminal::CURSOR_REPORT_REPLY);
                     }

--- a/crates/et-bin/src/client_terminal_windows.rs
+++ b/crates/et-bin/src/client_terminal_windows.rs
@@ -50,8 +50,19 @@ where
     if let Ok(path) = std::env::var("ET_SSH_READY") {
         let _ = std::fs::write(path, b"ready");
     }
+    // A forwarding packet the worker had no room for. While it is held, no
+    // further session packets are read so forwarding data stays ordered.
+    let mut pending_forward: Option<et_core::packet::Packet> = None;
     loop {
         let mut reconnect_needed = false;
+        // Retry the held packet first: draining the forwarder's outbound
+        // queue below is what frees worker capacity, so this makes progress
+        // every 10ms tick instead of deadlocking on a blocking send.
+        if let Some(packet) = pending_forward.take() {
+            pending_forward = forwarder
+                .try_receive(packet)
+                .map_err(|error| terminal_text(error.to_string()))?;
+        }
 
         // 1. Console input and resize notifications.
         if read_stdin {
@@ -87,12 +98,15 @@ where
         }
 
         // 2. Server packets.
-        loop {
+        while pending_forward.is_none() {
             match connection.try_read_packet() {
                 Ok(Some(packet)) => {
                     last_received = Instant::now();
-                    if route_server_packet(packet, forwarder, terminal_enabled)?
-                        && auto_cursor_report
+                    if is_forward_packet(packet.header()) {
+                        pending_forward = forwarder
+                            .try_receive(packet)
+                            .map_err(|error| terminal_text(error.to_string()))?;
+                    } else if route_server_packet(packet, terminal_enabled)? && auto_cursor_report
                     {
                         let _ =
                             send_buffer(connection, crate::client_terminal::CURSOR_REPORT_REPLY);
@@ -165,15 +179,8 @@ where
 /// Returns `true` when a cursor position report must be sent back.
 fn route_server_packet(
     packet: et_core::packet::Packet,
-    forwarder: &Forwarder,
     terminal_enabled: bool,
 ) -> Result<bool, ClientError> {
-    if is_forward_packet(packet.header()) {
-        return forwarder
-            .receive(packet)
-            .map(|()| false)
-            .map_err(|error| terminal_text(error.to_string()));
-    }
     if terminal_enabled || packet.header() == TerminalPacketType::KeepAlive as u8 {
         return display_packet(packet);
     }

--- a/crates/et-net/src/forward.rs
+++ b/crates/et-net/src/forward.rs
@@ -123,10 +123,35 @@ impl Forwarder {
         Ok(&self.wake)
     }
 
+    /// Hand a forwarding packet to the worker, blocking when its command
+    /// queue is full.
+    ///
+    /// Only safe for callers that never also drain [`Forwarder::try_outbound`]
+    /// on the same thread (e.g. tests). Session loops must use
+    /// [`Forwarder::try_receive`] instead: the worker can itself be blocked
+    /// emitting outbound packets, which only the session loop drains, so a
+    /// blocking send from the session loop closes a cycle and deadlocks the
+    /// session permanently.
     pub fn receive(&self, packet: Packet) -> Result<(), ForwardError> {
         self.commands
             .send(Command::Packet(packet))
             .map_err(|_| ForwardError::Unavailable)
+    }
+
+    /// Hand a forwarding packet to the worker without blocking.
+    ///
+    /// Returns the packet back when the worker's command queue is full so the
+    /// caller can drain outbound packets (which is what unblocks the worker)
+    /// and retry later. Callers must not read further session packets while
+    /// holding a returned packet, or forwarding data would be reordered.
+    pub fn try_receive(&self, packet: Packet) -> Result<Option<Packet>, ForwardError> {
+        match self.commands.try_send(Command::Packet(packet)) {
+            Ok(()) => Ok(None),
+            Err(mpsc::TrySendError::Full(Command::Packet(packet))) => Ok(Some(packet)),
+            Err(mpsc::TrySendError::Full(_)) | Err(mpsc::TrySendError::Disconnected(_)) => {
+                Err(ForwardError::Unavailable)
+            }
+        }
     }
 
     pub fn try_outbound(&self) -> Result<Option<Packet>, ForwardError> {

--- a/crates/et-net/tests/forward.rs
+++ b/crates/et-net/tests/forward.rs
@@ -3,10 +3,14 @@
 use std::io::{Read, Write};
 use std::net::{Ipv4Addr, TcpListener, TcpStream};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use et_core::proto::{PortForwardSourceRequest, SocketEndpoint};
+use et_core::packet::Packet;
+use et_core::proto::{
+    PortForwardDestinationRequest, PortForwardSourceRequest, SocketEndpoint, TerminalPacketType,
+};
 use et_net::forward::Forwarder;
+use prost::Message;
 
 const TIMEOUT: Duration = Duration::from_secs(3);
 
@@ -68,6 +72,75 @@ fn refused_destination_closes_the_accepted_source() {
     assert_eq!(application.read(&mut byte).unwrap(), 0);
     source.shutdown().unwrap();
     destination.shutdown().unwrap();
+}
+
+/// Regression test for the forwarder deadlock cycle: the worker can block
+/// emitting outbound packets, which only the session loop drains, while a
+/// blocking `receive` would leave the session loop stuck handing the worker
+/// its next packet — wedging the session permanently. `try_receive` must
+/// report a full worker instead of blocking, and draining outbound packets
+/// (the session loop's next step) must make the held packet deliverable.
+#[test]
+fn try_receive_reports_backpressure_and_outbound_drain_recovers() {
+    let forwarder = Forwarder::start(Vec::new()).unwrap();
+    // Every destination request with an unparseable destination (port 0)
+    // makes the worker emit exactly one error response. Nothing drains the
+    // outbound queue yet, so the worker eventually blocks emitting and the
+    // command queue fills — the exact state that used to deadlock.
+    let request = |fd: i32| {
+        Packet::new(
+            TerminalPacketType::PortForwardDestinationRequest as u8,
+            PortForwardDestinationRequest {
+                destination: Some(SocketEndpoint {
+                    name: None,
+                    port: Some(0),
+                }),
+                fd: Some(fd),
+            }
+            .encode_to_vec(),
+        )
+    };
+    let mut delivered: usize = 0;
+    let mut held = None;
+    for fd in 1..=4096 {
+        match forwarder.try_receive(request(fd)).unwrap() {
+            None => delivered += 1,
+            Some(packet) => {
+                held = Some(packet);
+                break;
+            }
+        }
+    }
+    // With a blocking send this loop would never return once both queues
+    // filled; try_receive must surface the backpressure instead.
+    let held = held.expect("the worker queues never filled");
+
+    // Mirror the session loops: drain outbound, retry the held packet.
+    let deadline = Instant::now() + TIMEOUT;
+    let mut outbound: usize = 0;
+    let mut held = Some(held);
+    while let Some(packet) = held.take() {
+        assert!(
+            Instant::now() < deadline,
+            "held packet was never accepted after draining outbound"
+        );
+        while forwarder.try_outbound().unwrap().is_some() {
+            outbound += 1;
+        }
+        held = forwarder.try_receive(packet).unwrap();
+        if held.is_some() {
+            thread::sleep(Duration::from_millis(1));
+        }
+    }
+    delivered += 1;
+
+    // Every delivered request produces exactly one response; drain the rest
+    // so the worker is idle before shutting down.
+    while outbound < delivered {
+        forwarder.wait_outbound(TIMEOUT).unwrap();
+        outbound += 1;
+    }
+    forwarder.shutdown().unwrap();
 }
 
 fn reserve_port() -> u16 {

--- a/crates/et-server/src/terminal_bridge.rs
+++ b/crates/et-server/src/terminal_bridge.rs
@@ -9,6 +9,8 @@ use et_net::forward::{is_forward_packet, Forwarder};
 use et_net::local_packet::{write_local_packet, LocalPacketDecoder};
 #[cfg(unix)]
 use rustix::event::{poll, PollFd, PollFlags};
+#[cfg(unix)]
+use rustix::time::Timespec;
 
 use crate::session::{ActiveSession, SessionError};
 
@@ -59,9 +61,19 @@ fn run_mode_poll(
     wake.set_nonblocking(true).map_err(SessionError::Io)?;
     let mut decoder = LocalPacketDecoder::new();
     let mut connected = session.connected()?;
+    // A forwarding packet the worker had no room for. While it is held, no
+    // further client packets are read (ordering) and the client socket is not
+    // watched for readability (it would busy-loop the poll).
+    let mut pending_forward: Option<Packet> = None;
     loop {
         if session.is_shutting_down() {
             return Ok(());
+        }
+        // Retry the held packet first: draining the forwarder's outbound
+        // queue below is what frees worker capacity, so this makes progress
+        // every iteration instead of deadlocking on a blocking send.
+        if let Some(packet) = pending_forward.take() {
+            pending_forward = forwarder.try_receive(packet).map_err(forward_error)?;
         }
         let client = connected.then(|| session.try_clone_stream()).transpose()?;
         let accept_terminal = session.can_buffer_write((READ_BUFFER * 2) as i64)?;
@@ -71,6 +83,7 @@ fn run_mode_poll(
             forwarder.wake().map_err(forward_error)?,
             client.as_ref(),
             accept_terminal,
+            pending_forward.is_some(),
         )?;
         let client_events_are_stale = wake_events.intersects(PollFlags::IN | PollFlags::HUP);
         if client_events_are_stale {
@@ -101,7 +114,7 @@ fn run_mode_poll(
             }
         }
         if !client_events_are_stale && client_events.contains(PollFlags::IN) {
-            loop {
+            while pending_forward.is_none() {
                 match session.try_read_packet() {
                     // Jumphost relays every packet verbatim to the jump
                     // terminal, which owns the destination connection.
@@ -109,7 +122,8 @@ fn run_mode_poll(
                         write_local_packet(&mut terminal, &packet).map_err(SessionError::Io)?;
                     }
                     Ok(Some(packet)) if is_forward_packet(packet.header()) => {
-                        forwarder.receive(packet).map_err(forward_error)?;
+                        pending_forward =
+                            forwarder.try_receive(packet).map_err(forward_error)?;
                     }
                     Ok(Some(packet)) => forward_client_packet(&session, &mut terminal, packet)?,
                     Ok(None) => break,
@@ -161,11 +175,24 @@ fn run_mode_windows(
     wake.set_nonblocking(true).map_err(SessionError::Io)?;
     let mut decoder = LocalPacketDecoder::new();
     let mut connected = session.connected()?;
+    // A forwarding packet the worker had no room for; while it is held, no
+    // further client packets are read so forwarding data stays ordered.
+    let mut pending_forward: Option<Packet> = None;
     loop {
         if session.is_shutting_down() {
             return Ok(());
         }
         let mut progress = false;
+
+        // Retry the held packet first: draining the forwarder's outbound
+        // queue below is what frees worker capacity, so this makes progress
+        // every 10ms tick instead of deadlocking on a blocking send.
+        if let Some(packet) = pending_forward.take() {
+            match forwarder.try_receive(packet).map_err(forward_error)? {
+                Some(held) => pending_forward = Some(held),
+                None => progress = true,
+            }
+        }
 
         // Connection state changes are announced through the wake channel.
         if drain_available(&mut wake)? {
@@ -202,14 +229,15 @@ fn run_mode_windows(
 
         // Client -> terminal / forwarder.
         if connected {
-            loop {
+            while pending_forward.is_none() {
                 match session.try_read_packet() {
                     Ok(Some(packet)) => {
                         progress = true;
                         if mode == BridgeMode::Jumphost {
                             write_local_packet(&mut terminal, &packet).map_err(SessionError::Io)?;
                         } else if is_forward_packet(packet.header()) {
-                            forwarder.receive(packet).map_err(forward_error)?;
+                            pending_forward =
+                                forwarder.try_receive(packet).map_err(forward_error)?;
                         } else {
                             forward_client_packet(&session, &mut terminal, packet)?;
                         }
@@ -277,11 +305,27 @@ fn wait(
     forward_wake: &LocalStream,
     client: Option<&std::net::TcpStream>,
     accept_terminal: bool,
+    forward_blocked: bool,
 ) -> Result<(PollFlags, PollFlags, PollFlags, PollFlags), SessionError> {
     let terminal_flags = if accept_terminal {
         PollFlags::IN | PollFlags::HUP | PollFlags::ERR
     } else {
         PollFlags::HUP | PollFlags::ERR
+    };
+    // While a forwarding packet is held for worker capacity the client is not
+    // read, so do not watch it for readability, and wake on a 10ms cadence to
+    // retry the held packet even when nothing else becomes ready.
+    let client_flags = if forward_blocked {
+        PollFlags::HUP | PollFlags::ERR
+    } else {
+        PollFlags::IN | PollFlags::HUP | PollFlags::ERR
+    };
+    let timeout = if forward_blocked {
+        Some(
+            Timespec::try_from(std::time::Duration::from_millis(10)).expect("10ms fits timespec"),
+        )
+    } else {
+        None
     };
     let mut descriptors = vec![
         PollFd::new(terminal, terminal_flags),
@@ -289,15 +333,12 @@ fn wait(
         PollFd::new(forward_wake, PollFlags::IN | PollFlags::HUP),
     ];
     if let Some(client) = client {
-        descriptors.push(PollFd::new(
-            client,
-            PollFlags::IN | PollFlags::HUP | PollFlags::ERR,
-        ));
+        descriptors.push(PollFd::new(client, client_flags));
     }
     // poll() is never restarted by SA_RESTART; retry on EINTR instead of
     // tearing the session down when a signal interrupts the wait.
     loop {
-        match poll(&mut descriptors, None) {
+        match poll(&mut descriptors, timeout.as_ref()) {
             Ok(_) => break,
             Err(error) if error == rustix::io::Errno::INTR => {}
             Err(error) => return Err(SessionError::Io(io::Error::from(error))),

--- a/crates/et-server/src/terminal_bridge.rs
+++ b/crates/et-server/src/terminal_bridge.rs
@@ -122,8 +122,7 @@ fn run_mode_poll(
                         write_local_packet(&mut terminal, &packet).map_err(SessionError::Io)?;
                     }
                     Ok(Some(packet)) if is_forward_packet(packet.header()) => {
-                        pending_forward =
-                            forwarder.try_receive(packet).map_err(forward_error)?;
+                        pending_forward = forwarder.try_receive(packet).map_err(forward_error)?;
                     }
                     Ok(Some(packet)) => forward_client_packet(&session, &mut terminal, packet)?,
                     Ok(None) => break,
@@ -321,9 +320,7 @@ fn wait(
         PollFlags::IN | PollFlags::HUP | PollFlags::ERR
     };
     let timeout = if forward_blocked {
-        Some(
-            Timespec::try_from(std::time::Duration::from_millis(10)).expect("10ms fits timespec"),
-        )
+        Some(Timespec::try_from(std::time::Duration::from_millis(10)).expect("10ms fits timespec"))
     } else {
         None
     };


### PR DESCRIPTION
Follow-up to #11 — the second finding from the same bug-hunt review.

## Problem

The forwarding worker and the session loops share two **bounded** queues:

```
session loop ──receive()───▶ commands (sync, 256) ──▶ worker
session loop ◀─try_outbound── outbound (sync, 256) ◀──emit()── worker
```

Both sends were blocking, so under sustained bidirectional tunnel traffic (e.g. bulk transfers both ways through `-t`/`-r` tunnels) the queues could fill at the same time:

1. the worker blocks in `emit()` on the full `outbound` queue,
2. the session loop blocks in `receive()` on the full `commands` queue,
3. `outbound` is only drained by the session loop, `commands` only by the worker → **permanent deadlock**.

Once wedged, keepalives stop and the reconnect path cannot run either — the pump thread itself is blocked — so the session hangs forever. The same cycle exists in the client pump (Unix + Windows) and the server terminal bridge (Unix + Windows).

## Fix

New `Forwarder::try_receive` returns the packet instead of blocking when the worker is at capacity. The session loops now:

- hold the returned packet and **stop reading session packets** while it is held, preserving forwarding order;
- stop watching the session socket for readability (Unix: poll flags drop `IN`), avoiding a busy-loop;
- keep draining the worker's outbound queue — which is exactly what frees the worker — and retry the held packet on a 10ms cadence (matching the existing Windows pump cadence).

`Forwarder::receive` is kept for callers that never drain `try_outbound` on the same thread (tests), with a doc warning.

Jumphost mode is untouched (it never uses the forwarder).

## Test

`try_receive_reports_backpressure_and_outbound_drain_recovers` drives the worker into the exact wedged state (both queues full, worker blocked in `emit`) using destination requests that each produce one error response, then asserts:

- `try_receive` surfaces the backpressure instead of blocking (a blocking `receive` would hang the test here), and
- draining outbound — the session loop's next step — makes the held packet deliverable again.

## Verification

- `cargo test --workspace`: 36 suites, all green
- `cargo clippy --workspace --all-targets`: clean
- `cargo check -p et --target x86_64-pc-windows-gnu`: clean (covers the modified Windows loops)

Tegami changeset (`et: patch`) included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deadlock between session loops and the forwarding worker under heavy bidirectional port-forward traffic. Adds non-blocking `Forwarder::try_receive` and updates client/server loops to handle backpressure without spinning or reordering.

- **Bug Fixes**
  - Added `Forwarder::try_receive`, which returns the packet when the command queue is full; kept `receive` with a doc warning for safe callers.
  - Updated Unix/Windows client pumps and the server terminal bridge to hold a pending forward packet, stop reading the session socket and drop `IN` from poll, drain `try_outbound`, and retry every 10ms.
  - Added a regression test that fills both queues, asserts backpressure is surfaced, and confirms draining outbound makes the held packet deliverable.

<sup>Written for commit 8ed0cd13d85bb3129ebf4cb6b3cb707bf29d7a9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

