### PR TITLE
Add EternalTerminal factory pin, policy, and weekday watch

### DIFF
--- a/.github/upstream-pin.yml
+++ b/.github/upstream-pin.yml
@@ -1,0 +1,17 @@
+# Last *reviewed* MisterTea/EternalTerminal refs.
+# This is not a claim that et.rs has ported them.
+# Human record + FACTORY BACKLOG: docs/upstream-pin.md
+# Policy: docs/upstream-factory.md
+
+upstream_owner: MisterTea
+upstream_repo: EternalTerminal
+
+reviewed_release_tag: et-v7.0.0
+reviewed_release_sha: 7656a32a5bc15c6746726a27a5a4ba1e468fab6e
+reviewed_default_branch: master
+reviewed_default_branch_sha: b74a12efc567dbc1360ac0846f889c945a2eba60
+reviewed_date: "2026-08-21"
+
+# et.rs still claims protocol v6. ET product is v7.0.0; ET wire is still v6.
+et_rs_protocol_version: 6
+et_wire_protocol_version: 6

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -1,0 +1,80 @@
+name: Upstream watch
+
+on:
+  schedule:
+    # 09:30 KST weekdays (00:30 UTC).
+    - cron: "30 0 * * 1-5"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/upstream-pin.yml
+      - .github/workflows/upstream-watch.yml
+
+permissions:
+  contents: read
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compare EternalTerminal to pin
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          pin=".github/upstream-pin.yml"
+          pin_get() {
+            awk -F': *' -v k="$1" '$1 == k { gsub(/[" ]/, "", $2); print $2; exit }' "$pin"
+          }
+
+          owner="$(pin_get upstream_owner)"
+          repo="$(pin_get upstream_repo)"
+          pin_tag="$(pin_get reviewed_release_tag)"
+          pin_release_sha="$(pin_get reviewed_release_sha)"
+          pin_branch="$(pin_get reviewed_default_branch)"
+          pin_tip="$(pin_get reviewed_default_branch_sha)"
+
+          latest_tag="$(gh api "repos/${owner}/${repo}/releases/latest" --jq .tag_name)"
+          latest_release_sha="$(gh api "repos/${owner}/${repo}/commits/${latest_tag}" --jq .sha)"
+          default_branch="$(gh api "repos/${owner}/${repo}" --jq .default_branch)"
+          tip_sha="$(gh api "repos/${owner}/${repo}/commits/${default_branch}" --jq .sha)"
+
+          {
+            echo "## EternalTerminal vs pin"
+            echo
+            echo "| | pin | live |"
+            echo "| --- | --- | --- |"
+            echo "| release tag | \`${pin_tag}\` | \`${latest_tag}\` |"
+            echo "| release SHA | \`${pin_release_sha}\` | \`${latest_release_sha}\` |"
+            echo "| default branch | \`${pin_branch}\` | \`${default_branch}\` |"
+            echo "| default-branch SHA | \`${pin_tip}\` | \`${tip_sha}\` |"
+            echo
+            echo "Pin = last reviewed, not already ported. See docs/upstream-factory.md."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          drift=0
+          if [ "$latest_tag" != "$pin_tag" ]; then
+            echo "drift: latest release tag moved past pin ($pin_tag -> $latest_tag)"
+            drift=1
+          fi
+          if [ "$latest_release_sha" != "$pin_release_sha" ]; then
+            echo "drift: latest release SHA moved past pin ($pin_release_sha -> $latest_release_sha)"
+            drift=1
+          fi
+          if [ "$default_branch" != "$pin_branch" ]; then
+            echo "drift: default branch name changed ($pin_branch -> $default_branch)"
+            drift=1
+          fi
+          if [ "$tip_sha" != "$pin_tip" ]; then
+            echo "drift: default-branch tip moved past pin ($pin_tip -> $tip_sha)"
+            drift=1
+          fi
+
+          if [ "$drift" -ne 0 ]; then
+            echo "Upstream moved past the reviewed pin. Update .github/upstream-pin.yml after review." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "Pin still matches live EternalTerminal release + default-branch tip." >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ automatically reconnects without interrupting the session.
 
 Wire-compatible with upstream protocol version 6: an et.rs client can talk to a C++ `etserver`, and a
 C++ `et` client can talk to an et.rs server, in both terminal and port-forwarding modes.
+How we track upstream (Rust rewrite, not a C++ git fork): [docs/upstream-factory.md](docs/upstream-factory.md).
 
 Windows is a first-class target. Upstream builds only its client there, so hosting a session on
 Windows meant running the POSIX server inside WSL and landing in a WSL shell. et.rs runs the server

--- a/docs/upstream-factory.md
+++ b/docs/upstream-factory.md
@@ -1,0 +1,38 @@
+# Upstream factory
+
+et.rs is a **Rust rewrite** of [MisterTea/EternalTerminal](https://github.com/MisterTea/EternalTerminal).
+It is **not** a git fork. Never add a C++ merge remote, subtree, or vendor
+checkout that lands upstream trees into this repo.
+
+Machine pin (last *reviewed* refs, not “already ported”):
+[`.github/upstream-pin.yml`](../.github/upstream-pin.yml).
+Human record and FACTORY BACKLOG: [`docs/upstream-pin.md`](upstream-pin.md).
+
+## Shape
+
+1. **Watch** — weekday 09:30 KST (`30 0 * * 1-5` UTC) via
+   [`.github/workflows/upstream-watch.yml`](../.github/workflows/upstream-watch.yml).
+   The job asks GitHub REST (`gh api`) for ET’s latest release tag/SHA and
+   default-branch tip. If either moved past the pin, it writes a workflow
+   summary and exits nonzero. It does not open issues.
+2. **Review** — read the ET delta (protocol / wire / auth / security first).
+   Update the pin only after that review. Updating the pin is not a port.
+3. **Port** (later PRs) — reimplement in Rust. Gate is
+   `cargo test --workspace`, especially `fixtures/wire.json`. There is no GUI
+   gate. Do not bump `PROTOCOL_VERSION` unless the port is the coordinated
+   wire change.
+
+## Conflict policy
+
+| Area | Winner |
+| --- | --- |
+| Protocol, wire bytes, auth, security | **Upstream** |
+| Language / memory safety (`#![forbid(unsafe_code)]`) | **et.rs** |
+| Native Windows server (ConPTY, no WSL) | **et.rs** |
+| Telemetry | **et.rs** (`--telemetry` accepted, ignored) |
+| Busybox role dispatch (`argv[0]` → `et` / `etserver` / `etterminal` / `htm` / `htmd`) | **et.rs** |
+| Drop-in names (`et`, `etserver`) | **et.rs** |
+
+When a port would break an et.rs-kept row, keep the et.rs behavior and adapt
+the upstream idea around it (for example: same handshake bytes, ConPTY instead
+of a POSIX pty on Windows).

--- a/docs/upstream-pin.md
+++ b/docs/upstream-pin.md
@@ -1,0 +1,35 @@
+# Upstream pin
+
+**This pin is the last *reviewed* EternalTerminal snapshot. It does not mean
+et.rs has ported that snapshot.**
+
+Canonical machine file (the watch workflow reads this):
+[`.github/upstream-pin.yml`](../.github/upstream-pin.yml).
+
+Recorded 2026-08-21 from GitHub (`gh` / REST), not a scrape of private APIs.
+
+| Field | Value |
+| --- | --- |
+| Upstream | [MisterTea/EternalTerminal](https://github.com/MisterTea/EternalTerminal) |
+| Latest release tag | [`et-v7.0.0`](https://github.com/MisterTea/EternalTerminal/releases/tag/et-v7.0.0) |
+| Release commit | [`7656a32a5bc15c6746726a27a5a4ba1e468fab6e`](https://github.com/MisterTea/EternalTerminal/commit/7656a32a5bc15c6746726a27a5a4ba1e468fab6e) |
+| Default branch | `master` |
+| Default-branch tip | [`b74a12efc567dbc1360ac0846f889c945a2eba60`](https://github.com/MisterTea/EternalTerminal/commit/b74a12efc567dbc1360ac0846f889c945a2eba60) (`#788`, 2026-08-07) |
+| et.rs wire version | **protocol v6** (`PROTOCOL_VERSION = 6` in `crates/et-core/src/lib.rs`, README) |
+| ET wire version at this pin | still **protocol v6** (`PROTOCOL_VERSION = 6` in `src/base/Headers.hpp` on both `et-v7.0.0` and `master`) |
+
+## FACTORY BACKLOG (not in this PR)
+
+et.rs still claims **protocol v6**. EternalTerminal’s latest product release is
+**v7.0.0**, and `master` is several commits past that tag — including
+post-v7 security work. That gap is backlog. Do **not** treat this pin as a
+green light to bump `PROTOCOL_VERSION` or land a v7 port.
+
+Notable unported `master` work after `et-v7.0.0`:
+
+- [`69b3353`](https://github.com/MisterTea/EternalTerminal/commit/69b33537ab12f324cf619aca04dc483728dc30c3) (`#784`) — four pre-auth / privilege-escalation fixes (handshake size + absolute read deadlines; reconnect recover crash; unix-socket LPE). Upstream left reconnect passkey-before-recover for a future `PROTOCOL_VERSION` bump.
+- [`b74a12e`](https://github.com/MisterTea/EternalTerminal/commit/b74a12efc567dbc1360ac0846f889c945a2eba60) (`#788`) — keep the client alive when the console fd is not a tty.
+
+Review those against the conflict policy in
+[`docs/upstream-factory.md`](upstream-factory.md). Gate any later port with
+`cargo test --workspace` (especially `fixtures/wire.json`), not a GUI.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Factory scaffolding only. No protocol port, no `PROTOCOL_VERSION` bump, no telemetry, no C++ merge remote, no EternalTerminal checkout in this tree. Existing CI (`ci.yml`, `release.yml`) is unchanged.

## Pin (last reviewed, not already ported)

Looked up 2026-08-21 via GitHub REST:

| | Ref |
| --- | --- |
| Latest ET release | [`et-v7.0.0`](https://github.com/MisterTea/EternalTerminal/releases/tag/et-v7.0.0) @ [`7656a32a5bc15c6746726a27a5a4ba1e468fab6e`](https://github.com/MisterTea/EternalTerminal/commit/7656a32a5bc15c6746726a27a5a4ba1e468fab6e) |
| ET default-branch tip (`master`) | [`b74a12efc567dbc1360ac0846f889c945a2eba60`](https://github.com/MisterTea/EternalTerminal/commit/b74a12efc567dbc1360ac0846f889c945a2eba60) |

## Protocol gap (FACTORY BACKLOG — not implemented here)

- **et.rs still claims protocol v6** (`PROTOCOL_VERSION = 6` in `crates/et-core` and the README).
- **ET product is v7.0.0**; ET’s own wire `PROTOCOL_VERSION` is still 6 on both the v7.0.0 tag and `master`.
- `master` is past v7.0.0, including post-v7 security commit `#784` (`69b3353`). That is recorded as FACTORY BACKLOG in `docs/upstream-pin.md`. This PR does not port it.

## What landed

- `docs/upstream-factory.md` — factory shape, conflict policy (upstream wins protocol/wire/auth/security; et.rs keeps Rust/no-unsafe, Windows ConPTY server, ignored telemetry, busybox role names), weekday 09:30 KST watch, gate = `cargo test --workspace` / `fixtures/wire.json`.
- `.github/upstream-pin.yml` + `docs/upstream-pin.md` — reviewed refs + backlog.
- `.github/workflows/upstream-watch.yml` — weekday 09:30 KST (and `workflow_dispatch`). Uses `gh api` for latest release + default-branch SHA; workflow summary + nonzero exit on drift. Does not auto-open issues.
- README: one-line pointer to the factory doc.

Do not merge from this agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8779a338-dea4-4bda-8b71-08f0064acd1b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8779a338-dea4-4bda-8b71-08f0064acd1b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an upstream pin and weekday watch for EternalTerminal, plus policy docs, so we can track upstream changes without porting them yet. No protocol or wire changes; runtime behavior is unchanged except a new scheduled GitHub Action that fails when upstream moves past the recorded pin.

- Adds `.github/upstream-pin.yml` and `docs/upstream-pin.md` to record the last reviewed release/tag and default-branch SHA.
- Adds `.github/workflows/upstream-watch.yml` (weekdays 09:30 KST / 00:30 UTC and `workflow_dispatch`) that uses `gh api` to compare live upstream to the pin, writes a summary, and exits nonzero on drift. It does not open issues.
- Adds `docs/upstream-factory.md` with the conflict policy (upstream owns protocol/wire/auth/security; et.rs keeps Rust no-unsafe, native Windows ConPTY server, ignored telemetry, busybox role dispatch) and gate (`cargo test --workspace`, `fixtures/wire.json`). README links to this doc.
- No `PROTOCOL_VERSION` bump, no wire or telemetry changes, no C++ merge/checkout, and existing CI remains unchanged.

**Rollout**
- If the watch fails due to drift, review upstream and update `.github/upstream-pin.yml` after that review; do not treat a pin update as a port.

<sup>Written for commit 01542d89ff1601432b935a5f9cb3698021109534. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

