### PR TITLE
fix(server): unblock recover after blackholed client writes

### DIFF
--- a/crates/et-bin/CHANGELOG.md
+++ b/crates/et-bin/CHANGELOG.md
@@ -4,12 +4,15 @@
 
 `etserver` no longer lets a blackholed client TCP path (peer stops reading
 without FIN/RST) hold the session connection mutex inside an unbounded
-`write_all`. Live writes are bounded by a two-second timeout and soft-
-disconnect into the reconnect buffer; `ActiveSession::recover` acquires its
-session locks with the same recovery deadline and rejects concurrent recovers
-with a busy error instead of queuing for minutes. Returning clients that
-previously saw `ReturningClient` then hung with `ET bootstrap timed out while
-recovering ET session` can complete recovery again.
+`write_all`. Live writes are bounded by a two-second write loop and soft-
+disconnect (with socket shutdown) into the reconnect buffer so partial frames
+cannot desync a later recovery on a new stream. `ActiveSession::recover`
+acquires its session locks with the same recovery deadline, uses a panic-safe
+single-flight permit (`RecoverPermit`), and only sends `ReturningClient` after
+that permit is held — concurrent recovers are dropped without a handshake so
+clients retry instead of burning a sequence-exchange timeout. Returning clients
+that previously saw `ReturningClient` then hung with `ET bootstrap timed out
+while recovering ET session` can complete recovery again.
 
 ## et@0.0.11
 

--- a/crates/et-bin/CHANGELOG.md
+++ b/crates/et-bin/CHANGELOG.md
@@ -4,15 +4,16 @@
 
 `etserver` no longer lets a blackholed client TCP path (peer stops reading
 without FIN/RST) hold the session connection mutex inside an unbounded
-`write_all`. Live writes are bounded by a two-second write loop and soft-
-disconnect (with socket shutdown) into the reconnect buffer so partial frames
-cannot desync a later recovery on a new stream. `ActiveSession::recover`
-acquires its session locks with the same recovery deadline, uses a panic-safe
-single-flight permit (`RecoverPermit`), and only sends `ReturningClient` after
-that permit is held — concurrent recovers are dropped without a handshake so
-clients retry instead of burning a sequence-exchange timeout. Returning clients
-that previously saw `ReturningClient` then hung with `ET bootstrap timed out
-while recovering ET session` can complete recovery again.
+socket write. Live writes use a two-second deadline loop and soft-disconnect
+(with socket shutdown) into the reconnect buffer so partial frames cannot
+desync a later recovery on a new stream. Session recovery runs sequence
+exchange and peer auth *without* holding the connection mutex (terminal
+output is queued and flushed after install), uses a panic-safe single-flight
+permit (`RecoverPermit`), and only sends `ReturningClient` after that permit
+is held — concurrent recovers are dropped without a handshake so clients
+retry instead of burning a sequence-exchange timeout. Returning clients that
+previously saw `ReturningClient` then hung with `ET bootstrap timed out while
+recovering ET session` can complete recovery again.
 
 ## et@0.0.11
 

--- a/crates/et-bin/CHANGELOG.md
+++ b/crates/et-bin/CHANGELOG.md
@@ -1,3 +1,16 @@
+## et@0.0.12
+
+### Unblock session recovery after blackholed client writes
+
+`etserver` no longer lets a blackholed client TCP path (peer stops reading
+without FIN/RST) hold the session connection mutex inside an unbounded
+`write_all`. Live writes are bounded by a two-second timeout and soft-
+disconnect into the reconnect buffer; `ActiveSession::recover` acquires its
+session locks with the same recovery deadline and rejects concurrent recovers
+with a busy error instead of queuing for minutes. Returning clients that
+previously saw `ReturningClient` then hung with `ET bootstrap timed out while
+recovering ET session` can complete recovery again.
+
 ## et@0.0.11
 
 ### Keep server sessions alive across client transport loss

--- a/crates/et-net/src/connection.rs
+++ b/crates/et-net/src/connection.rs
@@ -13,13 +13,14 @@ mod recovery;
 
 pub use recovery::{DEFAULT_RECOVERY_TIMEOUT, MAX_RECOVERY_PROTO_LEN};
 
-/// Upper bound on how long a live `write_all` may block.
+/// Upper bound on how long a live socket write may block.
 ///
 /// A blackholed peer (laptop sleep, silent NAT drop, Wi-Fi loss without FIN)
-/// used to make `write_all` hang for minutes while holding the server
-/// session's connection mutex. That blocked `ActiveSession::recover` and
-/// left clients stuck after `ReturningClient`. Bound the write so the
-/// transport soft-disconnects and recovery can proceed.
+/// used to make an unbounded write hang for minutes while holding the server
+/// session's connection mutex. That blocked `ActiveSession::recover` and left
+/// clients stuck after `ReturningClient`. Live frames go through
+/// [`write_all_until`] with this deadline so the transport soft-disconnects
+/// and recovery can proceed.
 pub const DEFAULT_LIVE_WRITE_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Debug)]

--- a/crates/et-net/src/connection.rs
+++ b/crates/et-net/src/connection.rs
@@ -13,6 +13,15 @@ mod recovery;
 
 pub use recovery::{DEFAULT_RECOVERY_TIMEOUT, MAX_RECOVERY_PROTO_LEN};
 
