### PR TITLE
fix: reconnect after macOS live socket timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
         run: >-
           cargo test -p et
           --test reconnect_end_to_end
+          --test reconnect_outage_end_to_end
           --test server_runtime
           --test terminal_adversarial
           --test terminal_end_to_end

--- a/.tegami/reconnect-sleep-timeout.md
+++ b/.tegami/reconnect-sleep-timeout.md
@@ -1,0 +1,18 @@
+---
+packages:
+  et: patch
+---
+
+## Recover from macOS post-sleep socket timeouts
+
+Changing networks or waking a MacBook can leave the existing TCP connection in
+an unusable state. macOS reports some of those stale connections as
+`ETIMEDOUT` (`Operation timed out`, os error 60) rather than EOF or a reset.
+The client previously treated that live-transport error as fatal and exited,
+which also exposed any terminal mode left by the remote program.
+
+Every socket I/O failure from the live ET transport now enters the normal
+reconnect path. Recovery retains the same remote session and keeps retrying
+while Wi-Fi or routing returns; protocol, crypto, framing, backpressure, and
+local-terminal failures remain fatal. This matches upstream Eternal Terminal's
+behavior of reconnecting after any socket read/write error.

--- a/crates/et-bin/src/client_terminal.rs
+++ b/crates/et-bin/src/client_terminal.rs
@@ -52,7 +52,7 @@ pub fn run<F>(
     mut connection: Connection,
     options: TerminalOptions<'_>,
     forwarder: Forwarder,
-    reconnect: F,
+    mut reconnect: F,
 ) -> Result<(), ClientError>
 where
     F: FnMut(&mut Connection) -> Result<ReconnectOutcome, ClientError>,
@@ -69,12 +69,33 @@ where
     } else {
         RawMode { enabled: false }
     };
+    // The network can disappear immediately after the initial handshake (a
+    // laptop waking up is particularly prone to this).  These writes are
+    // replay-buffered by `Connection`, so once recovery succeeds they must
+    // not be sent again; doing so would duplicate a `--command`.  Recover the
+    // transport and let the buffered packet be replayed instead.
     if terminal_enabled {
-        send_size(&mut connection)?;
+        let initial_size = send_size(&mut connection);
+        if !recover_initial_transport(
+            &mut connection,
+            &mut reconnect,
+            terminal_enabled,
+            initial_size,
+        )? {
+            return Ok(());
+        }
     }
     if terminal_enabled {
         if let Some(command) = command {
-            send_command(&mut connection, command, no_exit, lines)?;
+            let initial_command = send_command(&mut connection, command, no_exit, lines);
+            if !recover_initial_transport(
+                &mut connection,
+                &mut reconnect,
+                terminal_enabled,
+                initial_command,
+            )? {
+                return Ok(());
+            }
         }
     }
     let read_stdin = terminal_enabled && (command.is_none() || io::stdin().is_terminal());
@@ -217,7 +238,7 @@ pub(crate) fn send_buffer(connection: &mut Connection, bytes: &[u8]) -> Result<(
 }
 
 fn send_buffer_checked(connection: &mut Connection, bytes: &[u8]) -> Result<(), ClientError> {
-    send_buffer(connection, bytes).map_err(terminal_error)
+    send_buffer(connection, bytes).map_err(ClientError::Transport)
 }
 
 pub(crate) fn send_size(connection: &mut Connection) -> Result<(), ClientError> {
@@ -237,7 +258,60 @@ pub(crate) fn send_size(connection: &mut Connection) -> Result<(), ClientError> 
             TerminalPacketType::TerminalInfo as u8,
             &message.encode_to_vec(),
         )
