### PR TITLE
feat(server): ET_DEBUG mode and session diagnostic logs

### DIFF
--- a/.tegami/server-debug-diagnostics.md
+++ b/.tegami/server-debug-diagnostics.md
@@ -1,0 +1,18 @@
+---
+packages:
+  et:
+    type: patch
+---
+
+## Add debug diagnostics for dropped server sessions
+
+`ET_DEBUG=1` now gives `etserver` a durable machine-local log destination,
+non-silent logging, and default verbosity 2. Operators can also use
+`ET_LOGDIR` and `ET_VERBOSE` when CLI or INI settings do not override them.
+
+Server diagnostics now record client accept/reject reasons, reconnect and
+recovery outcomes, terminal disconnects, and session removal, making long-lived
+session drops diagnosable from the server host. Client debug logs omit session
+credentials, malformed handshakes are bounded by a five-second deadline and
+128-connection pre-auth capacity, and completed connection handlers no longer
+accumulate after rapid failed handshakes.

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -22,12 +22,14 @@ const RECONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const RECONNECT_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 pub fn run(args: &[OsString]) -> Result<i32, clap::Error> {
-    let parsed = ClientArgs::try_parse_from(
+    let mut parsed = ClientArgs::try_parse_from(
         ["et"]
             .iter()
             .map(|value| OsString::from(*value))
             .chain(args.iter().cloned()),
     )?;
+    parsed.verbose = et_cli::logging::effective_verbose(parsed.verbose);
+    parsed.silent = et_cli::logging::effective_silent(parsed.silent);
     // `--telemetry` is accepted for upstream compatibility and ignored:
     // et.rs never collects telemetry, and upstream prints nothing here.
     init_logging(&parsed);
@@ -105,10 +107,7 @@ fn run_client(
         }
     }
     let invocation = build_invocation(&request, &provisional);
-    et_cli::logging::verbose(
-        1,
-        format!("Trying ssh with args: {}", invocation.args.join(" ")),
-    );
+    et_cli::logging::verbose(1, bootstrap_log_message(&request));
     let mut credentials = run_bootstrap(runner, &invocation, deadline)?;
     et_cli::logging::info("etserver started");
     // Without a jumphost the ET connection goes straight to the destination.
@@ -301,11 +300,9 @@ fn reconnect_wait_aborted(delay: Duration) -> bool {
 fn init_logging(args: &ClientArgs) {
     let user = std::env::var("USER").unwrap_or_else(|_| "unknown".to_owned());
     et_cli::logging::init(et_cli::logging::LogOptions {
-        directory: args
-            .logdir
-            .as_deref()
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(std::env::temp_dir),
+        directory: et_cli::logging::effective_log_directory(
+            args.logdir.as_deref().map(std::path::PathBuf::from),
+        ),
         prefix: format!("etclient-{user}"),
         to_stdout: args.logtostdout,
         silent: args.silent,
@@ -313,6 +310,14 @@ fn init_logging(args: &ClientArgs) {
         verbose: args.verbose,
         max_size: et_cli::logging::DEFAULT_MAX_LOG_SIZE,
     });
+}
+
+fn bootstrap_log_message(request: &BootstrapRequest) -> String {
+    format!(
+        "starting SSH bootstrap host={} options={}",
+        request.host_alias,
+        request.ssh_options.len()
+    )
 }
 
 fn command_user(positional: Option<String>, option: Option<String>) -> Option<String> {
@@ -501,5 +506,32 @@ mod tests {
             validate_jumphost("good,"),
             Err(ClientError::Unsupported("empty hop in --jumphost"))
         ));
+    }
+
+    #[test]
+    fn bootstrap_log_message_never_contains_credentials() {
+        let request = BootstrapRequest {
+            user: Some("user".to_owned()),
+            host_alias: "host.example".to_owned(),
+            jumphost: None,
+            terminal_path: None,
+            server_fifo: None,
+            kill_other_sessions: false,
+            verbose: 2,
+            ssh_options: vec!["Compression=yes".to_owned()],
+            term: "xterm".to_owned(),
+            remote_shell: RemoteShell::Posix,
+        };
+        let credentials = Credentials {
+            id: "abcdefghijklmnop".to_owned(),
+            passkey: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef".to_owned(),
+        };
+        let message = bootstrap_log_message(&request);
+        assert!(!message.contains(&credentials.id));
+        assert!(!message.contains(&credentials.passkey));
+        assert_eq!(
+            message,
+            "starting SSH bootstrap host=host.example options=1"
+        );
     }
 }

--- a/crates/et-bin/src/server.rs
+++ b/crates/et-bin/src/server.rs
@@ -43,7 +43,22 @@ pub fn run(args: &[OsString]) -> Result<i32, clap::Error> {
         verbose: config.verbose,
         max_size: config.log_size,
     });
+    // Forward server runtime diagnostics into the same file logger.
+    et_server::diag::init(|level, message| {
+        if level == 0 {
+            et_cli::logging::info(message);
+        } else {
+            et_cli::logging::verbose(level, message);
+        }
+    });
     et_cli::logging::info("In child, about to start server.");
+    et_cli::logging::info(format!(
+        "etserver logging enabled (verbose={}, logdir={}, silent={}, ET_DEBUG={})",
+        config.verbose,
+        config.log_directory.display(),
+        config.silent,
+        et_cli::logging::env_debug_enabled()
+    ));
     let shutdown = ShutdownSignal::install()
         .map_err(|error| clap_io("could not install server signal handlers", error))?;
     let router_path = select_router_path(config.server_fifo.as_deref())

