### PR TITLE
fix(server): keep sessions alive across client transport loss

### DIFF
--- a/.tegami/survive-client-disconnect.md
+++ b/.tegami/survive-client-disconnect.md
@@ -1,0 +1,16 @@
+---
+packages:
+  et:
+    type: patch
+---
+
+## Keep server sessions alive across client transport loss
+
+`etserver` now treats laptop sleep, Wi-Fi changes, and other client transport
+loss as a recoverable disconnect instead of terminating the registered
+terminal. Output produced while the client is away remains buffered, and a
+returning client resumes the same shell without an `InvalidKey` failure.
+
+Recovery handoff now ignores stale events from the replaced socket, drains
+packets read during recovery authentication, and preserves port-forwarding
+packets when the replay buffer is temporarily full.

--- a/crates/et-net/src/connection.rs
+++ b/crates/et-net/src/connection.rs
@@ -48,19 +48,20 @@ impl Connection {
     }
 
     pub fn write_packet(&mut self, header: u8, payload: &[u8]) -> Result<(), ConnError> {
-        if let Err(error) = self.refresh_connectivity() {
+        // Probe first so a half-closed peer (laptop sleep, Wi-Fi drop) moves
+        // the writer into the disconnected catch-up buffer before we try to
+        // push bytes onto a dead socket.
+        if let Err(_error) = self.refresh_connectivity() {
             self.disconnect();
-            return match self.writer.write_packet(header, payload)? {
-                WriterOutcome::BufferedOnly => Err(error),
-                WriterOutcome::Skipped => Err(ConnError::Backpressure),
-                WriterOutcome::Send(_) => Err(error),
-            };
         }
         match self.writer.write_packet(header, payload)? {
             WriterOutcome::Send(frame) => {
-                if let Err(error) = self.stream.write_all(&frame) {
+                if let Err(_error) = self.stream.write_all(&frame) {
+                    // The encrypted packet is already in the replay backup
+                    // (BackedWriter pushes before returning Send). Mark the
+                    // transport disconnected so further writes buffer for a
+                    // returning client instead of tearing the session down.
                     self.disconnect();
-                    return Err(ConnError::Io(error));
                 }
                 Ok(())
             }

--- a/crates/et-server/src/session.rs
+++ b/crates/et-server/src/session.rs
@@ -169,6 +169,19 @@ impl ActiveSession {
             .connected())
     }
 
+    /// Soft-drop the encrypted client transport without killing the terminal.
+    ///
+    /// Used when the client TCP path dies (sleep, Wi-Fi, NAT) so terminal
+    /// output keeps buffering and a returning client can recover the same
+    /// session. Does not set the session shutdown flag or close the terminal.
+    pub(crate) fn mark_client_disconnected(&self) -> Result<(), SessionError> {
+        self.connection
+            .lock()
+            .map_err(|_| SessionError::Unavailable)?
+            .disconnect();
+        Ok(())
+    }
+
     /// Apply a client delivery acknowledgement to the replay backup.
     pub(crate) fn acknowledge_delivery(&self, sequence: i64) -> Result<(), SessionError> {
         self.connection

--- a/crates/et-server/src/session.rs
+++ b/crates/et-server/src/session.rs
@@ -1,7 +1,7 @@
 use et_net::local::LocalStream;
 use std::io::{self, Write};
 use std::net::{Shutdown, TcpStream};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use et_core::proto::TerminalPacketType;
@@ -15,6 +15,7 @@ pub(crate) struct ActiveSession {
     wake_writer: Mutex<LocalStream>,
     wake_reader: Mutex<Option<LocalStream>>,
     shutdown: AtomicBool,
+    connection_generation: AtomicU64,
 }
 
 pub(crate) enum SessionConnection {
@@ -66,6 +67,7 @@ impl ActiveSession {
             wake_writer: Mutex::new(wake_writer),
             wake_reader: Mutex::new(Some(wake_reader)),
             shutdown: AtomicBool::new(false),
+            connection_generation: AtomicU64::new(0),
         })
     }
 
@@ -108,6 +110,7 @@ impl ActiveSession {
         let old_control = std::mem::replace(&mut *control, new_control);
         let _ = old_control.shutdown(Shutdown::Both);
         *connection = candidate;
+        self.connection_generation.fetch_add(1, Ordering::Release);
         drop(connection);
         drop(control);
         self.signal()
@@ -145,12 +148,16 @@ impl ActiveSession {
     }
 
     #[cfg_attr(windows, allow(dead_code))]
-    pub(crate) fn try_clone_stream(&self) -> Result<TcpStream, SessionError> {
-        self.connection
+    pub(crate) fn try_clone_stream(&self) -> Result<(TcpStream, u64), SessionError> {
+        let connection = self
+            .connection
             .lock()
-            .map_err(|_| SessionError::Unavailable)?
+            .map_err(|_| SessionError::Unavailable)?;
+        let generation = self.connection_generation.load(Ordering::Acquire);
+        let stream = connection
             .try_clone_stream()
-            .map_err(SessionError::Connection)
+            .map_err(SessionError::Connection)?;
+        Ok((stream, generation))
     }
 
     pub(crate) fn try_read_packet(&self) -> Result<Option<et_core::packet::Packet>, SessionError> {
@@ -161,12 +168,15 @@ impl ActiveSession {
             .map_err(SessionError::Connection)
     }
 
-    pub(crate) fn connected(&self) -> Result<bool, SessionError> {
-        Ok(self
+    pub(crate) fn connection_state(&self) -> Result<(bool, u64), SessionError> {
+        let connection = self
             .connection
             .lock()
-            .map_err(|_| SessionError::Unavailable)?
-            .connected())
+            .map_err(|_| SessionError::Unavailable)?;
+        Ok((
+            connection.connected(),
+            self.connection_generation.load(Ordering::Acquire),
+        ))
     }
 
     /// Soft-drop the encrypted client transport without killing the terminal.
@@ -174,12 +184,19 @@ impl ActiveSession {
     /// Used when the client TCP path dies (sleep, Wi-Fi, NAT) so terminal
     /// output keeps buffering and a returning client can recover the same
     /// session. Does not set the session shutdown flag or close the terminal.
-    pub(crate) fn mark_client_disconnected(&self) -> Result<(), SessionError> {
-        self.connection
+    pub(crate) fn mark_client_disconnected(
+        &self,
+        expected_generation: u64,
+    ) -> Result<bool, SessionError> {
+        let mut connection = self
+            .connection
             .lock()
-            .map_err(|_| SessionError::Unavailable)?
-            .disconnect();
-        Ok(())
+            .map_err(|_| SessionError::Unavailable)?;
+        if self.connection_generation.load(Ordering::Acquire) != expected_generation {
+            return Ok(false);
+        }
+        connection.disconnect();
+        Ok(true)
     }
 
     /// Apply a client delivery acknowledgement to the replay backup.

--- a/crates/et-server/src/terminal_bridge.rs
+++ b/crates/et-server/src/terminal_bridge.rs
@@ -65,12 +65,16 @@ fn run_mode_poll(
     let mut wake = session.take_wake_reader()?;
     wake.set_nonblocking(true).map_err(SessionError::Io)?;
     let mut decoder = LocalPacketDecoder::new();
-    let mut connected = session.connected()?;
+    let (mut connected, mut connection_generation) = session.connection_state()?;
     // A forwarding packet the worker had no room for. While it is held, no
     // further client packets are read (ordering) and the client socket is not
     // watched for readability (it would busy-loop the poll).
     let mut pending_forward: Option<Packet> = None;
+    // An outbound forwarding packet that could not fit in the disconnected
+    // replay buffer. Keep ownership until recovery restores write capacity.
+    let mut pending_outbound: Option<Packet> = None;
     loop {
+        let mut resume_outbound_drain = false;
         if session.is_shutting_down() {
             return Ok(());
         }
@@ -80,17 +84,28 @@ fn run_mode_poll(
         if let Some(packet) = pending_forward.take() {
             pending_forward = forwarder.try_receive(packet).map_err(forward_error)?;
         }
-        let client = if connected {
+        if let Some(packet) = pending_outbound.take() {
+            pending_outbound =
+                send_or_hold(&session, packet, &mut connected, &mut connection_generation)?;
+            resume_outbound_drain = pending_outbound.is_none();
+        }
+        let (client, polled_generation) = if connected {
             match session.try_clone_stream() {
-                Ok(stream) => Some(stream),
+                Ok((stream, generation)) => (Some(stream), Some(generation)),
                 // Cloning a dead socket is a soft disconnect, not session death.
                 Err(_) => {
-                    note_client_drop(&session, &mut connected);
-                    None
+                    let observed_generation = connection_generation;
+                    note_client_drop(
+                        &session,
+                        &mut connected,
+                        &mut connection_generation,
+                        observed_generation,
+                    )?;
+                    (None, None)
                 }
             }
         } else {
-            None
+            (None, None)
         };
         let accept_terminal = session.can_buffer_write((READ_BUFFER * 2) as i64)?;
         // When the client is down, poll with a short timeout so recovery wakes
@@ -102,7 +117,7 @@ fn run_mode_poll(
             forwarder.wake().map_err(forward_error)?,
             client.as_ref(),
             accept_terminal,
-            pending_forward.is_some() || !connected,
+            pending_forward.is_some() || pending_outbound.is_some() || !connected,
         )?;
         let client_events_are_stale = wake_events.intersects(PollFlags::IN | PollFlags::HUP);
         if client_events_are_stale {
@@ -110,7 +125,7 @@ fn run_mode_poll(
             if session.is_shutting_down() {
                 return Ok(());
             }
-            connected = session.connected()?;
+            (connected, connection_generation) = session.connection_state()?;
         }
         if terminal_events.intersects(PollFlags::HUP | PollFlags::ERR) {
             return Err(SessionError::Io(io::ErrorKind::UnexpectedEof.into()));
@@ -125,13 +140,23 @@ fn run_mode_poll(
                 };
                 decoder = LocalPacketDecoder::new();
                 if let Err(error) = session.send_packet(packet.header(), packet.payload()) {
-                    if !client_transport_error(&error, &session, &mut connected) {
+                    if !client_transport_error(
+                        &error,
+                        &session,
+                        &mut connected,
+                        &mut connection_generation,
+                    )? {
                         return Err(error);
                     }
                 }
             }
         }
-        if !client_events_are_stale && client_events.contains(PollFlags::IN) {
+        // Recovery authentication may read more than its proof packet into
+        // BackedReader. Drain it after the wake even when the new socket no
+        // longer has kernel-level readability.
+        let client_data_ready =
+            connected && (client_events_are_stale || client_events.contains(PollFlags::IN));
+        if client_data_ready {
             while pending_forward.is_none() {
                 match session.try_read_packet() {
                     // Jumphost relays every packet verbatim to the jump
@@ -146,7 +171,12 @@ fn run_mode_poll(
                     Ok(Some(packet)) => forward_client_packet(&session, &mut terminal, packet)?,
                     Ok(None) => break,
                     Err(error) => {
-                        if client_transport_error(&error, &session, &mut connected) {
+                        if client_transport_error(
+                            &error,
+                            &session,
+                            &mut connected,
+                            &mut connection_generation,
+                        )? {
                             break;
                         }
                         return Err(error);
@@ -155,15 +185,22 @@ fn run_mode_poll(
             }
         }
         if !client_events_are_stale && client_events.intersects(PollFlags::HUP | PollFlags::ERR) {
-            note_client_drop(&session, &mut connected);
+            let observed_generation = polled_generation.unwrap_or(connection_generation);
+            note_client_drop(
+                &session,
+                &mut connected,
+                &mut connection_generation,
+                observed_generation,
+            )?;
         }
-        if forward_events.intersects(PollFlags::IN | PollFlags::HUP) {
+        if pending_outbound.is_none()
+            && (resume_outbound_drain || forward_events.intersects(PollFlags::IN | PollFlags::HUP))
+        {
             while let Some(packet) = forwarder.try_outbound().map_err(forward_error)? {
-                if let Err(error) = session.send_packet(packet.header(), packet.payload()) {
-                    if client_transport_error(&error, &session, &mut connected) {
-                        break;
-                    }
-                    return Err(error);
+                pending_outbound =
+                    send_or_hold(&session, packet, &mut connected, &mut connection_generation)?;
+                if pending_outbound.is_some() {
+                    break;
                 }
             }
         }
@@ -189,10 +226,11 @@ fn run_mode_windows(
     let mut wake = session.take_wake_reader()?;
     wake.set_nonblocking(true).map_err(SessionError::Io)?;
     let mut decoder = LocalPacketDecoder::new();
-    let mut connected = session.connected()?;
+    let (mut connected, mut connection_generation) = session.connection_state()?;
     // A forwarding packet the worker had no room for; while it is held, no
     // further client packets are read so forwarding data stays ordered.
     let mut pending_forward: Option<Packet> = None;
+    let mut pending_outbound: Option<Packet> = None;
     loop {
         if session.is_shutting_down() {
             return Ok(());
@@ -208,13 +246,18 @@ fn run_mode_windows(
                 None => progress = true,
             }
         }
+        if let Some(packet) = pending_outbound.take() {
+            pending_outbound =
+                send_or_hold(&session, packet, &mut connected, &mut connection_generation)?;
+            progress |= pending_outbound.is_none();
+        }
 
         // Connection state changes are announced through the wake channel.
         if drain_available(&mut wake)? {
             if session.is_shutting_down() {
                 return Ok(());
             }
-            connected = session.connected()?;
+            (connected, connection_generation) = session.connection_state()?;
             progress = true;
         }
 
@@ -231,7 +274,12 @@ fn run_mode_windows(
                     };
                     decoder = LocalPacketDecoder::new();
                     if let Err(error) = session.send_packet(packet.header(), packet.payload()) {
-                        if !client_transport_error(&error, &session, &mut connected) {
+                        if !client_transport_error(
+                            &error,
+                            &session,
+                            &mut connected,
+                            &mut connection_generation,
+                        )? {
                             return Err(error);
                         }
                     }
@@ -259,7 +307,12 @@ fn run_mode_windows(
                     }
                     Ok(None) => break,
                     Err(error) => {
-                        if client_transport_error(&error, &session, &mut connected) {
+                        if client_transport_error(
+                            &error,
+                            &session,
+                            &mut connected,
+                            &mut connection_generation,
+                        )? {
                             break;
                         }
                         return Err(error);
@@ -269,13 +322,15 @@ fn run_mode_windows(
         }
 
         // Forwarding -> client.
-        while let Some(packet) = forwarder.try_outbound().map_err(forward_error)? {
+        while pending_outbound.is_none() {
+            let Some(packet) = forwarder.try_outbound().map_err(forward_error)? else {
+                break;
+            };
             progress = true;
-            if let Err(error) = session.send_packet(packet.header(), packet.payload()) {
-                if client_transport_error(&error, &session, &mut connected) {
-                    break;
-                }
-                return Err(error);
+            pending_outbound =
+                send_or_hold(&session, packet, &mut connected, &mut connection_generation)?;
+            if pending_outbound.is_some() {
+                break;
             }
         }
 
@@ -301,37 +356,73 @@ fn drain_available(wake: &mut LocalStream) -> Result<bool, SessionError> {
     }
 }
 
+fn send_or_hold(
+    session: &ActiveSession,
+    packet: Packet,
+    connected: &mut bool,
+    connection_generation: &mut u64,
+) -> Result<Option<Packet>, SessionError> {
+    match session.send_packet(packet.header(), packet.payload()) {
+        Ok(()) => Ok(None),
+        Err(SessionError::Connection(ConnError::Backpressure)) => Ok(Some(packet)),
+        Err(error) => {
+            if client_transport_error(&error, session, connected, connection_generation)? {
+                Ok(None)
+            } else {
+                Err(error)
+            }
+        }
+    }
+}
+
 /// Client-side transport failures are soft: keep the terminal alive so a
 /// returning client can recover. Terminal / local I/O errors stay fatal.
 fn client_transport_error(
     error: &SessionError,
     session: &ActiveSession,
     connected: &mut bool,
-) -> bool {
+    connection_generation: &mut u64,
+) -> Result<bool, SessionError> {
+    let observed_generation = *connection_generation;
     match error {
         SessionError::Connection(ConnError::Io(io_error)) if connection_ended(io_error) => {
-            note_client_drop(session, connected);
-            true
+            note_client_drop(
+                session,
+                connected,
+                connection_generation,
+                observed_generation,
+            )?;
+            Ok(true)
         }
         SessionError::Connection(ConnError::Io(_))
-        | SessionError::Connection(ConnError::Read(_))
-        | SessionError::Connection(ConnError::Backpressure)
-        | SessionError::Connection(ConnError::Encrypt(_)) => {
-            // Any client-path crypto/read/backpressure failure after a
-            // half-open sleep drop must not kill the shell session.
-            note_client_drop(session, connected);
-            true
+        | SessionError::Connection(ConnError::Read(_)) => {
+            note_client_drop(
+                session,
+                connected,
+                connection_generation,
+                observed_generation,
+            )?;
+            Ok(true)
         }
-        _ => false,
+        _ => Ok(false),
     }
 }
 
-fn note_client_drop(session: &ActiveSession, connected: &mut bool) {
-    if *connected {
-        crate::diag::info("client transport lost; buffering for reconnect");
+fn note_client_drop(
+    session: &ActiveSession,
+    connected: &mut bool,
+    connection_generation: &mut u64,
+    observed_generation: u64,
+) -> Result<(), SessionError> {
+    if session.mark_client_disconnected(observed_generation)? {
+        if *connected {
+            crate::diag::info("client transport lost; buffering for reconnect");
+        }
+        *connected = false;
+    } else {
+        (*connected, *connection_generation) = session.connection_state()?;
     }
-    *connected = false;
-    let _ = session.mark_client_disconnected();
+    Ok(())
 }
 
 fn connection_ended(error: &io::Error) -> bool {

--- a/crates/et-server/src/terminal_bridge.rs
+++ b/crates/et-server/src/terminal_bridge.rs
@@ -49,6 +49,11 @@ pub(crate) fn run_mode(
 }
 
 /// Readiness-driven bridge, mirroring upstream's `select()` loop.
+///
+/// Client TCP loss (sleep, Wi-Fi flap, NAT drop) must **not** end the bridge.
+/// The terminal stays registered and the session stays Active so a returning
+/// client can recover. Only terminal EOF/error or an explicit session shutdown
+/// tears the loop down.
 #[cfg(unix)]
 fn run_mode_poll(
     session: Arc<ActiveSession>,
@@ -75,15 +80,29 @@ fn run_mode_poll(
         if let Some(packet) = pending_forward.take() {
             pending_forward = forwarder.try_receive(packet).map_err(forward_error)?;
         }
-        let client = connected.then(|| session.try_clone_stream()).transpose()?;
+        let client = if connected {
+            match session.try_clone_stream() {
+                Ok(stream) => Some(stream),
+                // Cloning a dead socket is a soft disconnect, not session death.
+                Err(_) => {
+                    note_client_drop(&session, &mut connected);
+                    None
+                }
+            }
+        } else {
+            None
+        };
         let accept_terminal = session.can_buffer_write((READ_BUFFER * 2) as i64)?;
+        // When the client is down, poll with a short timeout so recovery wakes
+        // (via the wake pipe) are still processed promptly and we re-check
+        // `session.connected()` after recover installs a new stream.
         let (terminal_events, wake_events, forward_events, client_events) = wait(
             &terminal,
             &wake,
             forwarder.wake().map_err(forward_error)?,
             client.as_ref(),
             accept_terminal,
-            pending_forward.is_some(),
+            pending_forward.is_some() || !connected,
         )?;
         let client_events_are_stale = wake_events.intersects(PollFlags::IN | PollFlags::HUP);
         if client_events_are_stale {
@@ -105,14 +124,10 @@ fn run_mode_poll(
                     jumphost_terminal_packet(&session, packet)?
                 };
                 decoder = LocalPacketDecoder::new();
-                match session.send_packet(packet.header(), packet.payload()) {
-                    Ok(()) => {}
-                    Err(SessionError::Connection(ConnError::Io(error)))
-                        if connection_ended(&error) =>
-                    {
-                        connected = false;
+                if let Err(error) = session.send_packet(packet.header(), packet.payload()) {
+                    if !client_transport_error(&error, &session, &mut connected) {
+                        return Err(error);
                     }
-                    Err(error) => return Err(error),
                 }
             }
         }
@@ -130,28 +145,25 @@ fn run_mode_poll(
                     }
                     Ok(Some(packet)) => forward_client_packet(&session, &mut terminal, packet)?,
                     Ok(None) => break,
-                    Err(SessionError::Connection(_)) => {
-                        connected = false;
-                        break;
+                    Err(error) => {
+                        if client_transport_error(&error, &session, &mut connected) {
+                            break;
+                        }
+                        return Err(error);
                     }
-                    Err(error) => return Err(error),
                 }
             }
         }
         if !client_events_are_stale && client_events.intersects(PollFlags::HUP | PollFlags::ERR) {
-            connected = false;
+            note_client_drop(&session, &mut connected);
         }
         if forward_events.intersects(PollFlags::IN | PollFlags::HUP) {
             while let Some(packet) = forwarder.try_outbound().map_err(forward_error)? {
-                match session.send_packet(packet.header(), packet.payload()) {
-                    Ok(()) => {}
-                    Err(SessionError::Connection(ConnError::Io(error)))
-                        if connection_ended(&error) =>
-                    {
-                        connected = false;
+                if let Err(error) = session.send_packet(packet.header(), packet.payload()) {
+                    if client_transport_error(&error, &session, &mut connected) {
                         break;
                     }
-                    Err(error) => return Err(error),
+                    return Err(error);
                 }
             }
         }
@@ -218,14 +230,10 @@ fn run_mode_windows(
                         jumphost_terminal_packet(&session, packet)?
                     };
                     decoder = LocalPacketDecoder::new();
-                    match session.send_packet(packet.header(), packet.payload()) {
-                        Ok(()) => {}
-                        Err(SessionError::Connection(ConnError::Io(error)))
-                            if connection_ended(&error) =>
-                        {
-                            connected = false;
+                    if let Err(error) = session.send_packet(packet.header(), packet.payload()) {
+                        if !client_transport_error(&error, &session, &mut connected) {
+                            return Err(error);
                         }
-                        Err(error) => return Err(error),
                     }
                 }
                 Ok(None) => {}
@@ -250,11 +258,12 @@ fn run_mode_windows(
                         }
                     }
                     Ok(None) => break,
-                    Err(SessionError::Connection(_)) => {
-                        connected = false;
-                        break;
+                    Err(error) => {
+                        if client_transport_error(&error, &session, &mut connected) {
+                            break;
+                        }
+                        return Err(error);
                     }
-                    Err(error) => return Err(error),
                 }
             }
         }
@@ -262,13 +271,11 @@ fn run_mode_windows(
         // Forwarding -> client.
         while let Some(packet) = forwarder.try_outbound().map_err(forward_error)? {
             progress = true;
-            match session.send_packet(packet.header(), packet.payload()) {
-                Ok(()) => {}
-                Err(SessionError::Connection(ConnError::Io(error))) if connection_ended(&error) => {
-                    connected = false;
+            if let Err(error) = session.send_packet(packet.header(), packet.payload()) {
+                if client_transport_error(&error, &session, &mut connected) {
                     break;
                 }
-                Err(error) => return Err(error),
+                return Err(error);
             }
         }
 
@@ -294,6 +301,39 @@ fn drain_available(wake: &mut LocalStream) -> Result<bool, SessionError> {
     }
 }
 
+/// Client-side transport failures are soft: keep the terminal alive so a
+/// returning client can recover. Terminal / local I/O errors stay fatal.
+fn client_transport_error(
+    error: &SessionError,
+    session: &ActiveSession,
+    connected: &mut bool,
+) -> bool {
+    match error {
+        SessionError::Connection(ConnError::Io(io_error)) if connection_ended(io_error) => {
+            note_client_drop(session, connected);
+            true
+        }
+        SessionError::Connection(ConnError::Io(_))
+        | SessionError::Connection(ConnError::Read(_))
+        | SessionError::Connection(ConnError::Backpressure)
+        | SessionError::Connection(ConnError::Encrypt(_)) => {
+            // Any client-path crypto/read/backpressure failure after a
+            // half-open sleep drop must not kill the shell session.
+            note_client_drop(session, connected);
+            true
+        }
+        _ => false,
+    }
+}
+
+fn note_client_drop(session: &ActiveSession, connected: &mut bool) {
+    if *connected {
+        crate::diag::info("client transport lost; buffering for reconnect");
+    }
+    *connected = false;
+    let _ = session.mark_client_disconnected();
+}
+
 fn connection_ended(error: &io::Error) -> bool {
     matches!(
         error.kind(),
@@ -302,6 +342,7 @@ fn connection_ended(error: &io::Error) -> bool {
             | io::ErrorKind::ConnectionAborted
             | io::ErrorKind::ConnectionReset
             | io::ErrorKind::NotConnected
+            | io::ErrorKind::TimedOut
     )
 }
 

--- a/crates/et-server/tests/runtime_recovery.rs
+++ b/crates/et-server/tests/runtime_recovery.rs
@@ -108,6 +108,73 @@ fn returning_client_receives_exact_buffered_server_catchup() {
 }
 
 #[test]
+fn hard_client_drop_keeps_session_for_returning_recover() {
+    // Regression: laptop sleep / Wi-Fi drop aborts the TCP socket. The server
+    // used to tear the terminal down (bridge exit → session removed →
+    // InvalidKey on reconnect). The session must stay Active so a returning
+    // client recovers the same shell and any buffered catch-up.
+    use std::net::Shutdown;
+
+    let mut server = TestRuntime::start();
+    let mut terminal = server.register(ID_A, KEY_A);
+    terminal.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let (stream, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    let key = passkey_to_key(KEY_A).unwrap();
+    let (mut client, initial) = initialize(stream, &key, default_payload());
+    assert_eq!(initial.error, None);
+    server
+        .handle
+        .wait_for_state(ID_A, SessionState::Active, TIMEOUT)
+        .unwrap();
+    let initial_terminal_packet = read_local_packet(&mut terminal).unwrap();
+    assert_eq!(
+        initial_terminal_packet.header(),
+        TerminalPacketType::TerminalInit as u8
+    );
+
+    // Hard-drop the OS socket (FIN/RST) without Connection::shutdown's local
+    // bookkeeping — closer to what a sleeping laptop's stack does.
+    client
+        .try_clone_stream()
+        .unwrap()
+        .shutdown(Shutdown::Both)
+        .unwrap();
+
+    server.handle.send_packet(ID_A, 31, b"while-away").unwrap();
+    server.handle.send_packet(ID_A, 32, b"still-here").unwrap();
+    // Give the bridge a moment to observe the dead peer and soft-disconnect.
+    thread::sleep(std::time::Duration::from_millis(100));
+    assert_eq!(
+        server.handle.session_state(ID_A).unwrap(),
+        Some(SessionState::Active),
+        "client transport loss must not remove the session"
+    );
+
+    let (returning, response) = server.handshake(ID_A);
+    assert_eq!(
+        response.status,
+        Some(ConnectStatus::ReturningClient as i32),
+        "expected ReturningClient after hard drop, got {response:?}"
+    );
+    client.recover(returning).unwrap();
+    client
+        .write_packet(TerminalPacketType::KeepAlive as u8, &[])
+        .unwrap();
+    let first = client.read_packet().unwrap();
+    let second = client.read_packet().unwrap();
+    assert_eq!(
+        (first.header(), first.payload()),
+        (31, b"while-away".as_slice())
+    );
+    assert_eq!(
+        (second.header(), second.payload()),
+        (32, b"still-here".as_slice())
+    );
+    server.runtime.shutdown().unwrap();
+}
+
+#[test]
 fn keepalive_echo_acknowledges_everything_read_from_the_client() {
     let mut server = TestRuntime::start();
     let _terminal = server.register(ID_A, KEY_A);

--- a/crates/et-server/tests/runtime_recovery.rs
+++ b/crates/et-server/tests/runtime_recovery.rs
@@ -175,6 +175,50 @@ fn hard_client_drop_keeps_session_for_returning_recover() {
 }
 
 #[test]
+fn repeated_recovery_does_not_let_stale_hup_disconnect_the_new_stream() {
+    // Recover can both wake poll() with an old-socket HUP and read the first
+    // post-recovery packets into BackedReader while authenticating the peer.
+    // The stale event must not invalidate the new stream, and buffered input
+    // must be drained even if the new socket has no remaining POLLIN state.
+    let mut server = TestRuntime::start();
+    let mut terminal = server.register(ID_A, KEY_A);
+    terminal.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let (stream, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    let key = passkey_to_key(KEY_A).unwrap();
+    let (mut client, initial) = initialize(stream, &key, default_payload());
+    assert_eq!(initial.error, None);
+    server
+        .handle
+        .wait_for_state(ID_A, SessionState::Active, TIMEOUT)
+        .unwrap();
+    let initial_terminal_packet = read_local_packet(&mut terminal).unwrap();
+    assert_eq!(
+        initial_terminal_packet.header(),
+        TerminalPacketType::TerminalInit as u8
+    );
+
+    for iteration in 0..32u8 {
+        client.shutdown().unwrap();
+        let (returning, response) = server.handshake(ID_A);
+        assert_eq!(response.status, Some(ConnectStatus::ReturningClient as i32));
+        client.recover(returning).unwrap();
+        client
+            .write_packet(TerminalPacketType::KeepAlive as u8, &[])
+            .unwrap();
+        client
+            .write_packet(TerminalPacketType::TerminalInfo as u8, &[iteration])
+            .unwrap();
+        let forwarded = read_local_packet(&mut terminal)
+            .unwrap_or_else(|error| panic!("iteration {iteration}: {error}"));
+        assert_eq!(forwarded.header(), TerminalPacketType::TerminalInfo as u8);
+        assert_eq!(forwarded.payload(), &[iteration]);
+    }
+
+    server.runtime.shutdown().unwrap();
+}
+
+#[test]
 fn keepalive_echo_acknowledges_everything_read_from_the_client() {
     let mut server = TestRuntime::start();
     let _terminal = server.register(ID_A, KEY_A);


### PR DESCRIPTION
## Summary

Fixes the sleep/wake failure mode we diagnosed in production:

1. Laptop sleeps → client TCP to `etserver` dies  
2. Server bridge treated that as fatal → exited → `active.shutdown()` killed `etterminal`  
3. Lifecycle removed the registration/session  
4. On wake, reconnect got **`InvalidKey: client is not registered`**

After this change, client transport loss is a **soft disconnect**:

- Terminal stays registered, session stays `Active`
- Terminal output is buffered in the replay backup
- Returning client gets `ReturningClient` and recovers the same shell

### Code changes

- **`terminal_bridge`**: never tear down the loop on client I/O/crypto/backpressure errors; call `mark_client_disconnected()` and keep polling the terminal until it really dies or the session shuts down. Poll with a short timeout while disconnected so recovery wakes promptly.
- **`ActiveSession::mark_client_disconnected`**: invalidate the encrypted client writer/reader without closing the terminal.
- **`Connection::write_packet`**: if `write_all` fails after a `Send` outcome, soft-disconnect (packet already in backup) and return `Ok` so callers do not kill the session.
- **Test**: `hard_client_drop_keeps_session_for_returning_recover` — OS-level socket shutdown, buffer while away, `ReturningClient` + catch-up.

### Production evidence (this bug)

Server log on workstation:

```text
id=XXX7I8bK6DUM5mwj: terminal bridge ended
terminal disconnected for registration id=XXX7I8bK6DUM5mwj
id=XXX7I8bK6DUM5mwj: removed session after terminal disconnect
... ~2h later ...
reject ... id=XXX7I8bK6DUM5mwj status=InvalidKey: client is not registered
```

Client log matched: missed keepalive → 28 reconnect timeouts → InvalidKey when the network returned.

## Test plan

- [x] `cargo test -p et-net -p et-server --lib`
- [x] `cargo test -p et-server --tests`
- [x] `cargo test -p et-net --test connection_resilience`
- [x] `cargo test -p et --test reconnect_end_to_end --test reconnect_outage_end_to_end`
- [ ] Deploy to workstation, sleep laptop with live `et` session, wake + wait for network, confirm session resumes (same shell, no InvalidKey)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps server sessions alive when the client TCP path drops (sleep/Wi‑Fi/NAT). Hardens recovery so stale HUP/read events can’t disconnect a new stream, and a returning client resumes the same shell with full catch‑up.

- **Bug Fixes**
  - Probe connectivity before send; soft-disconnect on client send/read errors; keep session Active and buffer for catch-up.
  - `terminal_bridge`: track connection generation to ignore stale HUP/ERR; drain buffered client input after recovery; hold outbound forwarding packets on backpressure and resume after reconnect.
  - `ActiveSession`: add connection generation; `try_clone_stream`/`connection_state` return it; `mark_client_disconnected(expected_generation)` only drops the matching transport.
  - `Connection::write_packet`: probe before send; if `write_all` fails after `Send`, disconnect and continue (packet already backed up).
  - Tests/Docs: `hard_client_drop_keeps_session_for_returning_recover`; `repeated_recovery_does_not_let_stale_hup_disconnect_the_new_stream`; release note in `.tegami/survive-client-disconnect.md`.

<sup>Written for commit ac09620311a24130a57eea2ec84ff01ae51cf57d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

