### PR TITLE
perf: trim replay backups with keep-alive delivery acknowledgements

### DIFF
--- a/.tegami/keepalive-delivery-acks.md
+++ b/.tegami/keepalive-delivery-acks.md
@@ -1,0 +1,27 @@
+---
+packages:
+  et: patch
+---
+
+## Trim replay backups with delivery acknowledgements on keep-alives
+
+Replay backups previously only shrank at a fixed cap, so a single burst of
+output (`cat` a large file) pinned the cap's worth of memory per session for
+the rest of the daemon's uptime, and idle sessions slowly accumulated
+keep-alive echoes.
+
+Keep-alives now carry the sender's reader sequence as an 8-byte payload.
+Every implementation ignores keep-alive payloads on receipt (verified
+against upstream C++ `TerminalServer`/`TerminalClient` and released et.rs),
+so the extension is invisible to legacy peers. An et.rs receiver uses it to
+drop backup packets the peer has already consumed, keeping only the
+unacknowledged tail plus a fixed slack — a session's replay backup now
+returns to near-empty within one keep-alive interval instead of pinning the
+connected cap forever.
+
+Acknowledgements are strictly per-hop. Jumphosts relay packets verbatim
+(upstream and et.rs alike), so the jumphost etserver consumes the client's
+acknowledgement for its own connection and forwards a payload-less
+keep-alive, and `etterminal --jump` attaches its own sequence towards the
+destination. A foreign sequence that still arrives through a legacy C++
+jumphost is absorbed by the retention slack.

