### PR TITLE
fix: retry reconnects through network outages and reset leaked terminal modes

### DIFF
--- a/.tegami/fix-reconnect-retry-and-terminal-mode-reset.md
+++ b/.tegami/fix-reconnect-retry-and-terminal-mode-reset.md
@@ -1,0 +1,24 @@
+---
+packages:
+  et: patch
+---
+
+## Survive network outages during reconnect and restore leaked terminal modes
+
+A laptop waking from sleep has no route to the server for several seconds.
+The client attempted exactly one reconnect and treated its failure as fatal,
+so a live session died with "could not reach the ET server: connection timed
+out" the moment the first attempt raced the returning Wi-Fi. Transient
+network failures (unreachable endpoint, DNS outages, connect/transport I/O
+errors) are now retried every second until the link returns — matching
+upstream ET, which keeps a session alive until the server ends it. The
+client announces the retry loop once, and Ctrl-C gives up (raw mode turns
+ISIG off, so the byte is read from stdin); protocol mismatches and server
+rejections still fail immediately.
+
+Separately, exiting only restored the local termios. Terminal modes a remote
+application had enabled in the local emulator — the kitty keyboard protocol,
+bracketed paste, mouse and focus reporting, the alternate screen — survived
+the client, leaving the shell prompt printing key reports like `2618;9u` as
+garbage text. The client now emits the matching reset sequences when it
+leaves raw mode; every reset is a no-op when the mode is off or unsupported.

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -5,18 +5,21 @@ use clap::Parser;
 use et_cli::client::ClientArgs;
 use et_cli::host::parse_positional_host;
 
+use et_net::connection::Connection;
+
 use crate::bootstrap::{
     build_invocation, build_jump_invocation, cmd_safe, provisional_credentials,
-    validate_ssh_destination, BootstrapRequest, JumpBootstrapRequest, RemoteShell,
+    validate_ssh_destination, BootstrapRequest, Credentials, JumpBootstrapRequest, RemoteShell,
 };
 use crate::deadline::Deadline;
 use crate::error::ClientError;
