### PR TITLE
Version Packages

### DIFF
--- a/.tegami/publish-lock.yaml
+++ b/.tegami/publish-lock.yaml
@@ -1,9 +1,9 @@
 core:changelogs:
-  - content: "---\npackages:\n  et:\n    type: patch\n---\n\n## Keep server sessions alive across client transport loss\n\n`etserver` now treats laptop sleep, Wi-Fi changes, and other client transport\nloss as a recoverable disconnect instead of terminating the registered\nterminal. Output produced while the client is away remains buffered, and a\nreturning client resumes the same shell without an `InvalidKey` failure.\n\nRecovery handoff now ignores stale events from the replaced socket, drains\npackets read during recovery authentication, and preserves port-forwarding\npackets when the replay buffer is temporarily full.\n"
-    filename: survive-client-disconnect.md
+  - content: "---\npackages:\n  et:\n    type: patch\n---\n\n## Unblock session recovery after blackholed client writes\n\n`etserver` no longer lets a blackholed client TCP path (peer stops reading\nwithout FIN/RST) hold the session connection mutex inside an unbounded\nsocket write. Live writes use a two-second deadline loop and soft-disconnect\n(with socket shutdown) into the reconnect buffer so partial frames cannot\ndesync a later recovery on a new stream. Session recovery runs sequence\nexchange and peer auth *without* holding the connection mutex (terminal\noutput is queued and flushed after install), uses a panic-safe single-flight\npermit (`RecoverPermit`), and only sends `ReturningClient` after that permit\nis held — concurrent recovers are dropped without a handshake so clients\nretry instead of burning a sequence-exchange timeout. Returning clients that\npreviously saw `ReturningClient` then hung with `ET bootstrap timed out while\nrecovering ET session` can complete recovery again.\n"
+    filename: recover-hang-write-timeout.md
     v: 0.0.0
 core:packages:
   - changelogIds:
-      - survive-client-disconnect.md
+      - recover-hang-write-timeout.md
     id: cargo:et
     updated: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "et"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "clap",
  "crossterm",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "et-cli"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "clap",
  "et-core",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "et-core"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "crypto_secretbox",
  "hex",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "et-htm"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "base64",
  "portable-pty",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "et-net"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "et-core",
  "prost",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "et-server"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "et-core",
  "et-net",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.11"
+version = "0.0.12"
 edition = "2021"
 rust-version = "1.97"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

| Package | From | To |
| --- | --- | --- |
| `et` | `0.0.11` | `0.0.12` |

## Changelog

### Unblock session recovery after blackholed client writes

`etserver` no longer lets a blackholed client TCP path hold the session connection mutex inside an unbounded socket write. Live writes use a two-second deadline loop and soft-disconnect; session recovery runs off-lock with a panic-safe single-flight permit and only sends `ReturningClient` after the permit is held.

## Test plan

- [x] Version bump only; CI + Release workflow will tag `et@0.0.12` and attach binaries after merge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `et` 0.0.12 to fix session recovery hangs caused by blackholed client writes. This prevents stuck writes from blocking the session and makes recovery reliable.

- **Bug Fixes**
  - Live writes use a 2s deadline loop and soft-disconnect into the reconnect buffer, so a peer that stops reading can’t hold the connection mutex or desync frames.
  - Recovery runs off-lock with a panic-safe single-flight permit; `ReturningClient` is sent only after the permit is held, avoiding concurrent recover races and resolving “ET bootstrap timed out while recovering ET session.”

<sup>Written for commit 3d8dbacc7aabd7af99810ab7940d2ff7c684856e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