-        .map_err(terminal_error)
+        .map_err(ClientError::Transport)
+}
+
+/// Finish an initial client write without losing a session to a race between
+/// the handshake and the first terminal packet.
+///
+/// `Connection` has already retained a packet whose socket write failed.
+/// Recovery replays that exact packet, so this deliberately does not retry
+/// `result` after reconnecting (retrying a command could execute it twice).
+fn recover_initial_transport<F>(
+    connection: &mut Connection,
+    reconnect: &mut F,
+    send_terminal_size: bool,
+    result: Result<(), ClientError>,
+) -> Result<bool, ClientError>
+where
+    F: FnMut(&mut Connection) -> Result<ReconnectOutcome, ClientError>,
+{
+    match result {
+        Ok(()) => Ok(true),
+        Err(ClientError::Transport(error)) if connection_ended(&error) => {
+            recover_transport(connection, reconnect, send_terminal_size)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Recover a broken live transport, including a connection that fails again
+/// while its post-recovery terminal-size packet is being sent.
+///
+/// The latter race is common after laptop wake: Wi-Fi can become routable long
+/// enough for TCP recovery and then lose the first application packet.  Keep
+/// recovery inside the reconnect loop until a live terminal-size update has
+/// been sent, just as upstream reconnects after every socket read/write
+/// error.
+pub(crate) fn recover_transport<F>(
+    connection: &mut Connection,
+    reconnect: &mut F,
+    send_terminal_size: bool,
+) -> Result<bool, ClientError>
+where
+    F: FnMut(&mut Connection) -> Result<ReconnectOutcome, ClientError>,
+{
+    loop {
+        match reconnect(connection)? {
+            ReconnectOutcome::SessionEnded => return Ok(false),
+            ReconnectOutcome::Recovered if !send_terminal_size => return Ok(true),
+            ReconnectOutcome::Recovered => match send_size(connection) {
+                Ok(()) => return Ok(true),
+                Err(ClientError::Transport(error)) if connection_ended(&error) => {}
+                Err(error) => return Err(error),
+            },
+        }
+    }
 }
 
 /// Reset sequences for terminal modes a remote application may have enabled
@@ -281,20 +355,20 @@ impl Drop for RawMode {
     }
 }
 
-/// Errors that mean the session must reconnect rather than fail.
+/// Errors that mean the TCP transport is no longer usable and the session
+/// must reconnect rather than exit.
+///
+/// In particular, macOS reports a stale TCP flow after sleep as `ETIMEDOUT`
+/// (`io::ErrorKind::TimedOut`), not necessarily as EOF or reset.  There is no
+/// actionable socket I/O failure for the terminal loop: the connection state
+/// is preserved in the backed reader/writer, so every socket I/O error enters
+/// recovery.  Protocol, crypto, framing, backpressure, and local-terminal
+/// errors use other `ConnError` variants and still remain fatal.
+///
+/// This matches upstream `Connection::read`/`write`, which closes and starts
+/// its reconnect loop for both skippable and "serious" socket errors.
 pub(crate) fn connection_ended(error: &ConnError) -> bool {
-    matches!(
-        error,
-        ConnError::Io(source)
-            if matches!(
-                source.kind(),
-                io::ErrorKind::UnexpectedEof
-                    | io::ErrorKind::BrokenPipe
-                    | io::ErrorKind::ConnectionAborted
-                    | io::ErrorKind::ConnectionReset
-                    | io::ErrorKind::NotConnected
-            )
-    )
+    matches!(error, ConnError::Io(_))
 }
 
 pub(crate) fn terminal_error(error: ConnError) -> ClientError {

--- a/crates/et-bin/src/client_terminal_loop.rs
+++ b/crates/et-bin/src/client_terminal_loop.rs
@@ -18,8 +18,8 @@ use rustix::time::Timespec;
 
 #[cfg(unix)]
 use crate::client_terminal::{
-    connection_ended, display_packet, send_buffer, send_size, terminal_error, terminal_io,
-    terminal_text,
+    connection_ended, display_packet, recover_transport, send_buffer, send_size, terminal_error,
+    terminal_io, terminal_text,
 };
 #[cfg(unix)]
 use crate::error::ClientError;
@@ -275,16 +275,11 @@ fn recover<F>(
 where
     F: FnMut(&mut Connection) -> Result<ReconnectOutcome, ClientError>,
 {
-    match reconnect(connection)? {
-        ReconnectOutcome::Recovered => {
-            *stream = connection.try_clone_stream().map_err(terminal_error)?;
-            if send_terminal_size {
-                send_size(connection)?;
-            }
-            Ok(true)
-        }
-        ReconnectOutcome::SessionEnded => Ok(false),
+    if !recover_transport(connection, reconnect, send_terminal_size)? {
+        return Ok(false);
     }
+    *stream = connection.try_clone_stream().map_err(terminal_error)?;
+    Ok(true)
 }
 
 #[cfg(unix)]

--- a/crates/et-bin/src/client_terminal_tests.rs
+++ b/crates/et-bin/src/client_terminal_tests.rs
@@ -5,8 +5,10 @@ use et_core::proto::{TerminalBuffer, TerminalPacketType};
 use et_net::connection::{ConnError, Connection};
 use prost::Message;
 
-use super::send_command;
+use super::{recover_initial_transport, recover_transport, send_command};
 use crate::client_terminal::{connection_ended, RemoteLines};
+use crate::error::ClientError;
+use crate::initial_connect::ReconnectOutcome;
 
 #[test]
 fn command_exit_suffix_matches_no_exit_flag_and_remote_shell() {
@@ -38,11 +40,61 @@ fn command_exit_suffix_matches_no_exit_flag_and_remote_shell() {
 }
 
 #[test]
-fn only_terminal_connection_end_errors_are_clean() {
-    assert!(connection_ended(&ConnError::Io(
-        std::io::ErrorKind::UnexpectedEof.into()
-    )));
+fn every_socket_error_reconnects_including_sleep_timeout() {
+    // macOS reports a stale post-sleep TCP flow as ETIMEDOUT (os error 60).
+    // It must not become `terminal transport: io: Operation timed out`.
+    for kind in [
+        std::io::ErrorKind::UnexpectedEof,
+        std::io::ErrorKind::ConnectionReset,
+        std::io::ErrorKind::TimedOut,
+        std::io::ErrorKind::HostUnreachable,
+        std::io::ErrorKind::NetworkUnreachable,
+    ] {
+        assert!(connection_ended(&ConnError::Io(kind.into())), "{kind:?}");
+    }
     assert!(!connection_ended(&ConnError::Backpressure));
+}
+
+#[test]
+fn initial_socket_timeout_enters_recovery_instead_of_exiting() {
+    let (stream, _peer) = tcp_pair();
+    let mut connection = Connection::new_client(stream, &[7u8; KEY_LEN]);
+    let mut attempts = 0;
+    let recovered = recover_initial_transport(
+        &mut connection,
+        &mut |_| {
+            attempts += 1;
+            Ok(ReconnectOutcome::SessionEnded)
+        },
+        true,
+        Err(ClientError::Transport(ConnError::Io(
+            std::io::ErrorKind::TimedOut.into(),
+        ))),
+    )
+    .unwrap();
+    assert!(!recovered);
+    assert_eq!(attempts, 1);
+}
+
+#[test]
+fn recovery_rechecks_terminal_setup_before_returning_to_the_pump() {
+    let (stream, _peer) = tcp_pair();
+    let mut connection = Connection::new_client(stream, &[7u8; KEY_LEN]);
+    let mut attempts = 0;
+    let recovered = recover_transport(
+        &mut connection,
+        &mut |_| {
+            attempts += 1;
+            Ok(ReconnectOutcome::Recovered)
+        },
+        true,
+    )
+    .unwrap();
+    // Unit-test stdout is not a TTY, so the terminal-size operation is a
+    // successful no-op. The important invariant is that recovery owns that
+    // operation before it declares the socket usable to the pump.
+    assert!(recovered);
+    assert_eq!(attempts, 1);
 }
 
 fn tcp_pair() -> (TcpStream, TcpStream) {

--- a/crates/et-bin/src/client_terminal_windows.rs
+++ b/crates/et-bin/src/client_terminal_windows.rs
@@ -19,7 +19,8 @@ use et_net::connection::Connection;
 use et_net::forward::{is_forward_packet, Forwarder};
 
 use crate::client_terminal::{
-    connection_ended, display_packet, send_buffer, send_size, terminal_error, terminal_text,
+    connection_ended, display_packet, recover_transport, send_buffer, send_size, terminal_error,
+    terminal_text,
 };
 use crate::error::ClientError;
 use crate::initial_connect::ReconnectOutcome;
@@ -145,17 +146,12 @@ where
             reconnect_needed = true;
         }
         if reconnect_needed {
-            match reconnect(connection)? {
-                ReconnectOutcome::Recovered => {
-                    if terminal_enabled {
-                        send_size(connection)?;
-                    }
-                    last_received = Instant::now();
-                    next_keepalive = last_received + interval;
-                    continue;
-                }
-                ReconnectOutcome::SessionEnded => return Ok(()),
+            if !recover_transport(connection, &mut reconnect, terminal_enabled)? {
+                return Ok(());
             }
+            last_received = Instant::now();
+            next_keepalive = last_received + interval;
+            continue;
         }
         if Instant::now() >= next_keepalive {
             // The payload acknowledges everything read so far, so the server
@@ -164,11 +160,9 @@ where
             if connection
                 .write_packet(TerminalPacketType::KeepAlive as u8, &ack)
                 .is_err()
+                && !recover_transport(connection, &mut reconnect, terminal_enabled)?
             {
-                match reconnect(connection)? {
-                    ReconnectOutcome::Recovered => {}
-                    ReconnectOutcome::SessionEnded => return Ok(()),
-                }
+                return Ok(());
             }
             next_keepalive = Instant::now() + interval;
         }


### PR DESCRIPTION
## Summary

Fixes #20.

A long macOS sleep can leave the pre-sleep TCP flow stale. When it is next
read, Darwin reports `ETIMEDOUT` (`Operation timed out`, os error 60). The
client only considered EOF/reset-style errors reconnectable, so it surfaced
that I/O error as the fatal:

```text
et: terminal transport: io: Operation timed out (os error 60)
```

and exited instead of entering the retry loop added in #14.

`connection_ended()` now treats every `ConnError::Io` from the live TCP
transport as a reconnect trigger. These errors only identify a broken socket;
the backed reader/writer retains session state for recovery. Protocol, crypto,
framing, backpressure, and local terminal failures use separate error variants
and still fail immediately. This matches upstream Eternal Terminal, whose
`Connection::read` and `Connection::write` close and reconnect after every
socket error, including their “serious error” branch.

The existing reconnect path retries temporary route/DNS/connect/handshake
failures every second, so `ETIMEDOUT`, `EHOSTUNREACH`, and
`ENETUNREACH` now all preserve the same remote shell until connectivity
returns. Explicit Ctrl-C still abandons recovery, and the existing raw-mode
cleanup resets kitty keyboard, bracketed-paste, focus, mouse, and alternate
screen modes on exit.

## Tests

- New unit coverage classifies `TimedOut`, `HostUnreachable`, and
  `NetworkUnreachable` as reconnectable live-transport failures, while keeping
  `Backpressure` non-reconnectable.
- Existing outage e2e test proves multi-attempt recovery preserves the same
  shell PID.
- `cargo test -p et`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconnect after macOS sleep TCP timeouts. The client now reconnects on any live TCP I/O error, keeps the same remote shell, and avoids duplicate `--command` after handshake.

- **Bug Fixes**
  - `connection_ended()` now treats any `ConnError::Io` as reconnectable (covers `ETIMEDOUT`, `EHOSTUNREACH`, `ENETUNREACH`); send/write errors map to `ClientError::Transport` so they enter recovery.
  - New `recover_transport`/`recover_initial_transport` unify recovery on Unix and Windows (reads/writes, keepalives, and initial terminal-size/command). Retry until a terminal-size update succeeds, never re-send commands, and exit if the session ends. Tests added for sleep timeouts and outage recovery; CI runs `reconnect_outage_end_to_end`.

<sup>Written for commit 79ff802e2babe50f40b583c5a7ee0374f4956c52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