+/// Upper bound on how long a live `write_all` may block.
+///
+/// A blackholed peer (laptop sleep, silent NAT drop, Wi-Fi loss without FIN)
+/// used to make `write_all` hang for minutes while holding the server
+/// session's connection mutex. That blocked `ActiveSession::recover` and
+/// left clients stuck after `ReturningClient`. Bound the write so the
+/// transport soft-disconnects and recovery can proceed.
+pub const DEFAULT_LIVE_WRITE_TIMEOUT: Duration = Duration::from_secs(2);
+
 #[derive(Debug)]
 pub enum ConnError {
     Io(io::Error),
@@ -56,7 +65,7 @@ impl Connection {
         }
         match self.writer.write_packet(header, payload)? {
             WriterOutcome::Send(frame) => {
-                if let Err(_error) = self.stream.write_all(&frame) {
+                if let Err(_error) = self.write_live_frame(&frame) {
                     // The encrypted packet is already in the replay backup
                     // (BackedWriter pushes before returning Send). Mark the
                     // transport disconnected so further writes buffer for a
@@ -67,6 +76,23 @@ impl Connection {
             }
             WriterOutcome::BufferedOnly => Ok(()),
             WriterOutcome::Skipped => Err(ConnError::Backpressure),
+        }
+    }
+
+    /// Write a framed packet to a still-connected peer with a bounded timeout.
+    ///
+    /// Restores a cleared write timeout afterwards so recovery / handshake
+    /// code that sets its own deadlines is not left with a stale value.
+    fn write_live_frame(&mut self, frame: &[u8]) -> io::Result<()> {
+        self.stream
+            .set_write_timeout(Some(DEFAULT_LIVE_WRITE_TIMEOUT))?;
+        let result = self.stream.write_all(frame);
+        // Best-effort restore: a failed clear must not hide a write error.
+        let clear = self.stream.set_write_timeout(None);
+        match (result, clear) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(error), _) => Err(error),
+            (Ok(()), Err(error)) => Err(error),
         }
     }
 

--- a/crates/et-net/src/connection.rs
+++ b/crates/et-net/src/connection.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Read, Write};
 use std::net::{Shutdown, TcpStream};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use et_core::backed_reader::{BackedReader, ReadError, ReadItem};
 use et_core::backed_writer::{BackedWriter, RecoverError, WriterOutcome};
@@ -81,17 +81,29 @@ impl Connection {
 
     /// Write a framed packet to a still-connected peer with a bounded timeout.
     ///
+    /// Uses a write loop (not bare `write_all`) so each `write` is capped by
+    /// the remaining deadline. On any incomplete write we error out and the
+    /// caller soft-disconnects: the old TCP path is abandoned (and shut down
+    /// by the soft-disconnect path) so a partial frame left on the wire cannot
+    /// desync a later recovery, which always uses a new stream.
+    ///
     /// Restores a cleared write timeout afterwards so recovery / handshake
     /// code that sets its own deadlines is not left with a stale value.
     fn write_live_frame(&mut self, frame: &[u8]) -> io::Result<()> {
-        self.stream
-            .set_write_timeout(Some(DEFAULT_LIVE_WRITE_TIMEOUT))?;
-        let result = self.stream.write_all(frame);
+        let deadline = Instant::now()
+            .checked_add(DEFAULT_LIVE_WRITE_TIMEOUT)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::TimedOut, "live write deadline"))?;
+        let result = write_all_until(&mut self.stream, frame, deadline);
         // Best-effort restore: a failed clear must not hide a write error.
         let clear = self.stream.set_write_timeout(None);
         match (result, clear) {
             (Ok(()), Ok(())) => Ok(()),
-            (Err(error), _) => Err(error),
+            (Err(error), _) => {
+                // Force the peer off the half-written frame so it reconnects
+                // rather than blocking on the rest of a truncated record.
+                let _ = self.stream.shutdown(Shutdown::Both);
+                Err(error)
+            }
             (Ok(()), Err(error)) => Err(error),
         }
     }
@@ -228,4 +240,25 @@ impl Connection {
         }
         Ok(())
     }
+}
+
+/// Write the full buffer before `deadline`, refreshing the socket write
+/// timeout on each attempt so a blackholed peer cannot pin the caller.
+fn write_all_until(stream: &mut TcpStream, mut buffer: &[u8], deadline: Instant) -> io::Result<()> {
+    while !buffer.is_empty() {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .filter(|duration| !duration.is_zero())
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::TimedOut, "live write deadline elapsed")
+            })?;
+        stream.set_write_timeout(Some(remaining))?;
+        match stream.write(buffer) {
+            Ok(0) => return Err(io::ErrorKind::WriteZero.into()),
+            Ok(count) => buffer = &buffer[count..],
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
 }

--- a/crates/et-net/src/connection_recovery.rs
+++ b/crates/et-net/src/connection_recovery.rs
@@ -33,30 +33,46 @@ impl Connection {
         Ok(())
     }
 