--- a/crates/et-bin/src/terminal.rs
+++ b/crates/et-bin/src/terminal.rs
@@ -53,17 +53,19 @@ struct TerminalArgs {
 }
 
 pub fn run(args: &[OsString]) -> Result<i32, clap::Error> {
-    let parsed = TerminalArgs::try_parse_from(
+    let mut parsed = TerminalArgs::try_parse_from(
         ["etterminal"]
             .iter()
             .map(|value| OsString::from(*value))
             .chain(args.iter().cloned()),
     )?;
+    parsed.verbose = et_cli::logging::effective_verbose(parsed.verbose);
+    let log_directory = et_cli::logging::effective_log_directory(parsed.logdir.clone());
     let input = load_credentials(&parsed).map_err(clap_error)?;
     // Upstream names these logs `etterminal-<user>-<id>` (or `etjump-...`).
     let user = std::env::var("USER").unwrap_or_else(|_| "unknown".to_owned());
     et_cli::logging::init(et_cli::logging::LogOptions {
-        directory: parsed.logdir.clone().unwrap_or_else(std::env::temp_dir),
+        directory: log_directory,
         prefix: format!(
             "{}-{user}-{}",
             if parsed.jump { "etjump" } else { "etterminal" },

--- a/crates/et-cli/src/logging.rs
+++ b/crates/et-cli/src/logging.rs
@@ -84,6 +84,119 @@ pub fn log_path() -> Option<PathBuf> {
         .and_then(|logger| logger.lock().ok().and_then(|logger| logger.path.clone()))
 }
 
+/// Machine-local debug overrides shared by `et`, `etserver`, and `etterminal`.
+///
+/// | Variable     | Effect |
+/// |--------------|--------|
+/// | `ET_DEBUG=1` | Raise default verbosity to 2, force logging on, prefer a durable logdir |
+/// | `ET_LOGDIR`  | Default log directory when `--logdir` / INI do not set one |
+/// | `ET_VERBOSE` | Default verbosity when `--verbose` / INI leave it at 0 |
+///
+/// Explicit CLI flags and (for the server) INI values always win over these.
+pub fn env_debug_enabled() -> bool {
+    matches!(
+        std::env::var("ET_DEBUG").as_deref(),
+        Ok("1") | Ok("true") | Ok("TRUE") | Ok("yes") | Ok("YES") | Ok("on") | Ok("ON")
+    )
+}
+
+/// Resolve verbosity: CLI/INI value if non-zero, else `ET_VERBOSE`, else 2 when
+/// `ET_DEBUG` is set, else 0.
+pub fn effective_verbose(configured: u8) -> u8 {
+    resolve_verbose(
+        configured,
+        env_debug_enabled(),
+        std::env::var("ET_VERBOSE").ok(),
+    )
+}
+
+/// Pure resolution used by [`effective_verbose`] and unit tests.
+pub fn resolve_verbose(configured: u8, debug: bool, et_verbose: Option<String>) -> u8 {
+    if configured > 0 {
+        return configured;
+    }
+    if let Some(value) = et_verbose {
+        if let Ok(level) = value.parse::<u8>() {
+            return level;
+        }
+    }
+    if debug {
+        2
+    } else {
+        0
+    }
+}
+
+/// Resolve log directory: configured path if present, else `ET_LOGDIR`, else
+/// platform temp (or a durable home logdir when `ET_DEBUG` is set and no path
+/// was configured).
+pub fn effective_log_directory(configured: Option<PathBuf>) -> PathBuf {
+    resolve_log_directory(
+        configured,
+        env_debug_enabled(),
+        std::env::var_os("ET_LOGDIR").map(PathBuf::from),
+        default_debug_log_directory(),
+        std::env::temp_dir(),
+    )
+}
+
+/// Pure resolution used by [`effective_log_directory`] and unit tests.
+pub fn resolve_log_directory(
+    configured: Option<PathBuf>,
+    debug: bool,
+    et_logdir: Option<PathBuf>,
+    debug_default: PathBuf,
+    temp_dir: PathBuf,
+) -> PathBuf {
+    if let Some(directory) = configured {
+        return directory;
+    }
+    if let Some(directory) = et_logdir {
+        return directory;
+    }
+    if debug {
+        debug_default
+    } else {
+        temp_dir
+    }
+}
+
+/// When `ET_DEBUG` is set, logging is never silent. Otherwise keep `configured`.
+pub fn effective_silent(configured: bool) -> bool {
+    resolve_silent(configured, env_debug_enabled())
+}
+
+/// Pure resolution used by [`effective_silent`] and unit tests.
+pub fn resolve_silent(configured: bool, debug: bool) -> bool {
+    if debug {
+        false
+    } else {
+        configured
+    }
+}
+
+/// Durable default under `$HOME/Library/Logs/et-rs` (macOS) or
+/// `$HOME/.local/state/et-rs` / `$XDG_STATE_HOME/et-rs` elsewhere. Falls back
+/// to the process temp dir when `$HOME` is unset.
+pub fn default_debug_log_directory() -> PathBuf {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    #[cfg(target_os = "macos")]
+    {
+        return home
+            .unwrap_or_else(std::env::temp_dir)
+            .join("Library/Logs/et-rs");
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        if let Some(state) = std::env::var_os("XDG_STATE_HOME") {
+            return PathBuf::from(state).join("et-rs");
+        }
+        return home
+            .map(|home| home.join(".local/state/et-rs"))
+            .unwrap_or_else(std::env::temp_dir);
+    }
+}
+
 fn write_line(level: u8, message: &str) {
     let Some(logger) = LOGGER.get() else {
         return;
@@ -258,6 +371,58 @@ mod tests {
         logger.write(0, "hello");
         assert!(logger.path.is_none());
         assert!(!directory.exists());
+    }
+
+    #[test]
+    fn resolve_verbose_prefers_configured_then_env_then_debug_default() {
+        assert_eq!(resolve_verbose(3, true, Some("1".into())), 3);
+        assert_eq!(resolve_verbose(0, false, Some("4".into())), 4);
+        assert_eq!(resolve_verbose(0, true, None), 2);
+        assert_eq!(resolve_verbose(0, false, None), 0);
+        assert_eq!(resolve_verbose(0, true, Some("nope".into())), 2);
+    }
+
+    #[test]
+    fn resolve_log_directory_prefers_configured_then_env_then_debug_default() {
+        let configured = PathBuf::from("/cli");
+        let env = PathBuf::from("/env");
+        let debug_default = PathBuf::from("/debug");
+        let temp = PathBuf::from("/tmp");
+        assert_eq!(
+            resolve_log_directory(
+                Some(configured.clone()),
+                true,
+                Some(env.clone()),
+                debug_default.clone(),
+                temp.clone()
+            ),
+            configured
+        );
+        assert_eq!(
+            resolve_log_directory(
+                None,
+                false,
+                Some(env.clone()),
+                debug_default.clone(),
+                temp.clone()
+            ),
+            env
+        );
+        assert_eq!(
+            resolve_log_directory(None, true, None, debug_default.clone(), temp.clone()),
+            debug_default
+        );
+        assert_eq!(
+            resolve_log_directory(None, false, None, debug_default, temp.clone()),
+            temp
+        );
+    }
+
+    #[test]
+    fn resolve_silent_forces_logging_under_debug() {
+        assert!(!resolve_silent(true, true));
+        assert!(resolve_silent(true, false));
+        assert!(!resolve_silent(false, false));
     }
 
     #[cfg_attr(windows, ignore = "file mode bits are POSIX-only")]

--- a/crates/et-cli/src/logging.rs
+++ b/crates/et-cli/src/logging.rs
@@ -92,7 +92,8 @@ pub fn log_path() -> Option<PathBuf> {
 /// | `ET_LOGDIR`  | Default log directory when `--logdir` / INI do not set one |
 /// | `ET_VERBOSE` | Default verbosity when `--verbose` / INI leave it at 0 |
 ///
-/// Explicit CLI flags and (for the server) INI values always win over these.
+/// Non-zero CLI/INI verbosity and explicit log directories win over these.
+/// Verbosity 0 means "use the environment/default verbosity".
 pub fn env_debug_enabled() -> bool {
     matches!(
         std::env::var("ET_DEBUG").as_deref(),
@@ -176,24 +177,45 @@ pub fn resolve_silent(configured: bool, debug: bool) -> bool {
 }
 
 /// Durable default under `$HOME/Library/Logs/et-rs` (macOS) or
-/// `$HOME/.local/state/et-rs` / `$XDG_STATE_HOME/et-rs` elsewhere. Falls back
-/// to the process temp dir when `$HOME` is unset.
+/// `%LOCALAPPDATA%\et-rs` (Windows), or `$XDG_STATE_HOME/et-rs` /
+/// `$HOME/.local/state/et-rs` elsewhere. Falls back to the process temp dir.
 pub fn default_debug_log_directory() -> PathBuf {
-    let home = std::env::var_os("HOME").map(PathBuf::from);
-    #[cfg(target_os = "macos")]
-    {
-        return home
-            .unwrap_or_else(std::env::temp_dir)
-            .join("Library/Logs/et-rs");
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        if let Some(state) = std::env::var_os("XDG_STATE_HOME") {
-            return PathBuf::from(state).join("et-rs");
-        }
-        return home
-            .map(|home| home.join(".local/state/et-rs"))
-            .unwrap_or_else(std::env::temp_dir);
+    resolve_default_debug_log_directory(
+        cfg!(target_os = "macos"),
+        cfg!(target_os = "windows"),
+        std::env::var_os("HOME").map(PathBuf::from),
+        std::env::var_os("XDG_STATE_HOME").map(PathBuf::from),
+        std::env::var_os("LOCALAPPDATA").map(PathBuf::from),
+        std::env::temp_dir(),
+    )
+}
+
+fn resolve_default_debug_log_directory(
+    is_macos: bool,
+    is_windows: bool,
+    home: Option<PathBuf>,
+    xdg_state_home: Option<PathBuf>,
+    local_app_data: Option<PathBuf>,
+    temp_dir: PathBuf,
+) -> PathBuf {
+    if is_macos {
+        home.filter(|path| path.is_absolute())
+            .map(|path| path.join("Library/Logs/et-rs"))
+            .unwrap_or(temp_dir)
+    } else if is_windows {
+        local_app_data
+            .filter(|path| path.is_absolute())
+            .map(|path| path.join("et-rs"))
+            .unwrap_or(temp_dir)
+    } else {
+        xdg_state_home
+            .filter(|path| path.is_absolute())
+            .map(|path| path.join("et-rs"))
+            .or_else(|| {
+                home.filter(|path| path.is_absolute())
+                    .map(|path| path.join(".local/state/et-rs"))
+            })
+            .unwrap_or(temp_dir)
     }
 }
 
@@ -383,6 +405,12 @@ mod tests {
     }
 
     #[test]
+    fn zero_verbosity_uses_environment_semantics() {
+        assert_eq!(resolve_verbose(0, true, None), 2);
+        assert_eq!(resolve_verbose(0, true, Some("0".into())), 0);
+    }
+
+    #[test]
     fn resolve_log_directory_prefers_configured_then_env_then_debug_default() {
         let configured = PathBuf::from("/cli");
         let env = PathBuf::from("/env");
@@ -423,6 +451,54 @@ mod tests {
         assert!(!resolve_silent(true, true));
         assert!(resolve_silent(true, false));
         assert!(!resolve_silent(false, false));
+    }
+
+    #[test]
+    fn platform_debug_directory_uses_only_absolute_durable_roots() {
+        assert_eq!(
+            resolve_default_debug_log_directory(
+                true,
+                false,
+                Some(PathBuf::from("/home/test")),
+                None,
+                None,
+                PathBuf::from("/tmp"),
+            ),
+            PathBuf::from("/home/test/Library/Logs/et-rs")
+        );
+        assert_eq!(
+            resolve_default_debug_log_directory(
+                false,
+                false,
+                Some(PathBuf::from("/home/test")),
+                Some(PathBuf::from("/state")),
+                None,
+                PathBuf::from("/tmp"),
+            ),
+            PathBuf::from("/state/et-rs")
+        );
+        assert_eq!(
+            resolve_default_debug_log_directory(
+                false,
+                false,
+                Some(PathBuf::from("/home/test")),
+                Some(PathBuf::from("relative")),
+                None,
+                PathBuf::from("/tmp"),
+            ),
+            PathBuf::from("/home/test/.local/state/et-rs")
+        );
+        assert_eq!(
+            resolve_default_debug_log_directory(
+                false,
+                true,
+                None,
+                None,
+                Some(PathBuf::from("/local")),
+                PathBuf::from("/tmp"),
+            ),
+            PathBuf::from("/local/et-rs")
+        );
     }
 
     #[cfg_attr(windows, ignore = "file mode bits are POSIX-only")]

--- a/crates/et-cli/src/server.rs
+++ b/crates/et-cli/src/server.rs
@@ -112,9 +112,11 @@ pub fn resolve_config(
         log_size: DEFAULT_LOG_SIZE,
         telemetry: false,
     };
-    if let Some(text) = ini_text {
-        apply_ini(&mut config, args, text)?;
-    }
+    let ini_log_directory_set = if let Some(text) = ini_text {
+        apply_ini(&mut config, args, text)?
+    } else {
+        false
+    };
     if let Some(port) = args.port {
         config.port = port;
     }
@@ -133,7 +135,7 @@ pub fn resolve_config(
     // Machine-local env overrides (`ET_DEBUG` / `ET_LOGDIR` / `ET_VERBOSE`)
     // apply only when CLI (and, for logdir, INI) left the field at defaults.
     // CLI always wins; INI wins over env for values it set.
-    apply_env_debug_overrides(&mut config, args);
+    apply_env_debug_overrides(&mut config, args, ini_log_directory_set);
     Ok(config)
 }
 
@@ -145,23 +147,41 @@ pub fn resolve_config(
 ///   still the process temp default from construction). Callers that set
 ///   `logdir` on args already overwrote `log_directory` above.
 /// - `silent`: forced off under `ET_DEBUG`.
-fn apply_env_debug_overrides(config: &mut ServerConfig, args: &ServerArgs) {
+fn apply_env_debug_overrides(
+    config: &mut ServerConfig,
+    args: &ServerArgs,
+    ini_log_directory_set: bool,
+) {
     config.verbose = crate::logging::effective_verbose(config.verbose);
-    if args.logdir.is_none() {
-        // INI may have set log_directory already; only fall through to env when
-        // the directory is still the construction default (temp). Compare via
-        // the same helper so ET_LOGDIR / ET_DEBUG durable paths apply.
-        let from_env = crate::logging::effective_log_directory(None);
-        // If INI set a custom path, keep it: temp_dir means "unset by INI".
-        if config.log_directory == std::env::temp_dir() {
-            config.log_directory = from_env;
-        }
-    }
+    config.log_directory = resolve_server_log_directory(
+        config.log_directory.clone(),
+        args.logdir.is_some(),
+        ini_log_directory_set,
+        crate::logging::effective_log_directory(None),
+    );
     config.silent = crate::logging::effective_silent(config.silent);
 }
 
-fn apply_ini(config: &mut ServerConfig, args: &ServerArgs, text: &str) -> Result<(), ConfigError> {
+fn resolve_server_log_directory(
+    configured: PathBuf,
+    cli_log_directory_set: bool,
+    ini_log_directory_set: bool,
+    environment_default: PathBuf,
+) -> PathBuf {
+    if cli_log_directory_set || ini_log_directory_set {
+        configured
+    } else {
+        environment_default
+    }
+}
+
+fn apply_ini(
+    config: &mut ServerConfig,
+    args: &ServerArgs,
+    text: &str,
+) -> Result<bool, ConfigError> {
     let mut section = String::new();
+    let mut log_directory_set = false;
     for raw in text.lines() {
         let line = raw.trim();
         if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
@@ -193,6 +213,7 @@ fn apply_ini(config: &mut ServerConfig, args: &ServerArgs, text: &str) -> Result
             }
             ("debug", "logdirectory") if args.logdir.is_none() => {
                 config.log_directory = PathBuf::from(value);
+                log_directory_set = true;
             }
             ("debug", "silent") => {
                 config.silent = value.parse::<i64>().is_ok_and(|value| value != 0);
@@ -207,7 +228,7 @@ fn apply_ini(config: &mut ServerConfig, args: &ServerArgs, text: &str) -> Result
             _ => {}
         }
     }
-    Ok(())
+    Ok(log_directory_set)
 }
 
 fn parse_port(value: &str) -> Result<u16, String> {
@@ -285,5 +306,18 @@ mod tests {
         let config = resolve_config(&args, None).unwrap();
         assert_eq!(config.verbose, 3);
         assert_eq!(config.log_directory, PathBuf::from("/tmp/cli-wins"));
+    }
+
+    #[test]
+    fn explicit_ini_temp_logdir_wins_over_environment() {
+        assert_eq!(
+            resolve_server_log_directory(
+                PathBuf::from("/tmp"),
+                false,
+                true,
+                PathBuf::from("/environment"),
+            ),
+            PathBuf::from("/tmp")
+        );
     }
 }

--- a/crates/et-cli/src/server.rs
+++ b/crates/et-cli/src/server.rs
@@ -130,7 +130,34 @@ pub fn resolve_config(
     if let Some(directory) = &args.logdir {
         config.log_directory = directory.clone();
     }
+    // Machine-local env overrides (`ET_DEBUG` / `ET_LOGDIR` / `ET_VERBOSE`)
+    // apply only when CLI (and, for logdir, INI) left the field at defaults.
+    // CLI always wins; INI wins over env for values it set.
+    apply_env_debug_overrides(&mut config, args);
     Ok(config)
+}
+
+/// Apply `ET_*` debug env vars after CLI/INI resolution.
+///
+/// - `verbose`: raised only when still 0 (CLI `-v` / INI `verbose` win).
+/// - `log_directory`: replaced only when neither CLI `--logdir` nor INI
+///   `logdirectory` set a path (detected via args + whether the directory is
+///   still the process temp default from construction). Callers that set
+///   `logdir` on args already overwrote `log_directory` above.
+/// - `silent`: forced off under `ET_DEBUG`.
+fn apply_env_debug_overrides(config: &mut ServerConfig, args: &ServerArgs) {
+    config.verbose = crate::logging::effective_verbose(config.verbose);
+    if args.logdir.is_none() {
+        // INI may have set log_directory already; only fall through to env when
+        // the directory is still the construction default (temp). Compare via
+        // the same helper so ET_LOGDIR / ET_DEBUG durable paths apply.
+        let from_env = crate::logging::effective_log_directory(None);
+        // If INI set a custom path, keep it: temp_dir means "unset by INI".
+        if config.log_directory == std::env::temp_dir() {
+            config.log_directory = from_env;
+        }
+    }
+    config.silent = crate::logging::effective_silent(config.silent);
 }
 
 fn apply_ini(config: &mut ServerConfig, args: &ServerArgs, text: &str) -> Result<(), ConfigError> {
@@ -247,5 +274,16 @@ mod tests {
         assert!(args.daemon);
         assert!(!args.daemon_child);
         assert_eq!(args.pidfile, None);
+    }
+
+    #[test]
+    fn apply_env_debug_overrides_leaves_cli_logdir_alone() {
+        // Without mutating process env: CLI logdir is sticky because
+        // `args.logdir` is Some, so `apply_env_debug_overrides` skips the dir.
+        let args = ServerArgs::try_parse_from(["etserver", "-v", "3", "--logdir", "/tmp/cli-wins"])
+            .unwrap();
+        let config = resolve_config(&args, None).unwrap();
+        assert_eq!(config.verbose, 3);
+        assert_eq!(config.log_directory, PathBuf::from("/tmp/cli-wins"));
     }
 }

--- a/crates/et-net/src/handshake.rs
+++ b/crates/et-net/src/handshake.rs
@@ -3,6 +3,8 @@
 //! INVALID_KEY / MISMATCHED_PROTOCOL).
 
 use std::io;
+use std::net::TcpStream;
+use std::time::{Duration, Instant};
 
 use et_core::proto::{ConnectRequest, ConnectResponse, ConnectStatus};
 use et_core::PROTOCOL_VERSION;
@@ -10,6 +12,7 @@ use et_core::PROTOCOL_VERSION;
 use crate::framing_io::{read_proto_limited, write_proto};
 
 const MAX_HANDSHAKE_PROTO_LEN: i64 = 64 * 1024;
+pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub fn client_request(client_id: &str) -> ConnectRequest {
     ConnectRequest {
@@ -20,6 +23,13 @@ pub fn client_request(client_id: &str) -> ConnectRequest {
 
 pub fn read_request<R: io::Read>(r: &mut R) -> io::Result<ConnectRequest> {
     read_proto_limited(r, MAX_HANDSHAKE_PROTO_LEN)
+}
+
+pub fn read_request_deadline(
+    stream: &mut TcpStream,
+    deadline: Instant,
+) -> io::Result<ConnectRequest> {
+    crate::framing_io::read_proto_limited_deadline(stream, MAX_HANDSHAKE_PROTO_LEN, deadline)
 }
 
 pub fn write_response<W: io::Write>(w: &mut W, response: &ConnectResponse) -> io::Result<()> {
@@ -42,6 +52,8 @@ mod tests {
     use super::*;
     use crate::framing_io::{read_proto, write_proto};
     use std::io::Cursor;
+    use std::net::{TcpListener, TcpStream};
+    use std::time::Instant;
 
     #[test]
     fn request_carries_protocol_version() {
@@ -94,5 +106,16 @@ mod tests {
             let r = response_status(st);
             assert_eq!(r.status, Some(st as i32));
         }
+    }
+
+    #[test]
+    fn request_deadline_expires_before_reading_an_idle_peer() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let connector = std::thread::spawn(move || TcpStream::connect(address).unwrap());
+        let (mut server, _) = listener.accept().unwrap();
+        let _client = connector.join().unwrap();
+        let error = read_request_deadline(&mut server, Instant::now()).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
     }
 }

--- a/crates/et-server/src/diag.rs
+++ b/crates/et-server/src/diag.rs
@@ -1,0 +1,35 @@
+//! Optional process-wide diagnostic logging for the server runtime.
+//!
+//! `et-server` stays free of CLI/file-logging dependencies. The `etserver` binary
+//! installs a sink that forwards into `et_cli::logging` after it initialises.
+//! When no sink is installed (unit tests, embedded callers), log calls are no-ops.
+
+use std::sync::OnceLock;
+
+/// `level` matches upstream `VLOG` / `LOG(INFO)`: `0` is always kept by an
+/// installed sink that honours info lines; higher values are verbose.
+pub type DiagSink = fn(level: u8, message: &str);
+
+static SINK: OnceLock<DiagSink> = OnceLock::new();
+
+/// Install the process-wide diagnostic sink. Later calls are ignored so a live
+/// server cannot reconfigure logging mid-flight.
+pub fn init(sink: DiagSink) {
+    let _ = SINK.set(sink);
+}
+
+/// Log an informational line (always forwarded when a sink is installed).
+pub fn info(message: impl AsRef<str>) {
+    write(0, message.as_ref());
+}
+
+/// Log a verbose line; the sink decides whether `level` is kept.
+pub fn verbose(level: u8, message: impl AsRef<str>) {
+    write(level, message.as_ref());
+}
+
+fn write(level: u8, message: &str) {
+    if let Some(sink) = SINK.get() {
+        sink(level, message);
+    }
+}

--- a/crates/et-server/src/diag.rs
+++ b/crates/et-server/src/diag.rs
@@ -28,8 +28,45 @@ pub fn verbose(level: u8, message: impl AsRef<str>) {
     write(level, message.as_ref());
 }
 
+/// Escape and bound untrusted text before embedding it in a diagnostic line.
+pub fn sanitize_external_field(value: &str) -> String {
+    const MAX_LEN: usize = 256;
+    const ELLIPSIS: &str = "...";
+
+    let mut sanitized = String::with_capacity(value.len().min(MAX_LEN));
+    let mut truncated = false;
+    for character in value.chars() {
+        let escaped: String = character.escape_default().collect();
+        if sanitized.len() + escaped.len() > MAX_LEN - ELLIPSIS.len() {
+            truncated = true;
+            break;
+        }
+        sanitized.push_str(&escaped);
+    }
+    if truncated {
+        sanitized.push_str(ELLIPSIS);
+    }
+    sanitized
+}
+
 fn write(level: u8, message: &str) {
     if let Some(sink) = SINK.get() {
         sink(level, message);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn external_fields_escape_control_characters_and_limit_length() {
+        let malicious = format!("client\nforged\rentry\t{}", "x".repeat(300));
+        let sanitized = sanitize_external_field(&malicious);
+        assert_eq!(
+            sanitized,
+            format!("client\\nforged\\rentry\\t{}...", "x".repeat(230))
+        );
+        assert_eq!(sanitized.len(), 256);
     }
 }

--- a/crates/et-server/src/lib.rs
+++ b/crates/et-server/src/lib.rs
@@ -2,6 +2,7 @@
 
 //! Secure server listeners, local terminal registration, and encrypted session routing.
 
+pub mod diag;
 pub mod path;
 mod registry;
 mod registry_validation;

--- a/crates/et-server/src/runtime.rs
+++ b/crates/et-server/src/runtime.rs
@@ -16,7 +16,9 @@ use crate::runtime_accept;
 use crate::runtime_error::RuntimeError;
 use crate::runtime_handle::RuntimeHandle;
 use crate::runtime_lifecycle::{self, LifecycleEvent};
-use crate::runtime_state::{HandlerThreads, RawSockets, RuntimeCore};
+use crate::runtime_state::{
+    HandlerThreads, PreAuthSlots, RawSockets, RuntimeCore, MAX_PRE_AUTH_CONNECTIONS,
+};
 use crate::session_table::SessionTable;
 
 pub struct Runtime {
@@ -50,6 +52,7 @@ impl Runtime {
             sessions: SessionTable::new(),
             raw_sockets: Arc::new(RawSockets::new()),
             handlers: HandlerThreads::new(),
+            pre_auth_slots: Arc::new(PreAuthSlots::new(MAX_PRE_AUTH_CONNECTIONS)),
             shutdown: AtomicBool::new(false),
         });
         let router_name = router_path.path().to_path_buf();

--- a/crates/et-server/src/runtime_accept.rs
+++ b/crates/et-server/src/runtime_accept.rs
@@ -77,6 +77,10 @@ fn accept_ready(listener: &TcpListener, core: &Arc<RuntimeCore>) -> Result<(), R
     loop {
         match listener.accept() {
             Ok((stream, _)) => {
+                let Some(pre_auth_guard) = core.pre_auth_slots.clone().try_acquire() else {
+                    crate::diag::verbose(1, "reject TCP connection: pre-auth capacity exhausted");
+                    continue;
+                };
                 // Windows inherits the listener's non-blocking mode on accepted
                 // sockets (Unix does not), and the handshake below is blocking.
                 stream
@@ -90,7 +94,9 @@ fn accept_ready(listener: &TcpListener, core: &Arc<RuntimeCore>) -> Result<(), R
                 let worker_core = core.clone();
                 let worker = thread::Builder::new()
                     .name("et-session-handler".to_owned())
-                    .spawn(move || runtime_handler::handle(stream, worker_core, guard))
+                    .spawn(move || {
+                        runtime_handler::handle(stream, worker_core, guard, pre_auth_guard)
+                    })
                     .map_err(RuntimeError::Spawn)?;
                 if let Err(worker) = core.handlers.push(worker) {
                     let _ = worker.join();

--- a/crates/et-server/src/runtime_accept.rs
+++ b/crates/et-server/src/runtime_accept.rs
@@ -98,10 +98,7 @@ fn accept_ready(listener: &TcpListener, core: &Arc<RuntimeCore>) -> Result<(), R
                         runtime_handler::handle(stream, worker_core, guard, pre_auth_guard)
                     })
                     .map_err(RuntimeError::Spawn)?;
-                if let Err(worker) = core.handlers.push(worker) {
-                    let _ = worker.join();
-                    return Err(RuntimeError::WorkerUnavailable);
-                }
+                core.handlers.push(worker)?;
             }
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(()),
             Err(error) if error.kind() == io::ErrorKind::Interrupted => {}

--- a/crates/et-server/src/runtime_handler.rs
+++ b/crates/et-server/src/runtime_handler.rs
@@ -15,14 +15,22 @@ use crate::session::ActiveSession;
 use crate::session_table::SessionClaim;
 
 pub(crate) fn handle(stream: TcpStream, core: Arc<RuntimeCore>, mut guard: RawSocketGuard) {
+    let peer = stream
+        .peer_addr()
+        .map(|addr| addr.to_string())
+        .unwrap_or_else(|_| "unknown".to_owned());
+    crate::diag::verbose(1, &format!("accepted TCP connection from {peer}"));
     let mut stream = stream;
     let request = match read_request(&mut stream) {
         Ok(request) => request,
-        Err(_) => {
+        Err(error) => {
+            crate::diag::verbose(1, &format!("malformed ConnectRequest from {peer}: {error}"));
             reject(
                 &mut stream,
                 ConnectStatus::InvalidKey,
                 "malformed ConnectRequest",
+                &peer,
+                None,
             );
             return;
         }
@@ -32,11 +40,19 @@ pub(crate) fn handle(stream: TcpStream, core: Arc<RuntimeCore>, mut guard: RawSo
             &mut stream,
             ConnectStatus::MismatchedProtocol,
             "protocol version does not match server version 6",
+            &peer,
+            request.client_id.as_deref(),
         );
         return;
     }
     let Some(id) = request.client_id.filter(|id| valid_id(id)) else {
-        reject(&mut stream, ConnectStatus::InvalidKey, "invalid client id");
+        reject(
+            &mut stream,
+            ConnectStatus::InvalidKey,
+            "invalid client id",
+            &peer,
+            None,
+        );
         return;
     };
     let registration = match core.registry.get(&id) {
@@ -46,11 +62,16 @@ pub(crate) fn handle(stream: TcpStream, core: Arc<RuntimeCore>, mut guard: RawSo
                 &mut stream,
                 ConnectStatus::InvalidKey,
                 "client is not registered",
+                &peer,
+                Some(&id),
             );
             return;
         }
     };
     if guard.assign(registration.identity()).is_err() {
+        crate::diag::info(format!(
+            "drop {peer} id={id}: could not track raw socket for registration"
+        ));
         return;
     }
     let claim = match core.sessions.claim(registration, &stream, &core.registry) {
@@ -60,34 +81,76 @@ pub(crate) fn handle(stream: TcpStream, core: Arc<RuntimeCore>, mut guard: RawSo
                 &mut stream,
                 ConnectStatus::InvalidKey,
                 "client registration disconnected",
+                &peer,
+                Some(&id),
             );
             return;
         }
-        Err(_) => return,
+        Err(error) => {
+            crate::diag::info(format!(
+                "drop {peer} id={id}: session claim failed: {error}"
+            ));
+            return;
+        }
     };
     match claim {
         SessionClaim::New { start, replaced } => {
+            if replaced.is_some() {
+                crate::diag::info(format!(
+                    "id={id}: replacing existing session for new client from {peer}"
+                ));
+            }
             if replaced.is_some_and(|connection| connection.shutdown().is_err()) {
+                crate::diag::info(format!(
+                    "id={id}: failed to shut down replaced session; aborting new client"
+                ));
                 return;
             }
-            handle_new(stream, start, &core);
+            crate::diag::info(format!("id={id}: new client session from {peer}"));
+            handle_new(stream, start, &core, &id, &peer);
         }
         SessionClaim::Returning(session) => {
+            crate::diag::info(format!("id={id}: returning client reconnect from {peer}"));
             if send_status(&mut stream, ConnectStatus::ReturningClient).is_ok() {
-                let _ = session.recover(stream);
+                match session.recover(stream) {
+                    Ok(()) => {
+                        crate::diag::info(format!("id={id}: session recover accepted from {peer}"))
+                    }
+                    Err(error) => crate::diag::info(format!(
+                        "id={id}: session recover failed from {peer}: {error}"
+                    )),
+                }
+            } else {
+                crate::diag::info(format!(
+                    "id={id}: failed to send ReturningClient status to {peer}"
+                ));
             }
         }
     }
 }
 
-fn handle_new(mut stream: TcpStream, start: crate::session_slot::SessionStart, core: &RuntimeCore) {
+fn handle_new(
+    mut stream: TcpStream,
+    start: crate::session_slot::SessionStart,
+    core: &RuntimeCore,
+    id: &str,
+    peer: &str,
+) {
     if send_status(&mut stream, ConnectStatus::NewClient).is_err() {
+        crate::diag::info(format!(
+            "id={id}: failed to send NewClient status to {peer}"
+        ));
         return;
     }
     let mut connection = Connection::new_server(stream, &start.registration().key);
     let packet = match connection.read_packet() {
         Ok(packet) => packet,
-        Err(_) => return,
+        Err(error) => {
+            crate::diag::info(format!(
+                "id={id}: failed reading INITIAL_PAYLOAD from {peer}: {error}"
+            ));
+            return;
+        }
     };
     let payload = if packet.header() == EtPacketType::InitialPayload as u8 {
         InitialPayload::decode(packet.payload()).map_err(|_| "malformed InitialPayload")
@@ -97,12 +160,16 @@ fn handle_new(mut stream: TcpStream, start: crate::session_slot::SessionStart, c
     let payload = match payload {
         Ok(payload) => payload,
         Err(message) => {
+            crate::diag::info(format!(
+                "id={id}: rejecting InitialPayload from {peer}: {message}"
+            ));
             send_initial_error(&mut connection, message);
             return;
         }
     };
     if payload.jumphost.unwrap_or(false) {
-        run_jumphost(connection, start, core, payload);
+        crate::diag::info(format!("id={id}: jumphost session from {peer}"));
+        run_jumphost(connection, start, core, payload, id, peer);
         return;
     }
     let owner = {
@@ -115,6 +182,9 @@ fn handle_new(mut stream: TcpStream, start: crate::session_slot::SessionStart, c
     ) {
         Ok(started) => started,
         Err(error) => {
+            crate::diag::info(format!(
+                "id={id}: reverse-tunnel setup failed for {peer}: {error}"
+            ));
             send_initial_error(&mut connection, &error.to_string());
             return;
         }
@@ -126,11 +196,17 @@ fn handle_new(mut stream: TcpStream, start: crate::session_slot::SessionStart, c
         )
         .is_err()
     {
+        crate::diag::info(format!(
+            "id={id}: failed writing INITIAL_RESPONSE to {peer}"
+        ));
         return;
     }
     let mut terminal = match core.registry.clone_stream(start.registration()) {
         Ok(terminal) => terminal,
-        Err(_) => return,
+        Err(error) => {
+            crate::diag::info(format!("id={id}: could not clone terminal stream: {error}"));
+            return;
+        }
     };
     // Merge the client-supplied environment with variables created for
     // named-pipe forwards; upstream stores them in a sorted std::map.
@@ -153,13 +229,21 @@ fn handle_new(mut stream: TcpStream, start: crate::session_slot::SessionStart, c
     }
     let active = match ActiveSession::new(connection, &terminal) {
         Ok(active) => active,
-        Err(_) => return,
+        Err(error) => {
+            crate::diag::info(format!(
+                "id={id}: could not create active session for {peer}: {error}"
+            ));
+            return;
+        }
     };
     let active = Arc::new(active);
     if start.activate(active.clone()).is_err() {
+        crate::diag::info(format!("id={id}: could not activate session for {peer}"));
         return;
     }
+    crate::diag::info(format!("id={id}: terminal bridge running for {peer}"));
     let _ = crate::terminal_bridge::run(active.clone(), terminal, forwarder);
+    crate::diag::info(format!("id={id}: terminal bridge ended for {peer}"));
     let _ = active.shutdown();
 }
 
@@ -171,6 +255,8 @@ fn run_jumphost(
     start: crate::session_slot::SessionStart,
     core: &RuntimeCore,
     payload: InitialPayload,
+    id: &str,
+    peer: &str,
 ) {
     if connection
         .write_packet(
@@ -179,38 +265,56 @@ fn run_jumphost(
         )
         .is_err()
     {
+        crate::diag::info(format!(
+            "id={id}: jumphost failed writing INITIAL_RESPONSE to {peer}"
+        ));
         return;
     }
     let mut terminal = match core.registry.clone_stream(start.registration()) {
         Ok(terminal) => terminal,
-        Err(_) => return,
+        Err(error) => {
+            crate::diag::info(format!(
+                "id={id}: jumphost could not clone terminal stream: {error}"
+            ));
+            return;
+        }
     };
     let init_packet = et_core::packet::Packet::new(
         TerminalPacketType::JumphostInit as u8,
         payload.encode_to_vec(),
     );
     if write_local_packet(&mut terminal, &init_packet).is_err() {
+        crate::diag::info(format!("id={id}: jumphost failed sending JUMPHOST_INIT"));
         return;
     }
     let active = match ActiveSession::new(connection, &terminal) {
         Ok(active) => active,
-        Err(_) => return,
+        Err(error) => {
+            crate::diag::info(format!(
+                "id={id}: jumphost could not create active session: {error}"
+            ));
+            return;
+        }
     };
     let active = Arc::new(active);
     if start.activate(active.clone()).is_err() {
+        crate::diag::info(format!("id={id}: jumphost could not activate session"));
         return;
     }
     // A jumphost session owns no local forwarding: the destination side does.
     let Ok(forwarder) = et_net::forward::Forwarder::start(Vec::new()) else {
+        crate::diag::info(format!("id={id}: jumphost forwarder start failed"));
         let _ = active.shutdown();
         return;
     };
+    crate::diag::info(format!("id={id}: jumphost bridge running for {peer}"));
     let _ = crate::terminal_bridge::run_mode(
         active.clone(),
         terminal,
         forwarder,
         crate::terminal_bridge::BridgeMode::Jumphost,
     );
+    crate::diag::info(format!("id={id}: jumphost bridge ended for {peer}"));
     let _ = active.shutdown();
 }
 
@@ -234,7 +338,17 @@ fn send_status(stream: &mut TcpStream, status: ConnectStatus) -> std::io::Result
     )
 }
 
-fn reject(stream: &mut TcpStream, status: ConnectStatus, message: &str) {
+fn reject(
+    stream: &mut TcpStream,
+    status: ConnectStatus,
+    message: &str,
+    peer: &str,
+    client_id: Option<&str>,
+) {
+    let id = client_id.unwrap_or("-");
+    crate::diag::info(format!(
+        "reject {peer} id={id} status={status:?}: {message}"
+    ));
     let _ = write_response(
         stream,
         &ConnectResponse {

--- a/crates/et-server/src/runtime_handler.rs
+++ b/crates/et-server/src/runtime_handler.rs
@@ -6,42 +6,56 @@ use et_core::proto::{
     TerminalPacketType,
 };
 use et_net::connection::Connection;
-use et_net::handshake::{protocol_matches, read_request, write_response};
+use et_net::handshake::{
+    protocol_matches, read_request_deadline, write_response, HANDSHAKE_TIMEOUT,
+};
 use et_net::local_packet::write_local_packet;
 use prost::Message;
 
-use crate::runtime_state::{RawSocketGuard, RuntimeCore};
+use crate::runtime_state::{PreAuthGuard, RawSocketGuard, RuntimeCore};
 use crate::session::ActiveSession;
 use crate::session_table::SessionClaim;
 
-pub(crate) fn handle(stream: TcpStream, core: Arc<RuntimeCore>, mut guard: RawSocketGuard) {
+pub(crate) fn handle(
+    stream: TcpStream,
+    core: Arc<RuntimeCore>,
+    mut guard: RawSocketGuard,
+    pre_auth_guard: PreAuthGuard,
+) {
     let peer = stream
         .peer_addr()
         .map(|addr| addr.to_string())
         .unwrap_or_else(|_| "unknown".to_owned());
-    crate::diag::verbose(1, &format!("accepted TCP connection from {peer}"));
+    crate::diag::verbose(1, format!("accepted TCP connection from {peer}"));
     let mut stream = stream;
-    let request = match read_request(&mut stream) {
-        Ok(request) => request,
-        Err(error) => {
-            crate::diag::verbose(1, &format!("malformed ConnectRequest from {peer}: {error}"));
-            reject(
-                &mut stream,
-                ConnectStatus::InvalidKey,
-                "malformed ConnectRequest",
-                &peer,
-                None,
-            );
-            return;
-        }
-    };
+    let request =
+        match read_request_deadline(&mut stream, std::time::Instant::now() + HANDSHAKE_TIMEOUT) {
+            Ok(request) => request,
+            Err(error) => {
+                crate::diag::verbose(1, format!("malformed ConnectRequest from {peer}: {error}"));
+                reject(
+                    &mut stream,
+                    ConnectStatus::InvalidKey,
+                    "malformed ConnectRequest",
+                    &peer,
+                    None,
+                );
+                return;
+            }
+        };
+    drop(pre_auth_guard);
     if !protocol_matches(&request) {
+        let client_id = request
+            .client_id
+            .as_deref()
+            .filter(|id| valid_id(id))
+            .map(crate::diag::sanitize_external_field);
         reject(
             &mut stream,
             ConnectStatus::MismatchedProtocol,
             "protocol version does not match server version 6",
             &peer,
-            request.client_id.as_deref(),
+            client_id.as_deref(),
         );
         return;
     }

--- a/crates/et-server/src/runtime_lifecycle.rs
+++ b/crates/et-server/src/runtime_lifecycle.rs
@@ -18,19 +18,47 @@ pub(crate) fn run(
     while let Ok(event) = events.recv() {
         match event {
             LifecycleEvent::TerminalDisconnected(identity) => {
+                crate::diag::info(format!(
+                    "terminal disconnected for registration id={}",
+                    identity.id()
+                ));
                 if let Err(error) = core.raw_sockets.shutdown_registration(&identity) {
+                    crate::diag::info(format!(
+                        "id={}: error shutting down raw sockets: {error}",
+                        identity.id()
+                    ));
                     first_error.get_or_insert(error);
                 }
                 match core.sessions.remove_registration(&identity) {
                     Ok(Some(removed)) => {
+                        crate::diag::info(format!(
+                            "id={}: removed session after terminal disconnect",
+                            identity.id()
+                        ));
                         if let Some(connection) = removed.connection {
                             if let Err(error) = connection.shutdown() {
+                                crate::diag::info(format!(
+                                    "id={}: error shutting down session connection: {error}",
+                                    identity.id()
+                                ));
                                 first_error.get_or_insert(RuntimeError::Session(error));
                             }
                         }
                     }
-                    Ok(None) => {}
+                    Ok(None) => {
+                        crate::diag::verbose(
+                            1,
+                            &format!(
+                                "id={}: terminal disconnect with no active session slot",
+                                identity.id()
+                            ),
+                        );
+                    }
                     Err(error) => {
+                        crate::diag::info(format!(
+                            "id={}: session table error on terminal disconnect: {error}",
+                            identity.id()
+                        ));
                         first_error.get_or_insert(RuntimeError::SessionTable(error));
                     }
                 }

--- a/crates/et-server/src/runtime_lifecycle.rs
+++ b/crates/et-server/src/runtime_lifecycle.rs
@@ -48,7 +48,7 @@ pub(crate) fn run(
                     Ok(None) => {
                         crate::diag::verbose(
                             1,
-                            &format!(
+                            format!(
                                 "id={}: terminal disconnect with no active session slot",
                                 identity.id()
                             ),

--- a/crates/et-server/src/runtime_state.rs
+++ b/crates/et-server/src/runtime_state.rs
@@ -173,6 +173,7 @@ impl HandlerThreads {
     pub(crate) fn push(&self, handle: JoinHandle<()>) -> Result<(), JoinHandle<()>> {
         match self.handles.lock() {
             Ok(mut handles) => {
+                handles.retain(|existing| !existing.is_finished());
                 handles.push(handle);
                 Ok(())
             }
@@ -186,6 +187,54 @@ impl HandlerThreads {
             .lock()
             .map_err(|_| RuntimeError::WorkerUnavailable)?;
         Ok(std::mem::take(&mut *handles))
+    }
+}
+
+#[cfg(test)]
+mod handler_tests {
+    use super::*;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn unfinished_handlers_remain_owned_until_shutdown() {
+        let workers = HandlerThreads::new();
+        let (stop_tx, stop_rx) = mpsc::channel();
+        workers
+            .push(thread::spawn(move || stop_rx.recv().unwrap()))
+            .unwrap();
+        let mut pending = workers.take().unwrap();
+        assert_eq!(pending.len(), 1);
+        stop_tx.send(()).unwrap();
+        pending.pop().unwrap().join().unwrap();
+    }
+
+    #[test]
+    fn completed_handlers_are_reaped_before_shutdown() {
+        let workers = HandlerThreads::new();
+        for _ in 0..128 {
+            workers.push(completed_handle()).unwrap();
+        }
+        let (stop_tx, stop_rx) = mpsc::channel();
+        workers
+            .push(thread::spawn(move || stop_rx.recv().unwrap()))
+            .unwrap();
+        let observed = workers.handles.lock().unwrap().len();
+        let mut pending = workers.take().unwrap();
+        stop_tx.send(()).unwrap();
+        pending.pop().unwrap().join().unwrap();
+        assert_eq!(observed, 1);
+    }
+
+    fn completed_handle() -> JoinHandle<()> {
+        let handle = thread::spawn(|| ());
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !handle.is_finished() {
+            assert!(Instant::now() < deadline);
+            thread::yield_now();
+        }
+        handle
     }
 }
 

--- a/crates/et-server/src/runtime_state.rs
+++ b/crates/et-server/src/runtime_state.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::net::{Shutdown, TcpStream};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 
@@ -13,7 +13,43 @@ pub(crate) struct RuntimeCore {
     pub(crate) sessions: SessionTable,
     pub(crate) raw_sockets: Arc<RawSockets>,
     pub(crate) handlers: HandlerThreads,
+    pub(crate) pre_auth_slots: Arc<PreAuthSlots>,
     pub(crate) shutdown: AtomicBool,
+}
+
+pub(crate) const MAX_PRE_AUTH_CONNECTIONS: usize = 128;
+
+pub(crate) struct PreAuthSlots {
+    active: AtomicUsize,
+    limit: usize,
+}
+
+pub(crate) struct PreAuthGuard {
+    slots: Arc<PreAuthSlots>,
+}
+
+impl PreAuthSlots {
+    pub(crate) fn new(limit: usize) -> Self {
+        Self {
+            active: AtomicUsize::new(0),
+            limit,
+        }
+    }
+
+    pub(crate) fn try_acquire(self: Arc<Self>) -> Option<PreAuthGuard> {
+        self.active
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |active| {
+                (active < self.limit).then_some(active + 1)
+            })
+            .ok()?;
+        Some(PreAuthGuard { slots: self })
+    }
+}
+
+impl Drop for PreAuthGuard {
+    fn drop(&mut self) {
+        self.slots.active.fetch_sub(1, Ordering::Release);
+    }
 }
 
 struct TrackedSocket {
@@ -150,5 +186,19 @@ impl HandlerThreads {
             .lock()
             .map_err(|_| RuntimeError::WorkerUnavailable)?;
         Ok(std::mem::take(&mut *handles))
+    }
+}
+
+#[cfg(test)]
+mod pre_auth_tests {
+    use super::*;
+
+    #[test]
+    fn pre_auth_slots_reject_excess_and_release_on_drop() {
+        let slots = Arc::new(PreAuthSlots::new(1));
+        let first = slots.clone().try_acquire().unwrap();
+        assert!(slots.clone().try_acquire().is_none());
+        drop(first);
+        assert!(slots.try_acquire().is_some());
     }
 }

--- a/crates/et-server/src/runtime_state.rs
+++ b/crates/et-server/src/runtime_state.rs
@@ -170,14 +170,36 @@ impl HandlerThreads {
         }
     }
 
-    pub(crate) fn push(&self, handle: JoinHandle<()>) -> Result<(), JoinHandle<()>> {
+    pub(crate) fn push(&self, handle: JoinHandle<()>) -> Result<(), RuntimeError> {
+        let mut completed = Vec::new();
         match self.handles.lock() {
             Ok(mut handles) => {
-                handles.retain(|existing| !existing.is_finished());
-                handles.push(handle);
-                Ok(())
+                let mut pending = Vec::with_capacity(handles.len() + 1);
+                for existing in handles.drain(..) {
+                    if existing.is_finished() {
+                        completed.push(existing);
+                    } else {
+                        pending.push(existing);
+                    }
+                }
+                pending.push(handle);
+                *handles = pending;
             }
-            Err(_) => Err(handle),
+            Err(_) => {
+                let _ = handle.join();
+                return Err(RuntimeError::WorkerUnavailable);
+            }
+        }
+        let mut panicked = false;
+        for existing in completed {
+            if existing.join().is_err() {
+                panicked = true;
+            }
+        }
+        if panicked {
+            Err(RuntimeError::WorkerPanicked("TCP session handler"))
+        } else {
+            Ok(())
         }
     }
 
@@ -227,8 +249,28 @@ mod handler_tests {
         assert_eq!(observed, 1);
     }
 
+    #[test]
+    fn reaped_panicking_handlers_are_reported_as_worker_panics() {
+        let workers = HandlerThreads::new();
+        workers.push(completed_panicking_handle()).unwrap();
+        let result = workers.push(completed_handle());
+        assert!(matches!(
+            result,
+            Err(RuntimeError::WorkerPanicked("TCP session handler"))
+        ));
+    }
+
     fn completed_handle() -> JoinHandle<()> {
-        let handle = thread::spawn(|| ());
+        wait_until_finished(thread::spawn(|| ()))
+    }
+
+    fn completed_panicking_handle() -> JoinHandle<()> {
+        wait_until_finished(thread::spawn(|| {
+            panic!("intentional regression-test panic")
+        }))
+    }
+
+    fn wait_until_finished(handle: JoinHandle<()>) -> JoinHandle<()> {
         let deadline = Instant::now() + Duration::from_secs(5);
         while !handle.is_finished() {
             assert!(Instant::now() < deadline);


### PR DESCRIPTION
## Summary

- Honor machine-local env overrides for `etserver`: `ET_DEBUG`, `ET_LOGDIR`, `ET_VERBOSE` (CLI/INI still win).
- When `ET_DEBUG=1`, default verbosity rises to 2, logging is never silent, and the log directory prefers a durable path (`~/Library/Logs/et-rs` on macOS, `$XDG_STATE_HOME/et-rs` / `~/.local/state/et-rs` elsewhere) unless `ET_LOGDIR`/`--logdir`/INI set one.
- Add a thin `et_server::diag` sink (no CLI dep on the server crate) wired from `etserver` into `et_cli::logging`.
- Log session lifecycle that matters for disconnect diagnosis:
  - TCP accept / new client / returning reconnect
  - recover success/failure
  - reject reasons (`InvalidKey`, unregistered, obsolete registration, protocol mismatch, …)
  - terminal disconnect → session removal

This is aimed at the “long session then drops” class of issues where the client only sees `Connection refused` / timeouts / `InvalidKey` and the server was silent.

## Usage (server host)

```sh
export ET_DEBUG=1
export ET_LOGDIR=/var/log/et-rs   # optional; otherwise durable default under home
etserver --daemon
# or foreground:
etserver -v 2 --logdir /var/log/et-rs
```

Log files: `etserver-<timestamp>_<pid>.log` in the log directory.

Look for lines like:

```text
id=...: returning client reconnect from 1.2.3.4:5678
id=...: session recover failed from ...: ...
reject 1.2.3.4:5678 id=... status=InvalidKey: client is not registered
terminal disconnected for registration id=...
```

## Test plan

- [x] `cargo test -p et-cli -p et-server --lib`
- [x] `cargo build -p et --release`
- [x] Smoke: `ET_DEBUG=1 ET_LOGDIR=/tmp/... et server --port 39222` writes startup log with `verbose=2` and `ET_DEBUG=true`
- [ ] On a real workstation: enable `ET_DEBUG`, reproduce a long-session drop, confirm server log shows reconnect/reject/terminal-disconnect sequence

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ET_DEBUG mode and diagnostic session logs to `etserver` to make long-running session drops easier to debug. Under ET_DEBUG, logging is never silent and defaults to a durable machine-local log dir; CLI/INI can override env defaults.

- **New Features**
  - Honor `ET_DEBUG`, `ET_LOGDIR`, `ET_VERBOSE` across `et`, `etserver`, and `etterminal` (CLI wins; INI wins for `logdirectory`).
  - `ET_DEBUG=1`: default verbosity 2, logging forced on, durable log dir by default (`~/Library/Logs/et-rs` on macOS, `$XDG_STATE_HOME/et-rs` or `~/.local/state/et-rs` elsewhere) unless overridden.
  - Add `et_server::diag` and route it to `et_cli::logging`; log TCP accepts, new vs returning clients, recover success/failure, reject reasons, terminal disconnects, and session removal.

- **Bug Fixes**
  - Harden handshake and pre-auth: 5s handshake read deadline; cap 128 pre-auth connections to drop idle/abusive peers.
  - Safer logs: client bootstrap logs avoid credentials; sanitize external fields (escape control chars, truncate) before writing.
  - Reap finished session handler threads and report panics to avoid leaks and surface crashes.

<sup>Written for commit 35e23a689f5c41e22f7e280bc41d78d00f5424b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