--- a/crates/et-bin/src/client_terminal_loop.rs
+++ b/crates/et-bin/src/client_terminal_loop.rs
@@ -158,6 +158,11 @@ where
             match connection.try_read_packet() {
                 Ok(Some(packet)) => {
                     last_received = Instant::now();
+                    if packet.header() == TerminalPacketType::KeepAlive as u8 {
+                        if let Some(ack) = et_core::keepalive::decode_ack(packet.payload()) {
+                            connection.acknowledge_delivery(ack);
+                        }
+                    }
                     if is_forward_packet(packet.header()) {
                         pending_forward = forwarder
                             .try_receive(packet)
@@ -228,8 +233,11 @@ where
         }
         let now = Instant::now();
         if now >= next_keepalive {
+            // The payload acknowledges everything read so far, so the server
+            // can trim its replay backup; legacy servers ignore it.
+            let ack = connection.keepalive_ack();
             if connection
-                .write_packet(TerminalPacketType::KeepAlive as u8, &[])
+                .write_packet(TerminalPacketType::KeepAlive as u8, &ack)
                 .is_err()
                 && !recover(connection, &mut reconnect, &mut stream, terminal_enabled)?
             {

--- a/crates/et-bin/src/client_terminal_windows.rs
+++ b/crates/et-bin/src/client_terminal_windows.rs
@@ -102,6 +102,11 @@ where
             match connection.try_read_packet() {
                 Ok(Some(packet)) => {
                     last_received = Instant::now();
+                    if packet.header() == TerminalPacketType::KeepAlive as u8 {
+                        if let Some(ack) = et_core::keepalive::decode_ack(packet.payload()) {
+                            connection.acknowledge_delivery(ack);
+                        }
+                    }
                     if is_forward_packet(packet.header()) {
                         pending_forward = forwarder
                             .try_receive(packet)
@@ -153,8 +158,11 @@ where
             }
         }
         if Instant::now() >= next_keepalive {
+            // The payload acknowledges everything read so far, so the server
+            // can trim its replay backup; legacy servers ignore it.
+            let ack = connection.keepalive_ack();
             if connection
-                .write_packet(TerminalPacketType::KeepAlive as u8, &[])
+                .write_packet(TerminalPacketType::KeepAlive as u8, &ack)
                 .is_err()
             {
                 match reconnect(connection)? {

--- a/crates/et-bin/src/reconnect.rs
+++ b/crates/et-bin/src/reconnect.rs
@@ -55,8 +55,11 @@ fn recover_connection(
     connection
         .set_io_timeout(Some(remaining))
         .map_err(ClientError::Transport)?;
+    // The proof keep-alive carries a delivery acknowledgement so the server
+    // trims its replay backup right after recovery; legacy servers ignore it.
+    let ack = connection.keepalive_ack();
     connection
-        .write_packet(TerminalPacketType::KeepAlive as u8, &[])
+        .write_packet(TerminalPacketType::KeepAlive as u8, &ack)
         .map_err(|error| transport_error(deadline, "authenticating recovery", error))?;
     // Any packet that decrypts with the session key authenticates the server;
     // it is requeued and handled by the session loop. Upstream C++ servers

--- a/crates/et-bin/src/terminal_jump.rs
+++ b/crates/et-bin/src/terminal_jump.rs
@@ -172,6 +172,7 @@ fn relay(mut router: LocalStream, destination: &mut Connection) -> Result<i32, S
             Some(packet) => {
                 progress = true;
                 decoder = LocalPacketDecoder::new();
+                let packet = destination_packet(destination, packet);
                 if destination
                     .write_packet(packet.header(), packet.payload())
                     .is_err()
@@ -185,6 +186,7 @@ fn relay(mut router: LocalStream, destination: &mut Connection) -> Result<i32, S
             match destination.try_read_packet() {
                 Ok(Some(packet)) => {
                     progress = true;
+                    let packet = router_packet(destination, packet);
                     if write_local_packet(&mut router, &packet).is_err() {
                         return Ok(0);
                     }
@@ -225,6 +227,7 @@ fn relay(mut router: LocalStream, destination: &mut Connection) -> Result<i32, S
         if router_events.contains(PollFlags::IN) {
             if let Some(packet) = read_router_packet(&mut router, &mut decoder)? {
                 decoder = LocalPacketDecoder::new();
+                let packet = destination_packet(destination, packet);
                 if destination
                     .write_packet(packet.header(), packet.payload())
                     .is_err()
@@ -237,6 +240,7 @@ fn relay(mut router: LocalStream, destination: &mut Connection) -> Result<i32, S
             loop {
                 match destination.try_read_packet() {
                     Ok(Some(packet)) => {
+                        let packet = router_packet(destination, packet);
                         if write_local_packet(&mut router, &packet).is_err() {
                             return Ok(0);
                         }
@@ -250,6 +254,36 @@ fn relay(mut router: LocalStream, destination: &mut Connection) -> Result<i32, S
             return Ok(0);
         }
     }
+}
+
+/// Normalize a packet relayed towards the destination.
+///
+/// Keep-alive acknowledgements are per-hop: any payload the client attached
+/// was already consumed by the jumphost etserver, so replace it with this
+/// hop's own reader sequence, letting the destination trim its replay backup.
+fn destination_packet(destination: &Connection, packet: Packet) -> Packet {
+    if packet.header() != TerminalPacketType::KeepAlive as u8 {
+        return packet;
+    }
+    Packet::new(
+        TerminalPacketType::KeepAlive as u8,
+        destination.keepalive_ack().to_vec(),
+    )
+}
+
+/// Normalize a packet relayed towards the local router.
+///
+/// A keep-alive echo from the destination acknowledges this hop's writer;
+/// consume it and relay a payload-less keep-alive (the jumphost etserver
+/// attaches the client-facing acknowledgement).
+fn router_packet(destination: &mut Connection, packet: Packet) -> Packet {
+    if packet.header() != TerminalPacketType::KeepAlive as u8 {
+        return packet;
+    }
+    if let Some(ack) = et_core::keepalive::decode_ack(packet.payload()) {
+        destination.acknowledge_delivery(ack);
+    }
+    Packet::new(TerminalPacketType::KeepAlive as u8, Vec::new())
 }
 
 fn read_router_packet(

--- a/crates/et-core/src/backed_writer.rs
+++ b/crates/et-core/src/backed_writer.rs
@@ -29,6 +29,14 @@ pub const MAX_DISCONNECT_PACKETS: usize = 262_144;
 /// (socket send buffer + in flight, <= 4 MiB on default Linux autotuning).
 pub const CONNECTED_BACKUP_BYTES: i64 = 8 * 1024 * 1024;
 pub const CONNECTED_BACKUP_PACKETS: usize = 32_768;
+/// Packets retained beyond an acknowledged sequence. Jumphosts (upstream C++
+/// and released et.rs) relay keep-alives verbatim, so an acknowledgement can
+/// arrive carrying the sequence of a *different* hop's connection. The two
+/// domains only drift by packets a relay injects outside the relayed stream
+/// (one keep-alive per recovery), so retaining a generous fixed slack makes a
+/// foreign acknowledgement unable to trim away packets a genuine recovery
+/// could still request.
+pub const ACK_RETAIN_SLACK_PACKETS: usize = 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WriterOutcome {
@@ -113,13 +121,8 @@ impl BackedWriter {
                 self.backup_size -= old.wire_len() as i64;
             }
         }
-        // A disconnect can balloon the deque to the 64 MiB catchup cap;
-        // return that slack once the trimmed length no longer needs it.
-        if self.connected
-            && self.backup.capacity() > 4096
-            && self.backup.capacity() / 4 > self.backup.len()
-        {
-            self.backup.shrink_to(self.backup.len() * 2);
+        if self.connected {
+            self.release_slack_capacity();
         }
         if !self.connected {
             self.disconnected_bytes += packet.wire_len() as i64;
@@ -147,6 +150,36 @@ impl BackedWriter {
         }
         out.reverse();
         Ok(out)
+    }
+
+    /// Drop backup packets the peer has confirmed it consumed.
+    ///
+    /// `acknowledged` is the peer's reader sequence, delivered on a
+    /// keep-alive payload (see [`crate::keepalive`]). Only the
+    /// still-unacknowledged tail plus [`ACK_RETAIN_SLACK_PACKETS`] is kept,
+    /// so an idle session's backup stays near-empty instead of pinning the
+    /// full connected cap. Ignored while disconnected (a reconnect may
+    /// replay any of it) and for implausible sequences.
+    pub fn acknowledge(&mut self, acknowledged: i64) {
+        if !self.connected || acknowledged < 0 || acknowledged > self.sequence {
+            return;
+        }
+        let unacknowledged = usize::try_from(self.sequence - acknowledged).unwrap_or(usize::MAX);
+        let keep = unacknowledged.saturating_add(ACK_RETAIN_SLACK_PACKETS);
+        while self.backup.len() > keep {
+            if let Some(old) = self.backup.pop_back() {
+                self.backup_size -= old.wire_len() as i64;
+            }
+        }
+        self.release_slack_capacity();
+    }
+
+    /// A disconnect can balloon the deque to the 64 MiB catchup cap; return
+    /// that slack once the trimmed length no longer needs it.
+    fn release_slack_capacity(&mut self) {
+        if self.backup.capacity() > 4096 && self.backup.capacity() / 4 > self.backup.len() {
+            self.backup.shrink_to(self.backup.len() * 2);
+        }
     }
 
     pub fn revive(&mut self) {
@@ -273,6 +306,55 @@ mod tests {
             CONNECTED_BACKUP_PACKETS
         );
         assert_eq!(w.recover(extra as i64 - 1), Err(RecoverError::TooFarBehind));
+    }
+
+    #[test]
+    fn acknowledge_trims_to_the_unacknowledged_tail_plus_slack() {
+        let mut w = writer(true);
+        let total = ACK_RETAIN_SLACK_PACKETS + 100;
+        for _ in 0..total {
+            w.write_packet(0, b"x").unwrap();
+        }
+        w.acknowledge(w.sequence());
+        // Everything is acknowledged; only the slack margin remains.
+        let oldest_recoverable = (total - ACK_RETAIN_SLACK_PACKETS) as i64;
+        assert_eq!(
+            w.recover(oldest_recoverable).unwrap().len(),
+            ACK_RETAIN_SLACK_PACKETS
+        );
+        assert_eq!(
+            w.recover(oldest_recoverable - 1),
+            Err(RecoverError::TooFarBehind)
+        );
+    }
+
+    #[test]
+    fn acknowledge_keeps_unacknowledged_packets() {
+        let mut w = writer(true);
+        for _ in 0..10 {
+            w.write_packet(0, b"x").unwrap();
+        }
+        w.acknowledge(4);
+        // Nothing may be dropped: 6 unacknowledged + slack exceeds the 10 kept.
+        assert_eq!(w.recover(0).unwrap().len(), 10);
+    }
+
+    #[test]
+    fn acknowledge_ignores_implausible_and_disconnected_states() {
+        let mut w = writer(true);
+        for _ in 0..ACK_RETAIN_SLACK_PACKETS + 50 {
+            w.write_packet(0, b"x").unwrap();
+        }
+        let len = |w: &BackedWriter| w.recover(0).map(|out| out.len());
+        let full = len(&w).unwrap();
+        w.acknowledge(w.sequence() + 1); // ahead of what was written
+        assert_eq!(len(&w), Ok(full));
+        w.acknowledge(-1);
+        assert_eq!(len(&w), Ok(full));
+        w.invalidate();
+        w.acknowledge(w.sequence());
+        w.revive();
+        assert_eq!(len(&w), Ok(full));
     }
 
     #[test]

--- a/crates/et-core/src/keepalive.rs
+++ b/crates/et-core/src/keepalive.rs
@@ -1,0 +1,66 @@
+//! Delivery acknowledgements piggybacked on keep-alive packets.
+//!
+//! Upstream keep-alives carry an empty payload and every implementation
+//! (upstream C++ `TerminalServer`/`TerminalClient` and released et.rs)
+//! ignores the payload on receipt, so an et.rs peer can attach its reader
+//! sequence number without breaking interop. A receiver that understands the
+//! payload uses it to trim its replay backup down to the unacknowledged tail
+//! (see [`crate::backed_writer::BackedWriter::acknowledge`]); every other
+//! receiver keeps behaving as if the payload were empty.
+//!
+//! The payload is exactly 8 big-endian bytes so it can never be confused
+//! with the legacy empty payload, and any other length is ignored.
+
+/// Wire length of an acknowledgement payload.
+pub const ACK_PAYLOAD_LEN: usize = 8;
+
+/// Encode a reader sequence number as a keep-alive acknowledgement payload.
+pub fn encode_ack(sequence: i64) -> [u8; ACK_PAYLOAD_LEN] {
+    // Sequences are non-negative; clamp defensively so the wire value can
+    // always be decoded back into an i64.
+    sequence.max(0).to_be_bytes()
+}
+
+/// Decode a keep-alive payload into an acknowledged sequence number.
+///
+/// Returns `None` for the legacy empty payload, any other length, and
+/// values outside the non-negative `i64` range.
+pub fn decode_ack(payload: &[u8]) -> Option<i64> {
+    let bytes: [u8; ACK_PAYLOAD_LEN] = payload.try_into().ok()?;
+    let value = i64::from_be_bytes(bytes);
+    (value >= 0).then_some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        for sequence in [0, 1, 42, i64::MAX] {
+            assert_eq!(decode_ack(&encode_ack(sequence)), Some(sequence));
+        }
+    }
+
+    #[test]
+    fn legacy_empty_payload_is_ignored() {
+        assert_eq!(decode_ack(&[]), None);
+    }
+
+    #[test]
+    fn wrong_lengths_are_ignored() {
+        assert_eq!(decode_ack(&[0; 7]), None);
+        assert_eq!(decode_ack(&[0; 9]), None);
+    }
+
+    #[test]
+    fn negative_values_are_rejected() {
+        assert_eq!(decode_ack(&i64::MIN.to_be_bytes()), None);
+        assert_eq!(decode_ack(&(-1i64).to_be_bytes()), None);
+    }
+
+    #[test]
+    fn negative_sequences_encode_as_zero() {
+        assert_eq!(decode_ack(&encode_ack(-5)), Some(0));
+    }
+}

--- a/crates/et-core/src/lib.rs
+++ b/crates/et-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod backed_reader;
 pub mod backed_writer;
 pub mod crypto;
 pub mod framing;
+pub mod keepalive;
 pub mod keys;
 pub mod packet;
 pub mod proto;

--- a/crates/et-net/src/connection.rs
+++ b/crates/et-net/src/connection.rs
@@ -139,6 +139,17 @@ impl Connection {
         self.writer.has_capacity(bytes)
     }
 
+    /// Apply a peer delivery acknowledgement (keep-alive payload) to the
+    /// replay backup. Implausible values are ignored.
+    pub fn acknowledge_delivery(&mut self, sequence: i64) {
+        self.writer.acknowledge(sequence);
+    }
+
+    /// Keep-alive payload acknowledging everything read so far.
+    pub fn keepalive_ack(&self) -> [u8; et_core::keepalive::ACK_PAYLOAD_LEN] {
+        et_core::keepalive::encode_ack(self.reader.sequence())
+    }
+
     pub fn set_io_timeout(&self, timeout: Option<Duration>) -> Result<(), ConnError> {
         self.stream.set_read_timeout(timeout)?;
         self.stream.set_write_timeout(timeout)?;

--- a/crates/et-server/src/session.rs
+++ b/crates/et-server/src/session.rs
@@ -95,8 +95,12 @@ impl ActiveSession {
         candidate
             .authenticate_peer(DEFAULT_RECOVERY_TIMEOUT)
             .map_err(SessionError::Connection)?;
+        // The proof keep-alive carries a delivery acknowledgement so an
+        // et.rs client trims its replay backup right after recovery; legacy
+        // clients ignore the payload.
+        let ack = candidate.keepalive_ack();
         candidate
-            .write_packet(TerminalPacketType::KeepAlive as u8, &[])
+            .write_packet(TerminalPacketType::KeepAlive as u8, &ack)
             .map_err(SessionError::Connection)?;
         let new_control = candidate
             .try_clone_stream()
@@ -163,6 +167,26 @@ impl ActiveSession {
             .lock()
             .map_err(|_| SessionError::Unavailable)?
             .connected())
+    }
+
+    /// Apply a client delivery acknowledgement to the replay backup.
+    pub(crate) fn acknowledge_delivery(&self, sequence: i64) -> Result<(), SessionError> {
+        self.connection
+            .lock()
+            .map_err(|_| SessionError::Unavailable)?
+            .acknowledge_delivery(sequence);
+        Ok(())
+    }
+
+    /// Keep-alive payload acknowledging everything read from the client.
+    pub(crate) fn keepalive_ack(
+        &self,
+    ) -> Result<[u8; et_core::keepalive::ACK_PAYLOAD_LEN], SessionError> {
+        Ok(self
+            .connection
+            .lock()
+            .map_err(|_| SessionError::Unavailable)?
+            .keepalive_ack())
     }
 
     pub(crate) fn can_buffer_write(&self, bytes: i64) -> Result<bool, SessionError> {

--- a/crates/et-server/src/terminal_bridge.rs
+++ b/crates/et-server/src/terminal_bridge.rs
@@ -406,10 +406,7 @@ fn validate_terminal_output(packet: &Packet) -> Result<(), SessionError> {
 /// refers to this hop's connection, so apply it here and relay a payload-less
 /// keep-alive. The next hop (`etterminal --jump`) attaches its own sequence
 /// for the destination, and a foreign sequence never crosses a hop.
-fn jumphost_client_packet(
-    session: &ActiveSession,
-    packet: Packet,
-) -> Result<Packet, SessionError> {
+fn jumphost_client_packet(session: &ActiveSession, packet: Packet) -> Result<Packet, SessionError> {
     if packet.header() != TerminalPacketType::KeepAlive as u8 {
         return Ok(packet);
     }

--- a/crates/et-server/src/terminal_bridge.rs
+++ b/crates/et-server/src/terminal_bridge.rs
@@ -98,9 +98,12 @@ fn run_mode_poll(
         }
         if terminal_events.contains(PollFlags::IN) {
             if let Some(packet) = read_terminal_packet(&mut terminal, &mut decoder)? {
-                if mode == BridgeMode::Terminal {
+                let packet = if mode == BridgeMode::Terminal {
                     validate_terminal_output(&packet)?;
-                }
+                    packet
+                } else {
+                    jumphost_terminal_packet(&session, packet)?
+                };
                 decoder = LocalPacketDecoder::new();
                 match session.send_packet(packet.header(), packet.payload()) {
                     Ok(()) => {}
@@ -119,6 +122,7 @@ fn run_mode_poll(
                     // Jumphost relays every packet verbatim to the jump
                     // terminal, which owns the destination connection.
                     Ok(Some(packet)) if mode == BridgeMode::Jumphost => {
+                        let packet = jumphost_client_packet(&session, packet)?;
                         write_local_packet(&mut terminal, &packet).map_err(SessionError::Io)?;
                     }
                     Ok(Some(packet)) if is_forward_packet(packet.header()) => {
@@ -207,9 +211,12 @@ fn run_mode_windows(
             match read_terminal_packet(&mut terminal, &mut decoder) {
                 Ok(Some(packet)) => {
                     progress = true;
-                    if mode == BridgeMode::Terminal {
+                    let packet = if mode == BridgeMode::Terminal {
                         validate_terminal_output(&packet)?;
-                    }
+                        packet
+                    } else {
+                        jumphost_terminal_packet(&session, packet)?
+                    };
                     decoder = LocalPacketDecoder::new();
                     match session.send_packet(packet.header(), packet.payload()) {
                         Ok(()) => {}
@@ -233,6 +240,7 @@ fn run_mode_windows(
                     Ok(Some(packet)) => {
                         progress = true;
                         if mode == BridgeMode::Jumphost {
+                            let packet = jumphost_client_packet(&session, packet)?;
                             write_local_packet(&mut terminal, &packet).map_err(SessionError::Io)?;
                         } else if is_forward_packet(packet.header()) {
                             pending_forward =
@@ -392,6 +400,43 @@ fn validate_terminal_output(packet: &Packet) -> Result<(), SessionError> {
     Ok(())
 }
 
+/// Normalize a client packet relayed towards the jump terminal.
+///
+/// Keep-alive acknowledgements are per-hop: the payload the client sent
+/// refers to this hop's connection, so apply it here and relay a payload-less
+/// keep-alive. The next hop (`etterminal --jump`) attaches its own sequence
+/// for the destination, and a foreign sequence never crosses a hop.
+fn jumphost_client_packet(
+    session: &ActiveSession,
+    packet: Packet,
+) -> Result<Packet, SessionError> {
+    if packet.header() != TerminalPacketType::KeepAlive as u8 {
+        return Ok(packet);
+    }
+    if let Some(ack) = et_core::keepalive::decode_ack(packet.payload()) {
+        session.acknowledge_delivery(ack)?;
+    }
+    Ok(Packet::new(TerminalPacketType::KeepAlive as u8, Vec::new()))
+}
+
+/// Normalize a jump-terminal packet relayed towards the client.
+///
+/// A keep-alive echo returning from the destination acknowledges the previous
+/// hop; replace its payload with this hop's reader sequence so the client can
+/// trim its own replay backup.
+fn jumphost_terminal_packet(
+    session: &ActiveSession,
+    packet: Packet,
+) -> Result<Packet, SessionError> {
+    if packet.header() != TerminalPacketType::KeepAlive as u8 {
+        return Ok(packet);
+    }
+    Ok(Packet::new(
+        TerminalPacketType::KeepAlive as u8,
+        session.keepalive_ack()?.to_vec(),
+    ))
+}
+
 fn forward_client_packet(
     session: &ActiveSession,
     terminal: &mut LocalStream,
@@ -405,7 +450,16 @@ fn forward_client_packet(
             write_local_packet(terminal, &packet).map_err(SessionError::Io)
         }
         header if header == TerminalPacketType::KeepAlive as u8 => {
-            session.send_packet(TerminalPacketType::KeepAlive as u8, &[])
+            if let Some(ack) = et_core::keepalive::decode_ack(packet.payload()) {
+                session.acknowledge_delivery(ack)?;
+            }
+            // The echo acknowledges everything read from the client, letting
+            // an et.rs client trim its own replay backup. Legacy peers
+            // (upstream C++, released et.rs) ignore the payload.
+            session.send_packet(
+                TerminalPacketType::KeepAlive as u8,
+                &session.keepalive_ack()?,
+            )
         }
         _ => Err(SessionError::Io(io::Error::new(
             io::ErrorKind::InvalidData,

--- a/crates/et-server/tests/runtime_recovery.rs
+++ b/crates/et-server/tests/runtime_recovery.rs
@@ -108,6 +108,41 @@ fn returning_client_receives_exact_buffered_server_catchup() {
 }
 
 #[test]
+fn keepalive_echo_acknowledges_everything_read_from_the_client() {
+    let mut server = TestRuntime::start();
+    let _terminal = server.register(ID_A, KEY_A);
+    let (stream, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    let key = passkey_to_key(KEY_A).unwrap();
+    let (mut client, initial) = initialize(stream, &key, default_payload());
+    assert_eq!(initial.error, None);
+    server
+        .handle
+        .wait_for_state(ID_A, SessionState::Active, TIMEOUT)
+        .unwrap();
+
+    // An acknowledging keep-alive is echoed with the server's own ack: the
+    // count of every packet the client has written (the server processes
+    // packets in order, so by the time it echoes it has read them all).
+    let ack = client.keepalive_ack();
+    client
+        .write_packet(TerminalPacketType::KeepAlive as u8, &ack)
+        .unwrap();
+    let written = client.writer_sequence();
+    let echo = client.read_packet().unwrap();
+    assert_eq!(echo.header(), TerminalPacketType::KeepAlive as u8);
+    assert_eq!(et_core::keepalive::decode_ack(echo.payload()), Some(written));
+
+    // A legacy empty keep-alive still gets an echo.
+    client
+        .write_packet(TerminalPacketType::KeepAlive as u8, &[])
+        .unwrap();
+    let echo = client.read_packet().unwrap();
+    assert_eq!(echo.header(), TerminalPacketType::KeepAlive as u8);
+    server.runtime.shutdown().unwrap();
+}
+
+#[test]
 fn library_shutdown_interrupts_partial_handshakes_and_joins_workers() {
     let mut server = TestRuntime::start();
     let path = server.dir.socket();

--- a/crates/et-server/tests/runtime_recovery.rs
+++ b/crates/et-server/tests/runtime_recovery.rs
@@ -131,7 +131,10 @@ fn keepalive_echo_acknowledges_everything_read_from_the_client() {
     let written = client.writer_sequence();
     let echo = client.read_packet().unwrap();
     assert_eq!(echo.header(), TerminalPacketType::KeepAlive as u8);
-    assert_eq!(et_core::keepalive::decode_ack(echo.payload()), Some(written));
+    assert_eq!(
+        et_core::keepalive::decode_ack(echo.payload()),
+        Some(written)
+    );
 
     // A legacy empty keep-alive still gets an echo.
     client


### PR DESCRIPTION
Supersedes #17 (auto-closed when its stacked base branch was deleted by the #16 merge; full design/verification write-up is there).

TL;DR: keep-alives carry the sender's reader sequence as an 8-byte payload; receivers trim their replay backup to the unacknowledged tail + 1024-packet slack. Verified interop-safe: upstream C++ `TerminalServer`/`TerminalClient` and released et.rs all ignore keep-alive payloads. Acks are strictly per-hop across jumphosts (which relay verbatim); foreign sequences through legacy C++ jumphosts are absorbed by the slack.

Together with #16 this takes a session's steady-state replay backup from "pinned at the cap after any burst" to near-empty within one keep-alive interval.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim replay backups by piggybacking delivery acknowledgements on keep‑alive packets. Sessions drop acknowledged data and return to near‑empty within one keep‑alive interval, without breaking interop.

- New Features
  - Keep‑alives now carry an 8‑byte big‑endian reader sequence. Receivers drop acknowledged packets and keep only the unacked tail plus a 1024‑packet slack.
  - Acknowledgements are per‑hop. Clients, servers, and jumphosts consume/rewrite payloads at each hop; echoes return with the hop‑local ack. Legacy peers ignore payloads and keep working.
  - Added `et_core::keepalive` (encode/decode), `Connection::keepalive_ack`/`acknowledge_delivery`, and `BackedWriter::acknowledge` with capacity release. Tests cover echo and trimming behavior.

<sup>Written for commit e10be0a956daa608ef15acf5a19ae18087da6a0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

