### PR TITLE
perf: trim the connected replay backup to 8 MiB per session

### DIFF
--- a/.tegami/trim-connected-replay-backup.md
+++ b/.tegami/trim-connected-replay-backup.md
@@ -1,0 +1,22 @@
+---
+packages:
+  et: patch
+---
+
+## Stop the daemon from retaining 64 MiB of replay history per live session
+
+Every packet written to a client is kept in a per-session replay backup so a
+reconnecting peer can catch up. That backup was only trimmed at upstream's
+64 MiB / 262,144-packet cap and never expired otherwise, so a long-lived
+`etserver` slowly pinned up to 64 MiB per session — with a couple dozen
+sessions the daemon grew towards multiple gigabytes, exactly like the C++
+server it replaces.
+
+While the transport is connected, a reconnecting peer can only be missing
+data that was in flight, which is bounded by kernel socket buffering
+(≤ 4 MiB on default Linux autotuning). The connected backup is now trimmed
+to 8 MiB / 32,768 packets and the deque returns its slack capacity after a
+reconnect. The disconnected catch-up buffer keeps upstream's full 64 MiB,
+and nothing on the wire changes: recovery, the handshake, and the
+receive-side catch-up validation limits all stay byte-compatible with
+upstream C++ peers.

--- a/crates/et-core/src/backed_writer.rs
+++ b/crates/et-core/src/backed_writer.rs
@@ -272,10 +272,7 @@ mod tests {
             w.recover(extra as i64).unwrap().len(),
             CONNECTED_BACKUP_PACKETS
         );
-        assert_eq!(
-            w.recover(extra as i64 - 1),
-            Err(RecoverError::TooFarBehind)
-        );
+        assert_eq!(w.recover(extra as i64 - 1), Err(RecoverError::TooFarBehind));
     }
 
     #[test]

--- a/crates/et-core/src/backed_writer.rs
+++ b/crates/et-core/src/backed_writer.rs
@@ -4,7 +4,14 @@
 //! [`WriterOutcome`] describing the bytes the transport must send, so the
 //! reconnect/replay logic is fully testable without I/O.
 //!
-//! Buffer caps match upstream exactly (64 MiB backup, 64 MiB disconnect).
+//! Wire-facing caps match upstream exactly (64 MiB disconnect buffer, 76 MiB
+//! recovery total, and the catchup entry limits validated on receive). The
+//! *connected* backup retention deliberately diverges from upstream's 64 MiB:
+//! while the transport is up, a reconnecting peer can only be missing data
+//! that was in flight (bounded by kernel socket buffers, typically <= 4 MiB),
+//! so retaining 64 MiB per session mostly wastes daemon memory. The connected
+//! backup is therefore trimmed to 8 MiB / 32 Ki packets; the disconnected
+//! catchup path keeps upstream's full 64 MiB.
 
 use std::collections::VecDeque;
 
@@ -17,6 +24,11 @@ pub const DISCONNECT_BUFFER_BYTES: i64 = 64 * 1024 * 1024;
 pub const MAX_RECOVERY_BACKUP_BYTES: i64 = 76 * 1024 * 1024;
 pub const MAX_BACKUP_PACKETS: usize = 262_144;
 pub const MAX_DISCONNECT_PACKETS: usize = 262_144;