-    pub fn recovery_candidate(
-        &self,
-        new_stream: TcpStream,
-        timeout: Duration,
-    ) -> Result<Self, ConnError> {
+    /// Snapshot writer/reader state onto `new_stream` without network I/O.
+    ///
+    /// Used by the server session path so the connection mutex can be released
+    /// for the duration of [`Self::run_recovery_handshake`].
+    pub fn prepare_recovery_candidate(&self, new_stream: TcpStream) -> Self {
         let mut candidate = Self {
             stream: new_stream,
             writer: self.writer.clone(),
             reader: self.reader.clone(),
         };
         candidate.disconnect();
+        candidate
+    }
+
+    /// Sequence exchange, catchup transfer, and stream revive on a prepared
+    /// recovery candidate. Safe to run without holding the session mutex.
+    pub fn run_recovery_handshake(&mut self, timeout: Duration) -> Result<(), ConnError> {
         let deadline = recovery_deadline(timeout)?;
-        match candidate.exchange_recovery(deadline) {
+        match self.exchange_recovery(deadline) {
             Ok(remote_catchup) => {
-                candidate.reader.revive(remote_catchup.buffer)?;
-                candidate.writer.revive();
-                candidate.set_io_timeout(None)?;
-                Ok(candidate)
+                self.reader.revive(remote_catchup.buffer)?;
+                self.writer.revive();
+                self.set_io_timeout(None)?;
+                Ok(())
             }
             Err(error) => {
-                let _ = candidate.stream.shutdown(Shutdown::Both);
+                let _ = self.stream.shutdown(Shutdown::Both);
                 Err(error)
             }
         }
+    }
+
+    pub fn recovery_candidate(
+        &self,
+        new_stream: TcpStream,
+        timeout: Duration,
+    ) -> Result<Self, ConnError> {
+        let mut candidate = self.prepare_recovery_candidate(new_stream);
+        candidate.run_recovery_handshake(timeout)?;
+        Ok(candidate)
     }
 
     /// Wait for one live packet on the revived stream and requeue it for the

--- a/crates/et-net/tests/connection_resilience.rs
+++ b/crates/et-net/tests/connection_resilience.rs
@@ -90,7 +90,7 @@ fn blackholed_peer_write_soft_disconnects_within_live_timeout() {
     // Further output buffers for reconnect instead of hanging.
     connection.write_packet(8, b"buffered").unwrap();
     assert!(!connection.connected());
-    assert_eq!(connection.writer_sequence() >= 1, true);
+    assert!(connection.writer_sequence() >= 1);
     sink.thread().unpark();
     let _ = sink.join();
 }

--- a/crates/et-net/tests/connection_resilience.rs
+++ b/crates/et-net/tests/connection_resilience.rs
@@ -3,8 +3,9 @@
 use std::io::Read;
 use std::net::{TcpListener, TcpStream};
 use std::thread;
+use std::time::{Duration, Instant};
 
-use et_net::connection::{Connection, MAX_RECOVERY_PROTO_LEN};
+use et_net::connection::{Connection, DEFAULT_LIVE_WRITE_TIMEOUT, MAX_RECOVERY_PROTO_LEN};
 
 #[test]
 fn eof_invalidates_connection_so_future_output_is_buffered() {
@@ -43,6 +44,62 @@ fn recovery_protobuf_limit_is_explicit_and_enforced() {
     let stream = TcpStream::connect(address).unwrap();
     assert!(connection.recover(stream).is_err());
     peer.join().unwrap();
+}
+
+/// Regression: a blackholed peer (no FIN/RST, peer stops reading) used to make
+/// `write_all` block for minutes while the server session lock was held,
+/// which prevented `ActiveSession::recover` from starting. Live writes must
+/// soft-disconnect within roughly [`DEFAULT_LIVE_WRITE_TIMEOUT`].
+#[test]
+fn blackholed_peer_write_soft_disconnects_within_live_timeout() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    // Peer that accepts but never reads — fills the sender's TCP buffer.
+    let sink = thread::spawn(move || {
+        let (_stream, _) = listener.accept().unwrap();
+        thread::park();
+    });
+    let stream = TcpStream::connect(address).unwrap();
+    shrink_send_buffer(&stream);
+    let mut connection = Connection::new_server(stream, &[9; 32]);
+    let payload = vec![0u8; 32 * 1024];
+    let started = Instant::now();
+    let mut disconnected = false;
+    // Fill the socket send buffer until the bounded write times out.
+    for _ in 0..4_096 {
+        connection.write_packet(7, &payload).unwrap();
+        if !connection.connected() {
+            disconnected = true;
+            break;
+        }
+        assert!(
+            started.elapsed() < DEFAULT_LIVE_WRITE_TIMEOUT + Duration::from_secs(3),
+            "write_packet blocked for {:?} without soft-disconnect",
+            started.elapsed()
+        );
+    }
+    assert!(
+        disconnected,
+        "expected soft-disconnect after blackhole write timeout"
+    );
+    assert!(
+        started.elapsed() < DEFAULT_LIVE_WRITE_TIMEOUT + Duration::from_secs(3),
+        "soft-disconnect took {:?}, longer than live write bound",
+        started.elapsed()
+    );
+    // Further output buffers for reconnect instead of hanging.
+    connection.write_packet(8, b"buffered").unwrap();
+    assert!(!connection.connected());
+    assert_eq!(connection.writer_sequence() >= 1, true);
+    sink.thread().unpark();
+    let _ = sink.join();
+}
+
+fn shrink_send_buffer(stream: &TcpStream) {
+    // 4 KiB send buffer so the blackhole fills quickly under CI load.
+    socket2::SockRef::from(stream)
+        .set_send_buffer_size(4 * 1024)
+        .unwrap();
 }
 
 #[test]

--- a/crates/et-server/src/runtime_handler.rs
+++ b/crates/et-server/src/runtime_handler.rs
@@ -125,19 +125,39 @@ pub(crate) fn handle(
         }
         SessionClaim::Returning(session) => {
             crate::diag::info(format!("id={id}: returning client reconnect from {peer}"));
-            if send_status(&mut stream, ConnectStatus::ReturningClient).is_ok() {
-                match session.recover(stream) {
-                    Ok(()) => {
-                        crate::diag::info(format!("id={id}: session recover accepted from {peer}"))
-                    }
-                    Err(error) => crate::diag::info(format!(
-                        "id={id}: session recover failed from {peer}: {error}"
-                    )),
+            // Take the single-flight permit *before* ReturningClient so a
+            // concurrent recover does not commit the client to sequence
+            // exchange and then fail with RecoverBusy / silent hang.
+            let permit = match session.try_begin_recover() {
+                Ok(permit) => permit,
+                Err(crate::session::SessionError::RecoverBusy) => {
+                    crate::diag::info(format!(
+                        "id={id}: drop concurrent recover from {peer}: session recover busy"
+                    ));
+                    // No ConnectResponse: the client sees EOF/reset and
+                    // retries without burning a recovery exchange timeout.
+                    return;
                 }
-            } else {
+                Err(error) => {
+                    crate::diag::info(format!(
+                        "id={id}: drop recover from {peer}: could not begin recover: {error}"
+                    ));
+                    return;
+                }
+            };
+            if send_status(&mut stream, ConnectStatus::ReturningClient).is_err() {
                 crate::diag::info(format!(
                     "id={id}: failed to send ReturningClient status to {peer}"
                 ));
+                return;
+            }
+            match permit.complete(stream) {
+                Ok(()) => {
+                    crate::diag::info(format!("id={id}: session recover accepted from {peer}"))
+                }
+                Err(error) => crate::diag::info(format!(
+                    "id={id}: session recover failed from {peer}: {error}"
+                )),
             }
         }
     }

--- a/crates/et-server/src/session.rs
+++ b/crates/et-server/src/session.rs
@@ -398,10 +398,7 @@ impl Drop for RecoverPermit<'_> {
 
 /// Acquire a [`Mutex`] with a deadline so recover cannot park forever behind a
 /// bridge thread blocked in a live write.
-fn lock_timeout<T>(
-    mutex: &Mutex<T>,
-    timeout: Duration,
-) -> Result<MutexGuard<'_, T>, SessionError> {
+fn lock_timeout<T>(mutex: &Mutex<T>, timeout: Duration) -> Result<MutexGuard<'_, T>, SessionError> {
     let deadline = Instant::now()
         .checked_add(timeout)
         .ok_or(SessionError::RecoverBusy)?;

--- a/crates/et-server/src/session.rs
+++ b/crates/et-server/src/session.rs
@@ -169,7 +169,7 @@ impl ActiveSession {
         // Phase 1: soft-disconnect and snapshot under a short lock.
         let mut candidate = {
             let mut connection = lock_timeout(&self.connection, RECOVERY_LOCK_TIMEOUT)?;
-            // Stop live write_all on the old path; terminal output during the
+            // Soft-disconnect the old live path; terminal output during the
             // off-lock handshake is queued in `recover_hold`.
             connection.disconnect();
             connection.prepare_recovery_candidate(stream)
@@ -221,10 +221,24 @@ impl ActiveSession {
                 std::mem::take(&mut *hold)
             };
             let mut connection = lock_timeout(&self.connection, RECOVERY_LOCK_TIMEOUT)?;
-            for (header, payload) in batch {
-                connection
-                    .write_packet(header, &payload)
-                    .map_err(SessionError::Connection)?;
+            let mut remaining = batch.into_iter();
+            while let Some((header, payload)) = remaining.next() {
+                if let Err(error) = connection.write_packet(header, &payload) {
+                    // Release the connection lock before taking `recover_hold`
+                    // (send_packet may hold hold → connection; reverse deadlocks).
+                    drop(connection);
+                    // Put the failed packet and unwritten tail back ahead of
+                    // anything concurrent senders queued after we took `batch`.
+                    let mut hold = self
+                        .recover_hold
+                        .lock()
+                        .map_err(|_| SessionError::Unavailable)?;
+                    let concurrent = std::mem::take(&mut *hold);
+                    hold.push((header, payload));
+                    hold.extend(remaining);
+                    hold.extend(concurrent);
+                    return Err(SessionError::Connection(error));
+                }
             }
         }
     }

--- a/crates/et-server/src/session.rs
+++ b/crates/et-server/src/session.rs
@@ -102,10 +102,13 @@ impl ActiveSession {
             .map_err(SessionError::Connection)
     }
 
-    pub(crate) fn recover(&self, stream: TcpStream) -> Result<(), SessionError> {
-        // Fail concurrent recovers immediately so accept threads do not stack
-        // behind a single blackholed write that still holds the connection
-        // mutex. The client will retry with a fresh TCP connection.
+    /// Acquire the single-flight recover permit without speaking on the wire.
+    ///
+    /// Callers must send `ReturningClient` only after this succeeds, so a
+    /// concurrent recover does not commit the peer to sequence exchange and
+    /// then fail with `RecoverBusy`. The permit releases the flag on drop
+    /// (including panic unwind).
+    pub(crate) fn try_begin_recover(&self) -> Result<RecoverPermit<'_>, SessionError> {
         if self
             .recovering
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
@@ -113,11 +116,7 @@ impl ActiveSession {
         {
             return Err(SessionError::RecoverBusy);
         }
-        let result = self.recover_locked(stream);
-        self.recovering.store(false, Ordering::Release);
-        // Wake the bridge even on failure so it re-checks connection state.
-        let _ = self.signal();
-        result
+        Ok(RecoverPermit { session: self })
     }
 
     fn recover_locked(&self, stream: TcpStream) -> Result<(), SessionError> {
@@ -280,6 +279,28 @@ impl ActiveSession {
             .map_err(|_| SessionError::Unavailable)?
             .write_all(&[1])
             .map_err(SessionError::Io)
+    }
+}
+
+/// Single-flight recover permit. Dropping it (normally or on panic) always
+/// clears [`ActiveSession::recovering`] and wakes the terminal bridge.
+pub(crate) struct RecoverPermit<'a> {
+    session: &'a ActiveSession,
+}
+
+impl RecoverPermit<'_> {
+    /// Run the recovery handshake and install the new stream.
+    pub(crate) fn complete(self, stream: TcpStream) -> Result<(), SessionError> {
+        // `self` drops after this returns (or panics), clearing `recovering`.
+        self.session.recover_locked(stream)
+    }
+}
+
+impl Drop for RecoverPermit<'_> {
+    fn drop(&mut self) {
+        self.session.recovering.store(false, Ordering::Release);
+        // Wake the bridge even on failure so it re-checks connection state.
+        let _ = self.session.signal();
     }
 }
 

--- a/crates/et-server/src/session.rs
+++ b/crates/et-server/src/session.rs
@@ -2,11 +2,21 @@ use et_net::local::LocalStream;
 use std::io::{self, Write};
 use std::net::{Shutdown, TcpStream};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
+use std::time::{Duration, Instant};
 
 use et_core::proto::TerminalPacketType;
 use et_net::connection::DEFAULT_RECOVERY_TIMEOUT;
 use et_net::connection::{ConnError, Connection};
+
+/// How long `recover` may wait for the session mutexes.
+///
+/// Must stay at or below [`DEFAULT_RECOVERY_TIMEOUT`]: if the terminal bridge
+/// is mid-`write_all` on a blackholed socket, recover used to park forever on
+/// `connection.lock()`. With a bounded live write timeout plus this lock
+/// deadline, piled-up returning clients fail fast and retry instead of
+/// blocking the accept path for minutes.
+const RECOVERY_LOCK_TIMEOUT: Duration = DEFAULT_RECOVERY_TIMEOUT;
 
 pub(crate) struct ActiveSession {
     connection: Mutex<Connection>,
@@ -15,6 +25,9 @@ pub(crate) struct ActiveSession {
     wake_writer: Mutex<LocalStream>,
     wake_reader: Mutex<Option<LocalStream>>,
     shutdown: AtomicBool,
+    /// Only one recover may run at a time. Concurrent returning clients used
+    /// to queue on the connection mutex for minutes after a blackhole write.
+    recovering: AtomicBool,
     connection_generation: AtomicU64,
 }
 
@@ -28,6 +41,9 @@ pub enum SessionError {
     Connection(ConnError),
     Io(io::Error),
     Unavailable,
+    /// Another recover is already in progress, or a session lock could not
+    /// be acquired before [`RECOVERY_LOCK_TIMEOUT`].
+    RecoverBusy,
 }
 
 impl std::fmt::Display for SessionError {
@@ -36,6 +52,10 @@ impl std::fmt::Display for SessionError {
             Self::Connection(error) => write!(f, "session connection: {error}"),
             Self::Io(error) => write!(f, "session socket: {error}"),
             Self::Unavailable => write!(f, "session is unavailable"),
+            Self::RecoverBusy => write!(
+                f,
+                "session recover busy (lock contention or concurrent recover)"
+            ),
         }
     }
 }
@@ -45,7 +65,7 @@ impl std::error::Error for SessionError {
         match self {
             Self::Connection(error) => Some(error),
             Self::Io(error) => Some(error),
-            Self::Unavailable => None,
+            Self::Unavailable | Self::RecoverBusy => None,
         }
     }
 }
@@ -67,6 +87,7 @@ impl ActiveSession {
             wake_writer: Mutex::new(wake_writer),
             wake_reader: Mutex::new(Some(wake_reader)),
             shutdown: AtomicBool::new(false),
+            recovering: AtomicBool::new(false),
             connection_generation: AtomicU64::new(0),
         })
     }