-use crate::initial_connect::{connect_initial, reconnect, Endpoint};
+use crate::initial_connect::{connect_initial, reconnect, Endpoint, ReconnectOutcome};
 use crate::resolver::{EndpointResolver, SystemResolver};
 use crate::ssh_config::resolve_ssh_config;
 use crate::ssh_process::{run_bootstrap, SshRunner, SystemSsh};
 
 const RECONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const RECONNECT_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 pub fn run(args: &[OsString]) -> Result<i32, clap::Error> {
     let parsed = ClientArgs::try_parse_from(
@@ -172,16 +175,124 @@ fn run_client(
             lines: crate::client_terminal::RemoteLines::from(args.effective_remote_shell()),
         },
         forwarder,
-        |connection| {
+        |connection| reconnect_with_retry(connection, &endpoint, &credentials, resolver),
+    )
+}
+
+/// Reconnect, retrying transient network failures until the link returns.
+///
+/// A laptop that slept through a Wi-Fi drop wakes with no route to the
+/// server for several seconds; a single failed attempt must not kill the
+/// session (upstream ET retries until the server ends the session). Raw
+/// mode turns off ISIG, so Ctrl-C arrives as the 0x03 byte on stdin and is
+/// honoured as "give up now" while waiting between attempts.
+fn reconnect_with_retry(
+    connection: &mut Connection,
+    endpoint: &Endpoint,
+    credentials: &Credentials,
+    resolver: &dyn EndpointResolver,
+) -> Result<ReconnectOutcome, ClientError> {
+    let mut announced = false;
+    retry_transient(
+        || {
             reconnect(
                 connection,
-                &endpoint,
-                &credentials,
+                endpoint,
+                credentials,
                 resolver,
                 Deadline::after(RECONNECT_TIMEOUT),
             )
         },
+        |error| {
+            if !announced {
+                announced = true;
+                // Raw mode is active: lines need explicit carriage returns.
+                eprint!("\r\net: connection lost, reconnecting... (press Ctrl-C to give up)\r\n");
+            }
+            et_cli::logging::info(format!("reconnect attempt failed, retrying: {error}"));
+            reconnect_wait_aborted(RECONNECT_RETRY_DELAY)
+        },
     )
+}
+
+/// Run `attempt` until it succeeds, retrying transient network errors.
+/// `wait` runs between attempts and returns `true` to give up with the
+/// last error; non-transient errors propagate immediately.
+fn retry_transient<T>(
+    mut attempt: impl FnMut() -> Result<T, ClientError>,
+    mut wait: impl FnMut(&ClientError) -> bool,
+) -> Result<T, ClientError> {
+    loop {
+        match attempt() {
+            Ok(value) => return Ok(value),
+            Err(error) if error.is_transient_reconnect() => {
+                if wait(&error) {
+                    return Err(error);
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+/// Wait out the retry delay. Returns `true` when the user pressed Ctrl-C.
+///
+/// Stdin is in raw mode, so the byte must be read to be seen. Other input
+/// typed while the link is down cannot reach the server and is dropped,
+/// which is also what a dead TCP connection would have done with it.
+#[cfg(unix)]
+fn reconnect_wait_aborted(delay: Duration) -> bool {
+    use std::io::{IsTerminal, Read};
+
+    use rustix::event::{poll, PollFd, PollFlags};
+    use rustix::time::Timespec;
+
+    const CTRL_C: u8 = 0x03;
+    let stdin = std::io::stdin();
+    if !stdin.is_terminal() {
+        std::thread::sleep(delay);
+        return false;
+    }
+    let deadline = std::time::Instant::now() + delay;
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return false;
+        }
+        let Ok(timeout) = Timespec::try_from(remaining) else {
+            return false;
+        };
+        let mut descriptors = [PollFd::new(&stdin, PollFlags::IN)];
+        match poll(&mut descriptors, Some(&timeout)) {
+            Ok(0) => return false,
+            Ok(_) => {
+                if !descriptors[0].revents().contains(PollFlags::IN) {
+                    return false;
+                }
+                let mut bytes = [0u8; 256];
+                match stdin.lock().read(&mut bytes) {
+                    // EOF: stdin is gone, nothing to poll for any more.
+                    Ok(0) => {
+                        std::thread::sleep(remaining);
+                        return false;
+                    }
+                    Ok(count) if bytes[..count].contains(&CTRL_C) => return true,
+                    Ok(_) => {}
+                    Err(_) => return false,
+                }
+            }
+            Err(error) if error == rustix::io::Errno::INTR => {}
+            Err(_) => return false,
+        }
+    }
+}
+
+#[cfg(windows)]
+fn reconnect_wait_aborted(delay: Duration) -> bool {
+    // The Windows console loop owns stdin; a Ctrl-C abort would need a
+    // console reader here. Sleep and retry: the process can still be killed.
+    std::thread::sleep(delay);
+    false
 }
 
 /// Configure logging like upstream `TerminalClientMain`: files land in
@@ -266,6 +377,80 @@ fn validate_jumphost(jumphost: &str) -> Result<(), ClientError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn retry_transient_retries_until_success() {
+        let mut attempts = 0;
+        let result = retry_transient(
+            || {
+                attempts += 1;
+                if attempts < 3 {
+                    Err(ClientError::DnsTimeout("host:2022".to_owned()))
+                } else {
+                    Ok(7)
+                }
+            },
+            |error| {
+                assert!(error.is_transient_reconnect());
+                false
+            },
+        );
+        assert_eq!(result.unwrap(), 7);
+        assert_eq!(attempts, 3);
+    }
+
+    #[test]
+    fn retry_transient_gives_up_when_wait_aborts() {
+        let mut attempts = 0;
+        let result = retry_transient(
+            || -> Result<(), ClientError> {
+                attempts += 1;
+                Err(ClientError::UnreachableEndpoint {
+                    endpoint: "10.10.10.10:2022".to_owned(),
+                    source: std::io::Error::from(std::io::ErrorKind::TimedOut),
+                })
+            },
+            |_| true,
+        );
+        assert!(matches!(
+            result,
+            Err(ClientError::UnreachableEndpoint { .. })
+        ));
+        assert_eq!(attempts, 1);
+    }
+
+    #[test]
+    fn retry_transient_propagates_fatal_errors_immediately() {
+        let mut attempts = 0;
+        let result = retry_transient(
+            || -> Result<(), ClientError> {
+                attempts += 1;
+                Err(ClientError::ProtocolMismatch(None))
+            },
+            |_| panic!("fatal errors must not wait for a retry"),
+        );
+        assert!(matches!(result, Err(ClientError::ProtocolMismatch(None))));
+        assert_eq!(attempts, 1);
+    }
+
+    #[test]
+    fn transient_reconnect_classification() {
+        assert!(ClientError::DnsTimeout("h:1".to_owned()).is_transient_reconnect());
+        assert!(ClientError::BootstrapTimeout("x").is_transient_reconnect());
+        assert!(
+            ClientError::Transport(et_net::connection::ConnError::Io(std::io::Error::from(
+                std::io::ErrorKind::ConnectionReset
+            )))
+            .is_transient_reconnect()
+        );
+        assert!(!ClientError::ProtocolMismatch(None).is_transient_reconnect());
+        assert!(!ClientError::ServerRejected {
+            status: None,
+            message: None
+        }
+        .is_transient_reconnect());
+        assert!(!ClientError::InvalidPasskey.is_transient_reconnect());
+    }
 
     #[test]
     fn username_precedence_matches_upstream() {

--- a/crates/et-bin/src/client_terminal.rs
+++ b/crates/et-bin/src/client_terminal.rs
@@ -240,6 +240,22 @@ pub(crate) fn send_size(connection: &mut Connection) -> Result<(), ClientError> 
         .map_err(terminal_error)
 }
 
+/// Reset sequences for terminal modes a remote application may have enabled
+/// in the local emulator. The session can end while the remote side has no
+/// chance to restore them (connection lost, reconnect given up), which
+/// otherwise leaves the shell prompt receiving kitty keyboard reports
+/// (`CSI … u`, seen as garbage like `2618;9u`), mouse reports, or bracketed
+/// paste markers as literal text. Terminals ignore sequences they do not
+/// support, and every reset is a no-op when the mode is already off.
+///
+/// In order: pop and zero the kitty keyboard flags on the current (possibly
+/// alternate) screen, leave the alternate screen, pop and zero the kitty
+/// flags again on the main screen (the stacks are per-screen), disable
+/// xterm modifyOtherKeys, bracketed paste, focus reporting and all mouse
+/// modes, and show the cursor.
+const TERMINAL_MODE_RESET: &[u8] = b"\x1b[<64u\x1b[=0;1u\x1b[?1049l\x1b[<64u\x1b[=0;1u\
+\x1b[>4;0m\x1b[?2004l\x1b[?1004l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?25h";
+
 struct RawMode {
     enabled: bool,
 }
@@ -257,6 +273,9 @@ impl RawMode {
 impl Drop for RawMode {
     fn drop(&mut self) {
         if self.enabled {
+            let mut stdout = io::stdout().lock();
+            let _ = stdout.write_all(TERMINAL_MODE_RESET);
+            let _ = stdout.flush();
             let _ = disable_raw_mode();
         }
     }

--- a/crates/et-bin/src/error.rs
+++ b/crates/et-bin/src/error.rs
@@ -159,6 +159,23 @@ fn write_message(f: &mut std::fmt::Formatter<'_>, message: &Option<String>) -> s
 }
 
 impl ClientError {
+    /// Errors that mean the network is temporarily unreachable (e.g. a
+    /// laptop waking from sleep before Wi-Fi is back, a DNS outage, a
+    /// half-restored link). A live session should retry the reconnect
+    /// instead of exiting, mirroring upstream ET.
+    pub fn is_transient_reconnect(&self) -> bool {
+        matches!(
+            self,
+            Self::DnsTimeout(_)
+                | Self::DnsWorker(_)
+                | Self::DnsWorkerPanicked
+                | Self::UnreachableEndpoint { .. }
+                | Self::BootstrapTimeout(_)
+                | Self::ConnectIo { .. }
+                | Self::Transport(ConnError::Io(_))
+        )
+    }
+
     pub fn exit_code(&self) -> i32 {
         match self {
             Self::Unsupported(_) | Self::ForwardConfig(_) => 2,

--- a/crates/et-bin/tests/reconnect_outage_end_to_end.rs
+++ b/crates/et-bin/tests/reconnect_outage_end_to_end.rs
@@ -1,0 +1,312 @@
+#![forbid(unsafe_code)]
+
+//! Regression test for the sleep/wake disconnect: when the network is
+//! unreachable while the client tries to reconnect (e.g. a MacBook waking
+//! before Wi-Fi is back), every attempt fails with a transient error. The
+//! client used to exit with "could not reach the ET server" after the first
+//! failed attempt; it must instead keep retrying until the link returns.
+
+// The shared stack helper exports more than this test needs.
+#[allow(dead_code)]
+#[path = "reconnect_stack/mod.rs"]
+mod reconnect_stack;
+
+use std::fs;
+use std::io::{self, Read, Write};
+use std::net::{Ipv4Addr, Shutdown, TcpListener, TcpStream};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use reconnect_stack::Stack;
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+/// Long enough for several reconnect attempts (retry delay is one second).
+const OUTAGE: Duration = Duration::from_secs(4);
+
+#[test]
+fn client_retries_reconnect_through_network_outage() {
+    let mut stack = Stack::start();
+    let proxy = OutageProxy::start(stack.port);
+    let pair = native_pty_system()
+        .openpty(PtySize {
+            rows: 30,
+            cols: 90,
+            pixel_width: 900,
+            pixel_height: 600,
+        })
+        .unwrap();
+    let mut client = CommandBuilder::new(env!("CARGO_BIN_EXE_et"));
+    client.args([
+        "--terminal-path",
+        stack.terminal.to_str().unwrap(),
+        "--serverfifo",
+        stack.router.to_str().unwrap(),
+        "--keepalive=1",
+        "-p",
+        &proxy.port.to_string(),
+        "127.0.0.1",
+    ]);
+    client.env(
+        "PATH",
+        format!(
+            "{}:{}",
+            stack.directory.display(),
+            std::env::var("PATH").unwrap()
+        ),
+    );
+    client.env("TERM", "xterm-256color");
+    client.env("ET_SSH_COUNT", &stack.ssh_count);
+    let client_ready = stack.directory.join("client-ready");
+    client.env("ET_SSH_READY", &client_ready);
+    let mut child = pair.slave.spawn_command(client).unwrap();
+    drop(pair.slave);
+    let mut writer = pair.master.take_writer().unwrap();
+    let mut reader = pair.master.try_clone_reader().unwrap();
+    let (output_tx, output_rx) = mpsc::sync_channel(64);
+    thread::spawn(move || {
+        let mut chunk = [0u8; 4096];
+        loop {
+            match reader.read(&mut chunk) {
+                Ok(0) | Err(_) => break,
+                Ok(count) if output_tx.send(chunk[..count].to_vec()).is_err() => break,
+                Ok(_) => {}
+            }
+        }
+    });
+    wait_for_file(&client_ready, b"ready");
+
+    writer
+        .write_all(b"printf 'FIRST-PID:%s\\n' \"$$\"\n")
+        .unwrap();
+    let (mut output, first_pid) = receive_number(&output_rx, Vec::new(), b"FIRST-PID:");
+
+    // Drop the link and refuse every reconnect attempt for a while, like a
+    // laptop that wakes from sleep before its network is back.
+    proxy.outage();
+    thread::sleep(OUTAGE);
+    proxy.restore();
+
+    // The client announces the retry loop on the first failed attempt.
+    output = receive_until(&output_rx, output, b"connection lost, reconnecting");
+
+    // Input typed while the link is down is dropped, so keep asking until
+    // the recovered session answers.
+    let mut after_pid = None;
+    for _ in 0..15 {
+        writer
+            .write_all(b"printf 'AFTER-PID:%s\\n' \"$$\"\n")
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            if let Some(value) = marker_number(&output, b"AFTER-PID:") {
+                after_pid = Some(value);
+                break;
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match output_rx.recv_timeout(remaining) {
+                Ok(chunk) => output.extend(chunk),
+                Err(_) => break,
+            }
+        }
+        if after_pid.is_some() {
+            break;
+        }
+    }
+    // Same shell process: the session recovered instead of restarting.
+    assert_eq!(Some(first_pid), after_pid, "output={}", text(&output));
+
+    writer.write_all(b"exit\n").unwrap();
+    let status = child.wait().unwrap();
+    while let Ok(chunk) = output_rx.recv_timeout(TIMEOUT) {
+        output.extend(chunk);
+    }
+    let text = text(&output);
+    assert!(status.success(), "status={status:?} output={text}");
+    assert!(
+        !text.contains("could not reach the ET server"),
+        "client gave up during the outage: {text}"
+    );
+    let refused = proxy.join();
+    assert!(
+        refused >= 2,
+        "expected multiple retried reconnect attempts, saw {refused}"
+    );
+    stack.shutdown();
+}
+
+fn text(output: &[u8]) -> String {
+    String::from_utf8_lossy(output).into_owned()
+}
+
+/// TCP relay that can simulate a network outage: while down it accepts and
+/// immediately drops every connection, so reconnect attempts fail the way
+/// they do against an unreachable or half-up network.
+struct OutageProxy {
+    port: u16,
+    outage: mpsc::SyncSender<()>,
+    restore: mpsc::SyncSender<()>,
+    worker: Option<thread::JoinHandle<io::Result<usize>>>,
+}
+
+impl OutageProxy {
+    fn start(backend_port: u16) -> Self {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (outage_tx, outage_rx) = mpsc::sync_channel(1);
+        let (restore_tx, restore_rx) = mpsc::sync_channel::<()>(1);
+        let worker = thread::spawn(move || {
+            let (first, _) = listener.accept()?;
+            let backend = TcpStream::connect((Ipv4Addr::LOCALHOST, backend_port))?;
+            let relays = relay(&first, &backend)?;
+            outage_rx
+                .recv_timeout(TIMEOUT)
+                .map_err(|error| io::Error::other(error.to_string()))?;
+            let _ = first.shutdown(Shutdown::Both);
+            let _ = backend.shutdown(Shutdown::Both);
+            join_relays(relays)?;
+            // Outage: drop every attempt until the test restores the link.
+            let mut refused = 0usize;
+            let recovered = loop {
+                let (attempt, _) = listener.accept()?;
+                if restore_rx.try_recv().is_ok() {
+                    break attempt;
+                }
+                let _ = attempt.shutdown(Shutdown::Both);
+                refused += 1;
+            };
+            let backend = TcpStream::connect((Ipv4Addr::LOCALHOST, backend_port))?;
+            let relays = relay(&recovered, &backend)?;
+            join_relays(relays)?;
+            // After the shell exits the server closes the connection; the
+            // client reconnects once more to learn the session ended.
+            let (final_client, _) = listener.accept()?;
+            let final_backend = TcpStream::connect((Ipv4Addr::LOCALHOST, backend_port))?;
+            let final_relays = relay(&final_client, &final_backend)?;
+            join_relays(final_relays)?;
+            Ok(refused)
+        });
+        Self {
+            port,
+            outage: outage_tx,
+            restore: restore_tx,
+            worker: Some(worker),
+        }
+    }
+
+    fn outage(&self) {
+        self.outage.send(()).unwrap();
+    }
+
+    fn restore(&self) {
+        self.restore.send(()).unwrap();
+    }
+
+    fn join(mut self) -> usize {
+        self.worker.take().unwrap().join().unwrap().unwrap()
+    }
+}
+
+type Relays = (
+    thread::JoinHandle<io::Result<u64>>,
+    thread::JoinHandle<io::Result<u64>>,
+);
+
+fn relay(client: &TcpStream, backend: &TcpStream) -> io::Result<Relays> {
+    let mut client_reader = client.try_clone()?;
+    let mut client_writer = client.try_clone()?;
+    let mut backend_reader = backend.try_clone()?;
+    let mut backend_writer = backend.try_clone()?;
+    Ok((
+        thread::spawn(move || io::copy(&mut client_reader, &mut backend_writer)),
+        thread::spawn(move || io::copy(&mut backend_reader, &mut client_writer)),
+    ))
+}
+
+fn join_relays((first, second): Relays) -> io::Result<()> {
+    for worker in [first, second] {
+        match worker.join() {
+            Ok(Ok(_)) => {}
+            Ok(Err(error))
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::BrokenPipe
+                        | io::ErrorKind::ConnectionAborted
+                        | io::ErrorKind::ConnectionReset
+                ) => {}
+            Ok(Err(error)) => return Err(error),
+            Err(_) => return Err(io::Error::other("relay worker panicked")),
+        }
+    }
+    Ok(())
+}
+
+fn receive_until(
+    receiver: &mpsc::Receiver<Vec<u8>>,
+    mut output: Vec<u8>,
+    marker: &[u8],
+) -> Vec<u8> {
+    while !output.windows(marker.len()).any(|window| window == marker) {
+        output.extend(receiver.recv_timeout(TIMEOUT).unwrap_or_else(|error| {
+            panic!(
+                "timed out waiting for {}: {error}; output={}",
+                String::from_utf8_lossy(marker),
+                String::from_utf8_lossy(&output)
+            )
+        }));
+    }
+    output
+}
+
+fn receive_number(
+    receiver: &mpsc::Receiver<Vec<u8>>,
+    mut output: Vec<u8>,
+    marker: &[u8],
+) -> (Vec<u8>, u32) {
+    loop {
+        if let Some(value) = marker_number(&output, marker) {
+            return (output, value);
+        }
+        output.extend(receiver.recv_timeout(TIMEOUT).unwrap_or_else(|error| {
+            panic!(
+                "timed out waiting for {}: {error}; output={}",
+                String::from_utf8_lossy(marker),
+                String::from_utf8_lossy(&output)
+            )
+        }));
+    }
+}
+
+fn marker_number(output: &[u8], marker: &[u8]) -> Option<u32> {
+    output
+        .windows(marker.len())
+        .enumerate()
+        .filter(|(_, window)| *window == marker)
+        .find_map(|(offset, _)| {
+            String::from_utf8_lossy(&output[offset + marker.len()..])
+                .chars()
+                .take_while(char::is_ascii_digit)
+                .collect::<String>()
+                .parse()
+                .ok()
+        })
+}
+
+fn wait_for_file(path: &std::path::Path, expected: &[u8]) {
+    let deadline = Instant::now() + TIMEOUT;
+    loop {
+        if fs::read(path).is_ok_and(|contents| contents == expected) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {}",
+            path.display()
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}


### PR DESCRIPTION
## Summary

Closing a MacBook lid and reopening it killed live sessions with:

```
et: could not reach the ET server at 10.10.10.10:2022: connection timed out
minpeter@woonggis-macbook-pro ~ % 2618;9u2618::99;9:3u
```

That one screenshot is two bugs:

### 1. Reconnect gave up after a single attempt

After wake, Wi-Fi is down for a few seconds. The client made exactly **one** reconnect attempt (10s deadline) and treated any failure as fatal, so a perfectly recoverable session died. Upstream ET retries until the server ends the session.

- New `ClientError::is_transient_reconnect()` classifies temporary network failures (unreachable endpoint, DNS outages, connect/transport I/O errors).
- `reconnect_with_retry()` retries those every second until the link returns, announcing the loop once (`et: connection lost, reconnecting... (press Ctrl-C to give up)`). Raw mode turns ISIG off, so Ctrl-C is read from stdin as 0x03 and honoured as "give up". Protocol mismatches / server rejections still fail immediately.

### 2. Terminal modes leaked past exit

The `2618;9u...` garbage is kitty-keyboard-protocol key reports: a remote app enabled the protocol in the local emulator, and the client only restored termios on exit. `RawMode` now also emits reset sequences when leaving raw mode: pop/zero kitty keyboard flags (both screens), leave the alternate screen, disable modifyOtherKeys, bracketed paste, focus and mouse reporting, show the cursor. Every reset is a no-op when the mode is off or the terminal does not support it.

## Tests

- New e2e regression test (`reconnect_outage_end_to_end.rs`): an `OutageProxy` cuts the link and refuses every reconnect attempt for 4 seconds — the exact state that used to kill the client — then proves the **same shell PID** recovers, at least two attempts were retried, and the client exits 0. Fails on the previous code.
- Unit tests for the retry skeleton (`retry_transient`) and the transient-error classification.
- `cargo test -p et` (all unit + e2e), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check` pass.

Client-only change; the wire protocol is untouched, so existing servers (including upstream C++ etserver) keep working.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `et` client survive short network outages by retrying reconnects instead of exiting, and reset terminal modes on exit so the shell doesn’t print garbage like `2618;9u`. No protocol changes; existing servers keep working.

- **Bug Fixes**
  - Reconnects now retry transient network errors (DNS issues, unreachable endpoint, I/O resets) every second until the link returns; the loop is announced once, and Ctrl-C aborts. Fatal errors (protocol mismatch, server rejection) still fail immediately.
  - Leaving raw mode now restores terminal state: disables kitty keyboard protocol, modifyOtherKeys, bracketed paste, focus/mouse reporting, leaves the alternate screen, and shows the cursor. All resets are no-ops if unsupported.
  - Added end-to-end regression and unit tests to cover outage recovery and error classification.

<sup>Written for commit ec017a34a2ca041e4b129fc8d506ecc2fd759e20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