+/// Replay history kept while connected; must comfortably exceed the largest
+/// amount of written-but-undelivered data a live TCP connection can hold
+/// (socket send buffer + in flight, <= 4 MiB on default Linux autotuning).
+pub const CONNECTED_BACKUP_BYTES: i64 = 8 * 1024 * 1024;
+pub const CONNECTED_BACKUP_PACKETS: usize = 32_768;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WriterOutcome {
@@ -94,11 +106,20 @@ impl BackedWriter {
         self.backup_size += packet.wire_len() as i64;
         self.sequence += 1;
         while self.connected
-            && (self.backup_size > MAX_BACKUP_BYTES || self.backup.len() > MAX_BACKUP_PACKETS)
+            && (self.backup_size > CONNECTED_BACKUP_BYTES
+                || self.backup.len() > CONNECTED_BACKUP_PACKETS)
         {
             if let Some(old) = self.backup.pop_back() {
                 self.backup_size -= old.wire_len() as i64;
             }
+        }
+        // A disconnect can balloon the deque to the 64 MiB catchup cap;
+        // return that slack once the trimmed length no longer needs it.
+        if self.connected
+            && self.backup.capacity() > 4096
+            && self.backup.capacity() / 4 > self.backup.len()
+        {
+            self.backup.shrink_to(self.backup.len() * 2);
         }
         if !self.connected {
             self.disconnected_bytes += packet.wire_len() as i64;
@@ -223,6 +244,52 @@ mod tests {
         let recovered = w.recover(0).unwrap();
         assert_eq!(recovered.len(), 1);
         assert_eq!(w.recover(2), Err(RecoverError::AheadOfServer));
+    }
+
+    #[test]
+    fn connected_backup_trims_to_connected_byte_cap() {
+        let mut w = writer(true);
+        let chunk = vec![0u8; 3 * 1024 * 1024];
+        for _ in 0..3 {
+            assert!(matches!(
+                w.write_packet(0, &chunk).unwrap(),
+                WriterOutcome::Send(_)
+            ));
+        }
+        // 9 MiB written while connected; only ~6 MiB (2 packets) is retained.
+        assert_eq!(w.recover(0), Err(RecoverError::TooFarBehind));
+        assert_eq!(w.recover(1).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn connected_backup_trims_to_connected_packet_cap() {
+        let mut w = writer(true);
+        let extra = 10;
+        for _ in 0..CONNECTED_BACKUP_PACKETS + extra {
+            w.write_packet(0, b"").unwrap();
+        }
+        assert_eq!(
+            w.recover(extra as i64).unwrap().len(),
+            CONNECTED_BACKUP_PACKETS
+        );
+        assert_eq!(
+            w.recover(extra as i64 - 1),
+            Err(RecoverError::TooFarBehind)
+        );
+    }
+
+    #[test]
+    fn disconnected_backup_keeps_full_catchup_history() {
+        let mut w = writer(false);
+        let chunk = vec![0u8; 3 * 1024 * 1024];
+        for _ in 0..3 {
+            assert_eq!(
+                w.write_packet(0, &chunk).unwrap(),
+                WriterOutcome::BufferedOnly
+            );
+        }
+        // Beyond the connected cap, but every packet must stay replayable.
+        assert_eq!(w.recover(0).unwrap().len(), 3);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`etserver` memory grows unbounded-until-cap on long uptimes. Production numbers from a 26-session workstation daemon:

| | C++ 7.0.0 (2d 8h) | et.rs 0.0.6 (5h 17m) |
|---|---|---|
| CPU time | 27min 10s | 37.9s |
| mem peak | 2.6G (+1.2G swap) | 733.6M **and climbing** |

Essentially all of the daemon RSS was anonymous heap: the `BackedWriter` replay backup faithfully mirrors upstream and keeps **every** packet written to a client — terminal output and keep-alive replies alike — trimming only at 64 MiB / 262,144 packets **per session**, forever. 26 sessions × 64 MiB ⇒ the daemon converges towards ~1.6G. This is the same design that took the C++ server to 2.6G.

## Fix

While the transport is *connected*, a reconnecting peer can only be missing data that was in flight, which is bounded by kernel socket buffering (≤ 4 MiB with default Linux autotuning). Retaining 64 MiB per live session buys nothing.

- Trim the connected backup at **8 MiB / 32,768 packets** (2× the kernel bound for margin).
- Return `VecDeque` slack capacity after a disconnect balloons it to the catch-up cap.
- The *disconnected* catch-up buffer keeps upstream's full 64 MiB — that is the path that actually covers outages.

## Wire compatibility

Nothing on the wire changes. The recovery handshake, `CatchupBuffer` replay, and the receive-side validation limits (`MAX_BACKUP_PACKETS + MAX_DISCONNECT_PACKETS`) stay byte-compatible with upstream C++ peers. The only behavioural difference: a peer that reconnects from a *live* connection while missing more than 8 MiB would get `TooFarBehind` (session restart) — impossible in practice, since a live TCP connection cannot hold that much undelivered data.

## Expected effect

- Idle sessions: keep-alive replies stop accumulating at ~3 MB heap instead of ~25 MB per session.
- Busy sessions: 8 MiB ceiling instead of 64 MiB; 26-session worst case ~208 MB instead of ~1.6 GB.

## Testing

- New unit tests: connected byte-cap trim, connected packet-cap trim, disconnected history retained in full.
- `cargo test --workspace` green (incl. reconnect / outage e2e), `cargo clippy --all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim the connected replay backup in `BackedWriter` to 8 MiB (32,768 packets) per session to cap `etserver` memory growth on long uptimes. Disconnected catch-up stays 64 MiB and wire compatibility is unchanged; we also shrink deque capacity after reconnect, dropping idle sessions to ~3 MiB and capping busy sessions at 8 MiB instead of 64 MiB.

<sup>Written for commit ba100a04b42039888e4f4f73360d5f9ff51e0791. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