@@ -82,11 +103,33 @@ impl ActiveSession {
     }
 
     pub(crate) fn recover(&self, stream: TcpStream) -> Result<(), SessionError> {
-        let mut control = self.control.lock().map_err(|_| SessionError::Unavailable)?;
-        let mut connection = self
-            .connection
-            .lock()
-            .map_err(|_| SessionError::Unavailable)?;
+        // Fail concurrent recovers immediately so accept threads do not stack
+        // behind a single blackholed write that still holds the connection
+        // mutex. The client will retry with a fresh TCP connection.
+        if self
+            .recovering
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return Err(SessionError::RecoverBusy);
+        }
+        let result = self.recover_locked(stream);
+        self.recovering.store(false, Ordering::Release);
+        // Wake the bridge even on failure so it re-checks connection state.
+        let _ = self.signal();
+        result
+    }
+
+    fn recover_locked(&self, stream: TcpStream) -> Result<(), SessionError> {
+        let mut control = lock_timeout(&self.control, RECOVERY_LOCK_TIMEOUT)?;
+        let mut connection = lock_timeout(&self.connection, RECOVERY_LOCK_TIMEOUT)?;
+        // Hold the session lock for the whole recover. Live writes are bounded
+        // by DEFAULT_LIVE_WRITE_TIMEOUT so a blackholed peer cannot pin this
+        // mutex indefinitely; lock_timeout above bounds waiters that arrive
+        // while a recover (or a timed-out write) is still in progress.
+        //
+        // Do not soft-disconnect the incumbent transport until the candidate
+        // authenticates: a failed recover must leave a healthy session alone.
         let mut candidate = connection
             .recovery_candidate(stream, DEFAULT_RECOVERY_TIMEOUT)
             .map_err(SessionError::Connection)?;
@@ -113,7 +156,7 @@ impl ActiveSession {
         self.connection_generation.fetch_add(1, Ordering::Release);
         drop(connection);
         drop(control);
-        self.signal()
+        Ok(())
     }
 
     pub(crate) fn shutdown(&self) -> Result<(), SessionError> {
@@ -237,6 +280,29 @@ impl ActiveSession {
             .map_err(|_| SessionError::Unavailable)?
             .write_all(&[1])
             .map_err(SessionError::Io)
+    }
+}
+
+/// Acquire a [`Mutex`] with a deadline so recover cannot park forever behind a
+/// bridge thread blocked in a live write.
+fn lock_timeout<T>(
+    mutex: &Mutex<T>,
+    timeout: Duration,
+) -> Result<MutexGuard<'_, T>, SessionError> {
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or(SessionError::RecoverBusy)?;
+    loop {
+        match mutex.try_lock() {
+            Ok(guard) => return Ok(guard),
+            Err(TryLockError::Poisoned(_)) => return Err(SessionError::Unavailable),
+            Err(TryLockError::WouldBlock) => {
+                if Instant::now() >= deadline {
+                    return Err(SessionError::RecoverBusy);
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        }
     }
 }
 

--- a/crates/et-server/src/session.rs
+++ b/crates/et-server/src/session.rs
@@ -12,10 +12,11 @@ use et_net::connection::{ConnError, Connection};
 /// How long `recover` may wait for the session mutexes.
 ///
 /// Must stay at or below [`DEFAULT_RECOVERY_TIMEOUT`]: if the terminal bridge
-/// is mid-`write_all` on a blackholed socket, recover used to park forever on
+/// is mid-write on a blackholed socket, recover used to park forever on
 /// `connection.lock()`. With a bounded live write timeout plus this lock
 /// deadline, piled-up returning clients fail fast and retry instead of
-/// blocking the accept path for minutes.
+/// blocking the accept path for minutes. Recovery network I/O itself runs
+/// *without* the connection mutex (see [`ActiveSession::recover_body`]).
 const RECOVERY_LOCK_TIMEOUT: Duration = DEFAULT_RECOVERY_TIMEOUT;
 
 pub(crate) struct ActiveSession {
@@ -24,6 +25,10 @@ pub(crate) struct ActiveSession {
     terminal_control: Mutex<LocalStream>,
     wake_writer: Mutex<LocalStream>,
     wake_reader: Mutex<Option<LocalStream>>,
+    /// Terminal packets produced while `recovering` is set. Drained onto the
+    /// new stream after install so the connection mutex is not held for the
+    /// recovery network RTT.
+    recover_hold: Mutex<Vec<(u8, Vec<u8>)>>,
     shutdown: AtomicBool,
     /// Only one recover may run at a time. Concurrent returning clients used
     /// to queue on the connection mutex for minutes after a blackhole write.
@@ -86,6 +91,7 @@ impl ActiveSession {
             terminal_control: Mutex::new(terminal_control),
             wake_writer: Mutex::new(wake_writer),
             wake_reader: Mutex::new(Some(wake_reader)),
+            recover_hold: Mutex::new(Vec::new()),
             shutdown: AtomicBool::new(false),
             recovering: AtomicBool::new(false),
             connection_generation: AtomicU64::new(0),
@@ -93,13 +99,49 @@ impl ActiveSession {
     }
 
     pub(crate) fn send_packet(&self, header: u8, payload: &[u8]) -> Result<(), SessionError> {
+        // While a recover holds the single-flight permit, queue terminal
+        // output instead of contending on the connection mutex for the
+        // recovery network RTT. Flushed after the new stream is installed.
+        if self.queue_if_recovering(header, payload)? {
+            return Ok(());
+        }
         let mut connection = self
             .connection
             .lock()
             .map_err(|_| SessionError::Unavailable)?;
+        // Recover may have started after the fast path check. Drop the
+        // connection lock before taking `recover_hold` (flush takes hold
+        // then connection — reverse order deadlocks).
+        if self.recovering.load(Ordering::Acquire) {
+            drop(connection);
+            if self.queue_if_recovering(header, payload)? {
+                return Ok(());
+            }
+            connection = self
+                .connection
+                .lock()
+                .map_err(|_| SessionError::Unavailable)?;
+        }
         connection
             .write_packet(header, payload)
             .map_err(SessionError::Connection)
+    }
+
+    fn queue_if_recovering(&self, header: u8, payload: &[u8]) -> Result<bool, SessionError> {
+        if !self.recovering.load(Ordering::Acquire) {
+            return Ok(false);
+        }
+        let mut hold = self
+            .recover_hold
+            .lock()
+            .map_err(|_| SessionError::Unavailable)?;
+        // Re-check under the hold lock so a recover that just finished does
+        // not leave packets stranded in the hold after `recovering` clears.
+        if !self.recovering.load(Ordering::Acquire) {
+            return Ok(false);
+        }
+        hold.push((header, payload.to_vec()));
+        Ok(true)
     }
 
     /// Acquire the single-flight recover permit without speaking on the wire.
@@ -119,29 +161,29 @@ impl ActiveSession {
         Ok(RecoverPermit { session: self })
     }
 
-    fn recover_locked(&self, stream: TcpStream) -> Result<(), SessionError> {
-        let mut control = lock_timeout(&self.control, RECOVERY_LOCK_TIMEOUT)?;
-        let mut connection = lock_timeout(&self.connection, RECOVERY_LOCK_TIMEOUT)?;
-        // Hold the session lock for the whole recover. Live writes are bounded
-        // by DEFAULT_LIVE_WRITE_TIMEOUT so a blackholed peer cannot pin this
-        // mutex indefinitely; lock_timeout above bounds waiters that arrive
-        // while a recover (or a timed-out write) is still in progress.
-        //
-        // Do not soft-disconnect the incumbent transport until the candidate
-        // authenticates: a failed recover must leave a healthy session alone.
-        let mut candidate = connection
-            .recovery_candidate(stream, DEFAULT_RECOVERY_TIMEOUT)
+    /// Prepare → network handshake off-lock → install → flush hold.
+    ///
+    /// The connection mutex is held only for soft-disconnect/snapshot and for
+    /// installing the new stream, not for sequence exchange or peer auth.
+    fn recover_body(&self, stream: TcpStream) -> Result<(), SessionError> {
+        // Phase 1: soft-disconnect and snapshot under a short lock.
+        let mut candidate = {
+            let mut connection = lock_timeout(&self.connection, RECOVERY_LOCK_TIMEOUT)?;
+            // Stop live write_all on the old path; terminal output during the
+            // off-lock handshake is queued in `recover_hold`.
+            connection.disconnect();
+            connection.prepare_recovery_candidate(stream)
+        };
+
+        // Phase 2: recovery network I/O without the session connection lock.
+        candidate
+            .run_recovery_handshake(DEFAULT_RECOVERY_TIMEOUT)
             .map_err(SessionError::Connection)?;
         // Any packet that decrypts with the session key authenticates the
         // returning client; it is requeued and handled by the session loop.
-        // Upstream C++ clients send regular traffic here (e.g. typed input or
-        // a keep-alive), not a dedicated proof packet.
         candidate
             .authenticate_peer(DEFAULT_RECOVERY_TIMEOUT)
             .map_err(SessionError::Connection)?;
-        // The proof keep-alive carries a delivery acknowledgement so an
-        // et.rs client trims its replay backup right after recovery; legacy
-        // clients ignore the payload.
         let ack = candidate.keepalive_ack();
         candidate
             .write_packet(TerminalPacketType::KeepAlive as u8, &ack)
@@ -149,13 +191,42 @@ impl ActiveSession {
         let new_control = candidate
             .try_clone_stream()
             .map_err(SessionError::Connection)?;
-        let old_control = std::mem::replace(&mut *control, new_control);
-        let _ = old_control.shutdown(Shutdown::Both);
-        *connection = candidate;
-        self.connection_generation.fetch_add(1, Ordering::Release);
-        drop(connection);
-        drop(control);
-        Ok(())
+
+        // Phase 3: install under a short lock.
+        {
+            let mut control = lock_timeout(&self.control, RECOVERY_LOCK_TIMEOUT)?;
+            let mut connection = lock_timeout(&self.connection, RECOVERY_LOCK_TIMEOUT)?;
+            let old_control = std::mem::replace(&mut *control, new_control);
+            let _ = old_control.shutdown(Shutdown::Both);
+            *connection = candidate;
+            self.connection_generation.fetch_add(1, Ordering::Release);
+        }
+
+        // Phase 4: drain terminal output queued while the handshake ran.
+        // Still under `recovering` so concurrent send_packet keeps queuing
+        // until the permit drops; Drop flushes once more after clearing.
+        self.flush_recover_hold()
+    }
+
+    fn flush_recover_hold(&self) -> Result<(), SessionError> {
+        loop {
+            let batch = {
+                let mut hold = self
+                    .recover_hold
+                    .lock()
+                    .map_err(|_| SessionError::Unavailable)?;
+                if hold.is_empty() {
+                    return Ok(());
+                }
+                std::mem::take(&mut *hold)
+            };
+            let mut connection = lock_timeout(&self.connection, RECOVERY_LOCK_TIMEOUT)?;
+            for (header, payload) in batch {
+                connection
+                    .write_packet(header, &payload)
+                    .map_err(SessionError::Connection)?;
+            }
+        }
     }
 
     pub(crate) fn shutdown(&self) -> Result<(), SessionError> {
@@ -291,14 +362,21 @@ pub(crate) struct RecoverPermit<'a> {
 impl RecoverPermit<'_> {
     /// Run the recovery handshake and install the new stream.
     pub(crate) fn complete(self, stream: TcpStream) -> Result<(), SessionError> {
-        // `self` drops after this returns (or panics), clearing `recovering`.
-        self.session.recover_locked(stream)
+        // `self` drops after this returns (or panics), clearing `recovering`
+        // and flushing any straggler hold packets.
+        self.session.recover_body(stream)
     }
 }
 
 impl Drop for RecoverPermit<'_> {
     fn drop(&mut self) {
+        // Flush while still marked recovering so send_packet keeps queuing
+        // rather than racing into a half-installed connection.
+        let _ = self.session.flush_recover_hold();
         self.session.recovering.store(false, Ordering::Release);
+        // Catch anything that observed `recovering` and queued after the first
+        // flush but before the flag cleared (re-check is under the hold lock).
+        let _ = self.session.flush_recover_hold();
         // Wake the bridge even on failure so it re-checks connection state.
         let _ = self.session.signal();
     }

--- a/crates/et-server/tests/runtime_recovery.rs
+++ b/crates/et-server/tests/runtime_recovery.rs
@@ -218,6 +218,158 @@ fn repeated_recovery_does_not_let_stale_hup_disconnect_the_new_stream() {
     server.runtime.shutdown().unwrap();
 }
 
+/// Regression: when the live client path blackholes (peer stops reading, no
+/// FIN), terminal output used to block forever inside `write_all` while holding
+/// the session mutex. Returning clients then sat behind that lock after
+/// `ReturningClient` and timed out with "bootstrap timed out while recovering".
+///
+/// Flood the live socket without draining it, then recover on a new stream —
+/// both the soft-disconnect write path and recover must finish within a tight
+/// bound, proving the shipped mutex/write timeout path works end-to-end.
+#[test]
+fn recover_succeeds_while_old_peer_blackholes_writes() {
+    use std::time::Instant;
+
+    let mut server = TestRuntime::start();
+    let mut terminal = server.register(ID_A, KEY_A);
+    terminal.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let (stream, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    let key = passkey_to_key(KEY_A).unwrap();
+    let (mut client, initial) = initialize(stream, &key, default_payload());
+    assert_eq!(initial.error, None);
+    server
+        .handle
+        .wait_for_state(ID_A, SessionState::Active, TIMEOUT)
+        .unwrap();
+    let initial_terminal_packet = read_local_packet(&mut terminal).unwrap();
+    assert_eq!(
+        initial_terminal_packet.header(),
+        TerminalPacketType::TerminalInit as u8
+    );
+
+    // Keep the client socket open but stop reading so the server's send buffer
+    // fills and the bounded live write path soft-disconnects.
+    let _live = client.try_clone_stream().unwrap();
+
+    let payload = vec![b'x'; 32 * 1024];
+    let flood_started = Instant::now();
+    for round in 0..1_024u32 {
+        server
+            .handle
+            .send_packet(ID_A, 40, &payload)
+            .unwrap_or_else(|error| panic!("flood round {round}: {error}"));
+        assert!(
+            flood_started.elapsed() < std::time::Duration::from_secs(12),
+            "send_packet blocked for {:?} — live write timeout not applied",
+            flood_started.elapsed()
+        );
+    }
+
+    let recover_started = Instant::now();
+    let (returning, response) = server.handshake(ID_A);
+    assert_eq!(
+        response.status,
+        Some(ConnectStatus::ReturningClient as i32),
+        "expected ReturningClient after blackhole, got {response:?}"
+    );
+    client.recover(returning).unwrap();
+    client
+        .write_packet(TerminalPacketType::KeepAlive as u8, &[])
+        .unwrap();
+    assert!(
+        recover_started.elapsed() < std::time::Duration::from_secs(8),
+        "recover took {:?} — session mutex still blocked by live write",
+        recover_started.elapsed()
+    );
+
+    // Post-recovery traffic must flow on the new stream.
+    client
+        .write_packet(TerminalPacketType::TerminalInfo as u8, b"after-blackhole")
+        .unwrap();
+    let forwarded = read_local_packet(&mut terminal).unwrap();
+    assert_eq!(forwarded.header(), TerminalPacketType::TerminalInfo as u8);
+    assert_eq!(forwarded.payload(), b"after-blackhole");
+    server.runtime.shutdown().unwrap();
+}
+
+/// Concurrent returning clients must not stack for minutes on one recover.
+/// While the first recover is mid-handshake (peer deliberately stalls after
+/// ReturningClient), a second returning connection should still get a
+/// response promptly instead of parking behind the session mutex forever.
+#[test]
+fn concurrent_returning_recover_does_not_block_accept_path() {
+    use std::time::Instant;
+
+    let mut server = TestRuntime::start();
+    let mut terminal = server.register(ID_A, KEY_A);
+    terminal.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let (stream, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    let key = passkey_to_key(KEY_A).unwrap();
+    let (mut client, initial) = initialize(stream, &key, default_payload());
+    assert_eq!(initial.error, None);
+    server
+        .handle
+        .wait_for_state(ID_A, SessionState::Active, TIMEOUT)
+        .unwrap();
+    let _ = read_local_packet(&mut terminal).unwrap();
+
+    // First returning client: complete handshake to ReturningClient, then
+    // stall without speaking recovery so the server is inside
+    // ActiveSession::recover / exchange_recovery.
+    let address = server.address;
+    let stall = thread::spawn(move || {
+        let mut stream = std::net::TcpStream::connect(address).unwrap();
+        runtime_support::bound(&stream);
+        write_proto(&mut stream, &client_request(ID_A)).unwrap();
+        let response: ConnectResponse = read_proto_limited(&mut stream, 64 * 1024).unwrap();
+        assert_eq!(response.status, Some(ConnectStatus::ReturningClient as i32));
+        // Hold the TCP connection open without speaking recovery.
+        thread::sleep(std::time::Duration::from_millis(500));
+        // Closing ends the server's stalled recover promptly.
+        drop(stream);
+    });
+
+    // Give the stalled recover a moment to enter ActiveSession::recover.
+    thread::sleep(std::time::Duration::from_millis(50));
+
+    // Second returning client must still be accepted promptly. We only assert
+    // the handshake (ReturningClient): the recovery body may return Busy while
+    // the first recover holds the flag, which is the behaviour under test.
+    let second_started = Instant::now();
+    let (second_stream, response) = server.handshake(ID_A);
+    assert_eq!(
+        response.status,
+        Some(ConnectStatus::ReturningClient as i32),
+        "second returning client must still receive ReturningClient promptly"
+    );
+    assert!(
+        second_started.elapsed() < std::time::Duration::from_secs(2),
+        "second ReturningClient took {:?} — accept path blocked behind recover",
+        second_started.elapsed()
+    );
+    drop(second_stream);
+
+    stall.join().unwrap();
+    // Allow the server recover worker to observe EOF and clear `recovering`.
+    thread::sleep(std::time::Duration::from_millis(100));
+
+    // A clean recover after the stall ends must still work on the shipped path.
+    let (returning, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::ReturningClient as i32));
+    client.recover(returning).unwrap();
+    client
+        .write_packet(TerminalPacketType::KeepAlive as u8, &[])
+        .unwrap();
+    client
+        .write_packet(TerminalPacketType::TerminalInfo as u8, b"post-concurrent")
+        .unwrap();
+    let forwarded = read_local_packet(&mut terminal).unwrap();
+    assert_eq!(forwarded.payload(), b"post-concurrent");
+    server.runtime.shutdown().unwrap();
+}
+
 #[test]
 fn keepalive_echo_acknowledges_everything_read_from_the_client() {
     let mut server = TestRuntime::start();

--- a/crates/et-server/tests/runtime_recovery.rs
+++ b/crates/et-server/tests/runtime_recovery.rs
@@ -350,13 +350,12 @@ fn concurrent_returning_recover_does_not_block_accept_path() {
     );
     // Either a fast ReturningClient (stall already finished) or a short-read /
     // error from the busy drop is acceptable; hanging is not.
-    match second_response {
-        Ok(response) => assert_eq!(
+    if let Ok(response) = second_response {
+        assert_eq!(
             response.status,
             Some(ConnectStatus::ReturningClient as i32),
             "unexpected ConnectStatus for concurrent recover: {response:?}"
-        ),
-        Err(_) => {}
+        );
     }
     drop(second_stream);
 

--- a/crates/et-server/tests/runtime_recovery.rs
+++ b/crates/et-server/tests/runtime_recovery.rs
@@ -334,21 +334,30 @@ fn concurrent_returning_recover_does_not_block_accept_path() {
     // Give the stalled recover a moment to enter ActiveSession::recover.
     thread::sleep(std::time::Duration::from_millis(50));
 
-    // Second returning client must still be accepted promptly. We only assert
-    // the handshake (ReturningClient): the recovery body may return Busy while
-    // the first recover holds the flag, which is the behaviour under test.
+    // Second returning client must finish promptly. While the first recover
+    // holds the single-flight permit the server drops the connection *without*
+    // ReturningClient so the peer retries instead of entering sequence exchange.
     let second_started = Instant::now();
-    let (second_stream, response) = server.handshake(ID_A);
-    assert_eq!(
-        response.status,
-        Some(ConnectStatus::ReturningClient as i32),
-        "second returning client must still receive ReturningClient promptly"
-    );
+    let mut second_stream = std::net::TcpStream::connect(server.address).unwrap();
+    runtime_support::bound(&second_stream);
+    write_proto(&mut second_stream, &client_request(ID_A)).unwrap();
+    let second_response: Result<ConnectResponse, _> =
+        read_proto_limited(&mut second_stream, 64 * 1024);
     assert!(
         second_started.elapsed() < std::time::Duration::from_secs(2),
-        "second ReturningClient took {:?} — accept path blocked behind recover",
+        "second reconnect attempt took {:?} — accept path blocked behind recover",
         second_started.elapsed()
     );
+    // Either a fast ReturningClient (stall already finished) or a short-read /
+    // error from the busy drop is acceptable; hanging is not.
+    match second_response {
+        Ok(response) => assert_eq!(
+            response.status,
+            Some(ConnectStatus::ReturningClient as i32),
+            "unexpected ConnectStatus for concurrent recover: {response:?}"
+        ),
+        Err(_) => {}
+    }
     drop(second_stream);
 
     stall.join().unwrap();


### PR DESCRIPTION
## Summary

Fixes the production hang where clients received `ReturningClient` then stalled with `ET bootstrap timed out while recovering ET session`.

**Root cause:** a blackholed client TCP path (peer stops reading without FIN/RST) made the terminal bridge block forever in `write_all` while holding `ActiveSession`'s connection mutex. Concurrent `recover()` calls queued for minutes after the status was already sent.

**Fix:**
1. Bound live writes with a 2s write timeout and soft-disconnect into the reconnect buffer (`DEFAULT_LIVE_WRITE_TIMEOUT`).
2. Acquire session locks for recover with a deadline (`lock_timeout`).
3. Single-flight recover via `recovering` flag (`SessionError::RecoverBusy` for concurrent attempts).

## Test plan

- [x] `cargo test -p et-net -p et-server` (all green)
- [x] New: `blackholed_peer_write_soft_disconnects_within_live_timeout` (et-net)
- [x] New: `recover_succeeds_while_old_peer_blackholes_writes` (et-server e2e path)
- [x] New: `concurrent_returning_recover_does_not_block_accept_path` (et-server)

## Evidence (from incident)

Server logged `returning client reconnect` repeatedly with no `session recover accepted/failed` for minutes, then a burst of `Broken pipe` on piled-up recoveries. Client logged `ET bootstrap timed out while recovering ET session`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a server hang where returning clients saw ReturningClient and then timed out with “ET bootstrap timed out while recovering ET session.” Live writes are now bounded, recovery handshakes run without the session lock, and recovery no longer blocks behind a blackholed client.

- **Bug Fixes**
  - `et-net`: Bound live frame writes with a 2s deadline loop (`DEFAULT_LIVE_WRITE_TIMEOUT`); on partial writes, shut down the socket and soft‑disconnect so output goes to the reconnect buffer; restore the write timeout afterward.
  - `et-server`: Made recovery single‑flight with a panic/drop‑safe `RecoverPermit`; take the permit before sending `ReturningClient` and drop concurrent attempts without a response so clients retry; run sequence exchange and peer auth without holding the connection mutex, queue terminal output in `recover_hold`, and flush it after installing the new stream; on flush error, put back the failed packet and remaining batch so no terminal output is lost; acquire session locks with a deadline (`RECOVERY_LOCK_TIMEOUT`).
  - Added regression tests for blackholed writes, recovery while the old peer is blackholed, and concurrent returning clients.

<sup>Written for commit 356a0af5d5ebc74e0e06ca3cad9f91318c70204c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

