### PR TITLE
factory: ET commit ledger + unclassified-drift watch

### DIFF
--- a/.github/upstream-ledger.yml
+++ b/.github/upstream-ledger.yml
@@ -1,0 +1,79 @@
+# Machine ledger: every EternalTerminal master commit after baseline.
+# Unclassified SHA from compare(baseline...master) = drift.
+# Pin tip != ported. See docs/upstream-factory.md
+#
+# Schema (one map per commit; parseable without PyYAML):
+#   sha: 40-char hex
+#   date: YYYY-MM-DD
+#   kind: security | protocol | product | ci | docs | other
+#   status: skip | backlog | porting | ported
+#   note: short string
+#   et_pr: optional upstream PR number
+#
+# Classified 2026-08-22. Do not mark #784 ported here.
+
+baseline_sha: 7656a32a5bc15c6746726a27a5a4ba1e468fab6e
+classified: "2026-08-22"
+
+commits:
+  - sha: f6cf43707bde07eb6d11495586a35b9f2d64b032
+    date: "2026-07-08"
+    kind: ci
+    status: skip
+    note: "deployment fixes"
+  - sha: dfc75d6638c653249a2e4f6f1c27f665ca693420
+    date: "2026-07-09"
+    kind: ci
+    status: skip
+    note: "#771 cowbuilder"
+    et_pr: 771
+  - sha: 27a7db658e21ee9f9c1bff68db1c2cb241481b5e
+    date: "2026-07-10"
+    kind: ci
+    status: skip
+    note: "debian signing"
+  - sha: 3698116f764bc1868c179e4756eb0dabe7340827
+    date: "2026-07-10"
+    kind: ci
+    status: skip
+    note: "debian fix"
+  - sha: cd5b530d18affe7d77c290e3af8035700275cb51
+    date: "2026-07-12"
+    kind: ci
+    status: skip
+    note: "debian"
+  - sha: fb9ef1da67eb8e1cd1a30fdd9a4a5b6415e7a440
+    date: "2026-07-13"
+    kind: ci
+    status: skip
+    note: "debian deploy SSH"
+  - sha: 3dd946d7128ea98653bbbab2f454706aa66d9893
+    date: "2026-07-13"
+    kind: ci
+    status: skip
+    note: "#774 GCC 15"
+    et_pr: 774
+  - sha: 12889c5bfbf1ece81d45b4834f9b05254e723e1e
+    date: "2026-07-21"
+    kind: ci
+    status: skip
+    note: "#776 GCC-16 CI"
+    et_pr: 776
+  - sha: 90711ad421264db30dc5d05df4a37452b41a7667
+    date: "2026-07-21"
+    kind: ci
+    status: skip
+    note: "#777 windows deploy"
+    et_pr: 777
+  - sha: 69b33537ab12f324cf619aca04dc483728dc30c3
+    date: "2026-07-30"
+    kind: security
+    status: backlog
+    note: "#784 handshake 4KiB, recover, unix-socket LPE. Do not mark ported in this PR — a sibling port PR owns the code."
+    et_pr: 784
+  - sha: b74a12efc567dbc1360ac0846f889c945a2eba60
+    date: "2026-08-07"
+    kind: product
+    status: skip
+    note: "#788 non-tty console keep-alive; not wire/security"
+    et_pr: 788

--- a/.github/upstream-ledger.yml
+++ b/.github/upstream-ledger.yml
@@ -10,7 +10,7 @@
 #   note: short string
 #   et_pr: optional upstream PR number
 #
-# Classified 2026-08-22. Do not mark #784 ported here.
+# Classified 2026-08-22. #784 marked ported after et.rs #31 / 906a7ca.
 
 baseline_sha: 7656a32a5bc15c6746726a27a5a4ba1e468fab6e
 classified: "2026-08-22"
@@ -68,8 +68,8 @@ commits:
   - sha: 69b33537ab12f324cf619aca04dc483728dc30c3
     date: "2026-07-30"
     kind: security
-    status: backlog
-    note: "#784 handshake 4KiB, recover, unix-socket LPE. Do not mark ported in this PR — a sibling port PR owns the code."
+    status: ported
+    note: "#784 handshake 4KiB, recover, unix-socket LPE. Landed in et.rs via #31 / 906a7ca."
     et_pr: 784
   - sha: b74a12efc567dbc1360ac0846f889c945a2eba60
     date: "2026-08-07"

--- a/.github/upstream-pin.yml
+++ b/.github/upstream-pin.yml
@@ -1,6 +1,7 @@
 # Last *reviewed* MisterTea/EternalTerminal refs.
-# This is not a claim that et.rs has ported them.
-# Human record + FACTORY BACKLOG: docs/upstream-pin.md
+# This is not a claim that et.rs has ported them. Pin != ported.
+# Commit ledger (every master SHA after baseline): .github/upstream-ledger.yml
+# Human record: docs/upstream-pin.md
 # Policy: docs/upstream-factory.md
 
 upstream_owner: MisterTea

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -8,10 +8,13 @@ on:
   pull_request:
     paths:
       - .github/upstream-pin.yml
+      - .github/upstream-ledger.yml
       - .github/workflows/upstream-watch.yml
+      - scripts/check-upstream-ledger.py
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   watch:
@@ -19,62 +22,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Compare EternalTerminal to pin
+      - name: Check ledger schema
+        run: python3 scripts/check-upstream-ledger.py --self-test
+
+      - name: Compare EternalTerminal to pin + ledger
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          set -euo pipefail
-          pin=".github/upstream-pin.yml"
-          pin_get() {
-            awk -F': *' -v k="$1" '$1 == k { gsub(/[" ]/, "", $2); print $2; exit }' "$pin"
-          }
-
-          owner="$(pin_get upstream_owner)"
-          repo="$(pin_get upstream_repo)"
-          pin_tag="$(pin_get reviewed_release_tag)"
-          pin_release_sha="$(pin_get reviewed_release_sha)"
-          pin_branch="$(pin_get reviewed_default_branch)"
-          pin_tip="$(pin_get reviewed_default_branch_sha)"
-
-          latest_tag="$(gh api "repos/${owner}/${repo}/releases/latest" --jq .tag_name)"
-          latest_release_sha="$(gh api "repos/${owner}/${repo}/commits/${latest_tag}" --jq .sha)"
-          default_branch="$(gh api "repos/${owner}/${repo}" --jq .default_branch)"
-          tip_sha="$(gh api "repos/${owner}/${repo}/commits/${default_branch}" --jq .sha)"
-
-          {
-            echo "## EternalTerminal vs pin"
-            echo
-            echo "| | pin | live |"
-            echo "| --- | --- | --- |"
-            echo "| release tag | \`${pin_tag}\` | \`${latest_tag}\` |"
-            echo "| release SHA | \`${pin_release_sha}\` | \`${latest_release_sha}\` |"
-            echo "| default branch | \`${pin_branch}\` | \`${default_branch}\` |"
-            echo "| default-branch SHA | \`${pin_tip}\` | \`${tip_sha}\` |"
-            echo
-            echo "Pin = last reviewed, not already ported. See docs/upstream-factory.md."
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          drift=0
-          if [ "$latest_tag" != "$pin_tag" ]; then
-            echo "drift: latest release tag moved past pin ($pin_tag -> $latest_tag)"
-            drift=1
+          extra=()
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            extra+=(--file-issue)
           fi
-          if [ "$latest_release_sha" != "$pin_release_sha" ]; then
-            echo "drift: latest release SHA moved past pin ($pin_release_sha -> $latest_release_sha)"
-            drift=1
-          fi
-          if [ "$default_branch" != "$pin_branch" ]; then
-            echo "drift: default branch name changed ($pin_branch -> $default_branch)"
-            drift=1
-          fi
-          if [ "$tip_sha" != "$pin_tip" ]; then
-            echo "drift: default-branch tip moved past pin ($pin_tip -> $tip_sha)"
-            drift=1
-          fi
-
-          if [ "$drift" -ne 0 ]; then
-            echo "Upstream moved past the reviewed pin. Update .github/upstream-pin.yml after review." >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-
-          echo "Pin still matches live EternalTerminal release + default-branch tip." >> "$GITHUB_STEP_SUMMARY"
+          python3 scripts/check-upstream-ledger.py "${extra[@]}"

--- a/docs/upstream-factory.md
+++ b/docs/upstream-factory.md
@@ -19,7 +19,7 @@ This is a hybrid of three real rewrite factories — not a fourth invention:
 | --- | --- |
 | [`.github/upstream-pin.yml`](../.github/upstream-pin.yml) | Last reviewed release tag/SHA, default-branch **name**, protocol versions, last classified tip. **Pin ≠ ported.** |
 | [`.github/upstream-ledger.yml`](../.github/upstream-ledger.yml) | Every ET `master` commit after baseline `et-v7.0.0` / `7656a32a5bc15c6746726a27a5a4ba1e468fab6e`. |
-| [`docs/upstream-pin.md`](upstream-pin.md) | Human record of the pin and the current ledger. |
+| [`docs/upstream-pin.md`](upstream-pin.md) | Human record of the pin and the current ledger. `#784` / `69b3353` is `ported` (et.rs [#31](https://github.com/minpeter/et.rs/pull/31) / `906a7ca`). `#788` / `b74a12e` stays `skip`. |
 
 ## Shape
 

--- a/docs/upstream-factory.md
+++ b/docs/upstream-factory.md
@@ -1,26 +1,62 @@
 # Upstream factory
 
 et.rs is a **Rust rewrite** of [MisterTea/EternalTerminal](https://github.com/MisterTea/EternalTerminal).
-It is **not** a git fork. Never add a C++ merge remote, subtree, or vendor
-checkout that lands upstream trees into this repo.
+It is **not** a git fork and **not** an OpenUsage-style git-merge factory.
+Never add a C++ merge remote, subtree, or vendor checkout of
+MisterTea/EternalTerminal.
 
-Machine pin (last *reviewed* refs, not “already ported”):
-[`.github/upstream-pin.yml`](../.github/upstream-pin.yml).
-Human record and FACTORY BACKLOG: [`docs/upstream-pin.md`](upstream-pin.md).
+This is a hybrid of three real rewrite factories — not a fourth invention:
+
+| Pattern | What we take |
+| --- | --- |
+| **uutils/coreutils** | Pin the original and run its suite as the oracle. Here that is [`fixtures/wire.json`](../fixtures/wire.json) plus `cargo test --workspace`. |
+| **rustls BoGo** | Fixtures and interop are the contract. We never merge the other language tree. |
+| **Linux-stable** | Every upstream default-branch commit after a baseline is **classified** (`skip` / `backlog` / `porting` / `ported`). Unclassified = drift. |
+
+## Machine files
+
+| File | Role |
+| --- | --- |
+| [`.github/upstream-pin.yml`](../.github/upstream-pin.yml) | Last reviewed release tag/SHA, default-branch **name**, protocol versions, last classified tip. **Pin ≠ ported.** |
+| [`.github/upstream-ledger.yml`](../.github/upstream-ledger.yml) | Every ET `master` commit after baseline `et-v7.0.0` / `7656a32a5bc15c6746726a27a5a4ba1e468fab6e`. |
+| [`docs/upstream-pin.md`](upstream-pin.md) | Human record of the pin and the current ledger. |
 
 ## Shape
 
 1. **Watch** — weekday 09:30 KST (`30 0 * * 1-5` UTC) via
-   [`.github/workflows/upstream-watch.yml`](../.github/workflows/upstream-watch.yml).
-   The job asks GitHub REST (`gh api`) for ET’s latest release tag/SHA and
-   default-branch tip. If either moved past the pin, it writes a workflow
-   summary and exits nonzero. It does not open issues.
-2. **Review** — read the ET delta (protocol / wire / auth / security first).
-   Update the pin only after that review. Updating the pin is not a port.
+   [`.github/workflows/upstream-watch.yml`](../.github/workflows/upstream-watch.yml)
+   and [`scripts/check-upstream-ledger.py`](../scripts/check-upstream-ledger.py)
+   (`gh` + `python3` stdlib). The job:
+   1. Compares ET’s latest release tag/SHA and default-branch **name** to the pin.
+   2. Calls `gh api repos/MisterTea/EternalTerminal/compare/{baseline}...{master}`
+      (paginated). Every commit SHA in that compare **must** appear in the
+      ledger. Missing SHA = fail; the SHAs are listed in the step summary.
+   3. Classified-but-unported (`status: backlog` and kind `security` /
+      `protocol`) is visibility only — listed in the summary, does **not**
+      fail CI.
+   4. On unclassified drift, opens or updates a single issue titled
+      `upstream: unclassified ET master commits` (reuse if open). Needs
+      `issues: write`. Actions never auto-push ledger edits; a factory agent
+      classifies in a PR.
+2. **Classify** — for each new `master` commit, add a ledger row in a PR.
+   Bumping the pin tip to the last classified SHA is bookkeeping, not a port.
 3. **Port** (later PRs) — reimplement in Rust. Gate is
    `cargo test --workspace`, especially `fixtures/wire.json`. There is no GUI
    gate. Do not bump `PROTOCOL_VERSION` unless the port is the coordinated
    wire change.
+
+## Ledger schema
+
+Each commit after baseline (boring YAML, parsed without PyYAML):
+
+| Field | Values |
+| --- | --- |
+| `sha` | full 40-char hex |
+| `date` | `YYYY-MM-DD` |
+| `kind` | `security` \| `protocol` \| `product` \| `ci` \| `docs` \| `other` |
+| `status` | `skip` \| `backlog` \| `porting` \| `ported` |
+| `note` | short reason |
+| `et_pr` | optional upstream PR number |
 
 ## Conflict policy
 

--- a/docs/upstream-pin.md
+++ b/docs/upstream-pin.md
@@ -1,35 +1,57 @@
 # Upstream pin
 
 **This pin is the last *reviewed* EternalTerminal snapshot. It does not mean
-et.rs has ported that snapshot.**
+et.rs has ported that snapshot.** Pin ≠ ported.
 
-Canonical machine file (the watch workflow reads this):
-[`.github/upstream-pin.yml`](../.github/upstream-pin.yml).
+Canonical machine files:
 
-Recorded 2026-08-21 from GitHub (`gh` / REST), not a scrape of private APIs.
+- Pin (release tag/SHA, default-branch name, protocol versions, last classified tip):
+  [`.github/upstream-pin.yml`](../.github/upstream-pin.yml)
+- Ledger (every `master` commit after baseline):
+  [`.github/upstream-ledger.yml`](../.github/upstream-ledger.yml)
+
+Recorded 2026-08-21 from GitHub (`gh` / REST). Ledger classified 2026-08-22.
 
 | Field | Value |
 | --- | --- |
 | Upstream | [MisterTea/EternalTerminal](https://github.com/MisterTea/EternalTerminal) |
-| Latest release tag | [`et-v7.0.0`](https://github.com/MisterTea/EternalTerminal/releases/tag/et-v7.0.0) |
-| Release commit | [`7656a32a5bc15c6746726a27a5a4ba1e468fab6e`](https://github.com/MisterTea/EternalTerminal/commit/7656a32a5bc15c6746726a27a5a4ba1e468fab6e) |
+| Baseline / latest release tag | [`et-v7.0.0`](https://github.com/MisterTea/EternalTerminal/releases/tag/et-v7.0.0) |
+| Baseline / release commit | [`7656a32a5bc15c6746726a27a5a4ba1e468fab6e`](https://github.com/MisterTea/EternalTerminal/commit/7656a32a5bc15c6746726a27a5a4ba1e468fab6e) |
 | Default branch | `master` |
-| Default-branch tip | [`b74a12efc567dbc1360ac0846f889c945a2eba60`](https://github.com/MisterTea/EternalTerminal/commit/b74a12efc567dbc1360ac0846f889c945a2eba60) (`#788`, 2026-08-07) |
+| Pin tip (last classified) | [`b74a12efc567dbc1360ac0846f889c945a2eba60`](https://github.com/MisterTea/EternalTerminal/commit/b74a12efc567dbc1360ac0846f889c945a2eba60) (`#788`, 2026-08-07) |
 | et.rs wire version | **protocol v6** (`PROTOCOL_VERSION = 6` in `crates/et-core/src/lib.rs`, README) |
 | ET wire version at this pin | still **protocol v6** (`PROTOCOL_VERSION = 6` in `src/base/Headers.hpp` on both `et-v7.0.0` and `master`) |
 
-## FACTORY BACKLOG (not in this PR)
+`7656a32...master` is `ahead_by` 11. All 11 are classified. Unclassified would be drift.
+
+## Ledger (classified 2026-08-22)
+
+| sha | date | kind | status | note |
+| --- | --- | --- | --- | --- |
+| [`f6cf437`](https://github.com/MisterTea/EternalTerminal/commit/f6cf43707bde07eb6d11495586a35b9f2d64b032) | 2026-07-08 | ci | skip | deployment fixes |
+| [`dfc75d6`](https://github.com/MisterTea/EternalTerminal/commit/dfc75d6638c653249a2e4f6f1c27f665ca693420) | 2026-07-09 | ci | skip | #771 cowbuilder |
+| [`27a7db6`](https://github.com/MisterTea/EternalTerminal/commit/27a7db658e21ee9f9c1bff68db1c2cb241481b5e) | 2026-07-10 | ci | skip | debian signing |
+| [`3698116`](https://github.com/MisterTea/EternalTerminal/commit/3698116f764bc1868c179e4756eb0dabe7340827) | 2026-07-10 | ci | skip | debian fix |
+| [`cd5b530`](https://github.com/MisterTea/EternalTerminal/commit/cd5b530d18affe7d77c290e3af8035700275cb51) | 2026-07-12 | ci | skip | debian |
+| [`fb9ef1d`](https://github.com/MisterTea/EternalTerminal/commit/fb9ef1da67eb8e1cd1a30fdd9a4a5b6415e7a440) | 2026-07-13 | ci | skip | debian deploy SSH |
+| [`3dd946d`](https://github.com/MisterTea/EternalTerminal/commit/3dd946d7128ea98653bbbab2f454706aa66d9893) | 2026-07-13 | ci | skip | #774 GCC 15 |
+| [`12889c5`](https://github.com/MisterTea/EternalTerminal/commit/12889c5bfbf1ece81d45b4834f9b05254e723e1e) | 2026-07-21 | ci | skip | #776 GCC-16 CI |
+| [`90711ad`](https://github.com/MisterTea/EternalTerminal/commit/90711ad421264db30dc5d05df4a37452b41a7667) | 2026-07-21 | ci | skip | #777 windows deploy |
+| [`69b3353`](https://github.com/MisterTea/EternalTerminal/commit/69b33537ab12f324cf619aca04dc483728dc30c3) | 2026-07-30 | security | **backlog** | #784 handshake 4KiB, recover, unix-socket LPE |
+| [`b74a12e`](https://github.com/MisterTea/EternalTerminal/commit/b74a12efc567dbc1360ac0846f889c945a2eba60) | 2026-08-07 | product | skip | #788 non-tty console keep-alive; not wire/security |
+
+## FACTORY BACKLOG (not ported here)
 
 et.rs still claims **protocol v6**. EternalTerminal’s latest product release is
-**v7.0.0**, and `master` is several commits past that tag — including
+**v7.0.0**, and `master` is eleven classified commits past that tag — including
 post-v7 security work. That gap is backlog. Do **not** treat this pin as a
 green light to bump `PROTOCOL_VERSION` or land a v7 port.
 
-Notable unported `master` work after `et-v7.0.0`:
+[`69b3353`](https://github.com/MisterTea/EternalTerminal/commit/69b33537ab12f324cf619aca04dc483728dc30c3) (`#784`) stays `status: backlog`.
+A sibling port PR owns the Rust code. Do not mark it `ported` in a factory-only
+change. Upstream left reconnect passkey-before-recover for a future
+`PROTOCOL_VERSION` bump.
 
-- [`69b3353`](https://github.com/MisterTea/EternalTerminal/commit/69b33537ab12f324cf619aca04dc483728dc30c3) (`#784`) — four pre-auth / privilege-escalation fixes (handshake size + absolute read deadlines; reconnect recover crash; unix-socket LPE). Upstream left reconnect passkey-before-recover for a future `PROTOCOL_VERSION` bump.
-- [`b74a12e`](https://github.com/MisterTea/EternalTerminal/commit/b74a12efc567dbc1360ac0846f889c945a2eba60) (`#788`) — keep the client alive when the console fd is not a tty.
-
-Review those against the conflict policy in
+Review ports against the conflict policy in
 [`docs/upstream-factory.md`](upstream-factory.md). Gate any later port with
 `cargo test --workspace` (especially `fixtures/wire.json`), not a GUI.

--- a/scripts/check-upstream-ledger.py
+++ b/scripts/check-upstream-ledger.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""Watch EternalTerminal master against the pin + commit ledger.
+
+Stdlib only. Used by .github/workflows/upstream-watch.yml.
+
+Gates:
+  1. Latest release tag/SHA and default-branch *name* still match the pin.
+  2. Every SHA in compare(baseline...master) appears in the ledger.
+     Missing SHA = unclassified drift (fail + list).
+  3. status=backlog and kind in {security, protocol} is visibility only.
+
+Does not push ledger edits. Optional --file-issue opens or updates one
+ticket titled "upstream: unclassified ET master commits".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+KINDS = frozenset({"security", "protocol", "product", "ci", "docs", "other"})
+STATUSES = frozenset({"skip", "backlog", "porting", "ported"})
+WATCH_KINDS = frozenset({"security", "protocol"})
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+ISSUE_TITLE = "upstream: unclassified ET master commits"
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PIN = ROOT / ".github" / "upstream-pin.yml"
+DEFAULT_LEDGER = ROOT / ".github" / "upstream-ledger.yml"
+
+
+class LedgerError(Exception):
+    pass
+
+
+def unquote(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+
+def parse_pin(path: Path) -> dict[str, str]:
+    meta: dict[str, str] = {}
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        key = key.strip()
+        if key:
+            meta[key] = unquote(value)
+        else:
+            raise LedgerError(f"{path}:{lineno}: empty key")
+    return meta
+
+
+def parse_ledger(path: Path) -> tuple[dict[str, str], list[dict[str, str]]]:
+    meta: dict[str, str] = {}
+    commits: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("- "):
+            if current is not None:
+                commits.append(current)
+            rest = stripped[2:]
+            if ":" not in rest:
+                raise LedgerError(f"{path}:{lineno}: expected '- key: value'")
+            key, value = rest.split(":", 1)
+            current = {key.strip(): unquote(value)}
+            continue
+        if ":" not in stripped:
+            raise LedgerError(f"{path}:{lineno}: expected 'key: value'")
+        key, value = stripped.split(":", 1)
+        key, value = key.strip(), unquote(value)
+        if current is not None and line[:1].isspace():
+            current[key] = value
+        else:
+            if current is not None:
+                commits.append(current)
+                current = None
+            if key and key != "commits":
+                meta[key] = value
+    if current is not None:
+        commits.append(current)
+    return meta, commits
+
+
+def validate_commits(commits: list[dict[str, str]], origin: str) -> dict[str, dict[str, str]]:
+    by_sha: dict[str, dict[str, str]] = {}
+    for index, row in enumerate(commits, 1):
+        sha = row.get("sha", "").lower()
+        date = row.get("date", "")
+        kind = row.get("kind", "")
+        status = row.get("status", "")
+        note = row.get("note", "")
+        if not SHA_RE.match(sha):
+            raise LedgerError(f"{origin} #{index}: sha must be 40-char lowercase hex")
+        if not DATE_RE.match(date):
+            raise LedgerError(f"{origin} #{index}: date must be YYYY-MM-DD")
+        if kind not in KINDS:
+            raise LedgerError(f"{origin} #{index}: kind must be one of {sorted(KINDS)}")
+        if status not in STATUSES:
+            raise LedgerError(f"{origin} #{index}: status must be one of {sorted(STATUSES)}")
+        if not note:
+            raise LedgerError(f"{origin} #{index}: note is required")
+        if "et_pr" in row and row["et_pr"] and not row["et_pr"].isdigit():
+            raise LedgerError(f"{origin} #{index}: et_pr must be an integer")
+        if sha in by_sha:
+            raise LedgerError(f"{origin}: duplicate sha {sha}")
+        normalized = dict(row)
+        normalized["sha"] = sha
+        by_sha[sha] = normalized
+    return by_sha
+
+
+def gh_json(path: str) -> object:
+    env = os.environ.copy()
+    if "GH_TOKEN" not in env and "GITHUB_TOKEN" in env:
+        env["GH_TOKEN"] = env["GITHUB_TOKEN"]
+    result = subprocess.run(
+        ["gh", "api", path],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        raise LedgerError(f"gh api {path} failed: {result.stderr.strip() or result.stdout.strip()}")
+    return json.loads(result.stdout)
+
+
+def gh_run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if "GH_TOKEN" not in env and "GITHUB_TOKEN" in env:
+        env["GH_TOKEN"] = env["GITHUB_TOKEN"]
+    return subprocess.run(["gh", *args], check=False, capture_output=True, text=True, env=env)
+
+
+def compare_commits(owner: str, repo: str, baseline: str, head: str) -> tuple[list[dict[str, str]], int]:
+    first = gh_json(f"repos/{owner}/{repo}/compare/{baseline}...{head}?per_page=100&page=1")
+    if not isinstance(first, dict):
+        raise LedgerError("compare API returned a non-object")
+    ahead = int(first.get("ahead_by") or first.get("total_commits") or 0)
+    raw = list(first.get("commits") or [])
+    page = 2
+    while len(raw) < ahead:
+        data = gh_json(f"repos/{owner}/{repo}/compare/{baseline}...{head}?per_page=100&page={page}")
+        if not isinstance(data, dict):
+            break
+        batch = list(data.get("commits") or [])
+        existing = {row["sha"] for row in raw}
+        added = [row for row in batch if row.get("sha") not in existing]
+        if not added:
+            break
+        raw.extend(added)
+        page += 1
+        if page > 100:
+            break
+    if ahead > len(raw):
+        raw = walk_commits_after(owner, repo, head, baseline)
+        ahead = len(raw)
+    return [_commit_row(row) for row in raw], ahead
+
+
+def walk_commits_after(owner: str, repo: str, head: str, baseline: str) -> list[dict]:
+    out: list[dict] = []
+    page = 1
+    while page <= 100:
+        batch = gh_json(f"repos/{owner}/{repo}/commits?sha={head}&per_page=100&page={page}")
+        if not isinstance(batch, list) or not batch:
+            raise LedgerError(f"baseline {baseline} not found walking {head}")
+        for row in batch:
+            if row.get("sha") == baseline:
+                return out
+            out.append(row)
+        page += 1
+    raise LedgerError(f"gave up walking {head} before reaching baseline {baseline}")
+
+
+def _commit_row(row: dict) -> dict[str, str]:
+    commit = row.get("commit") or {}
+    author = commit.get("author") or {}
+    date = str(author.get("date") or "")[:10]
+    message = str((commit.get("message") or "")).split("\n", 1)[0]
+    return {"sha": row["sha"], "date": date, "message": message}
+
+
+def write_output(key: str, value: str) -> None:
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(f"{key}={value}\n")
+
+
+def write_summary(text: str) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        sys.stdout.write(text)
+        if not text.endswith("\n"):
+            sys.stdout.write("\n")
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(text)
+        if not text.endswith("\n"):
+            handle.write("\n")
+
+
+def md_table(headers: list[str], rows: list[list[str]]) -> str:
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    for row in rows:
+        lines.append("| " + " | ".join(row) + " |")
+    return "\n".join(lines)
+
+
+def this_repo() -> str:
+    return os.environ.get("GITHUB_REPOSITORY") or "minpeter/et.rs"
+
+
+def upsert_unclassified_issue(unclassified: list[dict[str, str]], baseline: str, head: str) -> None:
+    repo = this_repo()
+    rows = [
+        [
+            f"[`{row['sha']}`](https://github.com/MisterTea/EternalTerminal/commit/{row['sha']})",
+            row.get("date") or "",
+            (row.get("message") or "").replace("|", "\\|"),
+        ]
+        for row in unclassified
+    ]
+    body = "\n".join(
+        [
+            "## Unclassified EternalTerminal master commits",
+            "",
+            f"Watch compared `{baseline}...{head}` and these SHAs are missing from "
+            "`.github/upstream-ledger.yml`.",
+            "",
+            "Unclassified = drift. Classify in a PR. Actions must not auto-push ledger edits.",
+            "",
+            md_table(["sha", "date", "subject"], rows),
+            "",
+            "See `docs/upstream-factory.md`.",
+            "",
+        ]
+    )
+    listed = gh_run(
+        ["issue", "list", "--repo", repo, "--state", "open", "--limit", "50", "--json", "number,title"]
+    )
+    if listed.returncode != 0:
+        raise LedgerError(f"gh issue list failed: {listed.stderr.strip()}")
+    number = None
+    for issue in json.loads(listed.stdout or "[]"):
+        if issue.get("title") == ISSUE_TITLE:
+            number = issue.get("number")
+            break
+    if number is not None:
+        edited = gh_run(["issue", "edit", str(number), "--repo", repo, "--body", body])
+        if edited.returncode != 0:
+            raise LedgerError(f"gh issue edit failed: {edited.stderr.strip()}")
+        write_summary(f"\nUpdated issue #{number}: {ISSUE_TITLE}\n")
+        return
+    created = gh_run(["issue", "create", "--repo", repo, "--title", ISSUE_TITLE, "--body", body])
+    if created.returncode != 0:
+        raise LedgerError(f"gh issue create failed: {created.stderr.strip()}")
+    write_summary(f"\nOpened issue: {created.stdout.strip()}\n")
+
+
+def check(pin_path: Path, ledger_path: Path, file_issue: bool) -> int:
+    pin = parse_pin(pin_path)
+    ledger_meta, ledger_rows = parse_ledger(ledger_path)
+    by_sha = validate_commits(ledger_rows, str(ledger_path))
+
+    owner = pin["upstream_owner"]
+    repo = pin["upstream_repo"]
+    pin_tag = pin["reviewed_release_tag"]
+    pin_release_sha = pin["reviewed_release_sha"]
+    pin_branch = pin["reviewed_default_branch"]
+    pin_tip = pin.get("reviewed_default_branch_sha", "")
+    baseline = ledger_meta.get("baseline_sha") or pin_release_sha
+    if baseline != pin_release_sha:
+        raise LedgerError(
+            f"ledger baseline_sha {baseline} != pin reviewed_release_sha {pin_release_sha}"
+        )
+
+    latest_tag = gh_json(f"repos/{owner}/{repo}/releases/latest")["tag_name"]
+    latest_release_sha = gh_json(f"repos/{owner}/{repo}/commits/{latest_tag}")["sha"]
+    default_branch = gh_json(f"repos/{owner}/{repo}")["default_branch"]
+    tip_sha = gh_json(f"repos/{owner}/{repo}/commits/{default_branch}")["sha"]
+    compare_rows, ahead_by = compare_commits(owner, repo, baseline, default_branch)
+
+    unclassified = [row for row in compare_rows if row["sha"] not in by_sha]
+    extra = sorted(set(by_sha) - {row["sha"] for row in compare_rows})
+    backlog = [
+        by_sha[row["sha"]]
+        for row in compare_rows
+        if row["sha"] in by_sha
+        and by_sha[row["sha"]]["status"] == "backlog"
+        and by_sha[row["sha"]]["kind"] in WATCH_KINDS
+    ]
+
+    pin_rows = [
+        ["release tag", f"`{pin_tag}`", f"`{latest_tag}`"],
+        ["release SHA", f"`{pin_release_sha}`", f"`{latest_release_sha}`"],
+        ["default branch", f"`{pin_branch}`", f"`{default_branch}`"],
+        ["default-branch SHA (pin tip, last classified)", f"`{pin_tip}`", f"`{tip_sha}`"],
+        ["baseline (ledger)", f"`{baseline}`", f"ahead_by {ahead_by}"],
+    ]
+    summary = [
+        "## EternalTerminal vs pin + ledger",
+        "",
+        md_table(["", "pin / ledger", "live"], pin_rows),
+        "",
+        f"Compared `{baseline}...{default_branch}`: **{len(compare_rows)}** commits, "
+        f"**{len(unclassified)}** unclassified, **{len(by_sha)}** ledger rows.",
+        "",
+        "Pin = last reviewed / last classified tip, not already ported. "
+        "See docs/upstream-factory.md.",
+        "",
+    ]
+
+    if compare_rows:
+        classified_table = []
+        for row in compare_rows:
+            entry = by_sha.get(row["sha"])
+            if entry:
+                classified_table.append(
+                    [
+                        f"`{row['sha'][:12]}`",
+                        entry["kind"],
+                        entry["status"],
+                        entry["note"].replace("|", "\\|"),
+                    ]
+                )
+            else:
+                classified_table.append(
+                    [f"`{row['sha'][:12]}`", "—", "**unclassified**", row.get("message") or ""]
+                )
+        summary.extend(
+            [
+                "### Ledger vs compare",
+                "",
+                md_table(["sha", "kind", "status", "note"], classified_table),
+                "",
+            ]
+        )
+
+    if backlog:
+        summary.extend(
+            [
+                "### Classified but unported (visibility only; does not fail)",
+                "",
+                md_table(
+                    ["sha", "kind", "status", "note"],
+                    [
+                        [f"`{row['sha']}`", row["kind"], row["status"], row["note"].replace("|", "\\|")]
+                        for row in backlog
+                    ],
+                ),
+                "",
+            ]
+        )
+
+    if extra:
+        summary.extend(
+            [
+                "### Ledger SHAs not in compare (ignored)",
+                "",
+                *[f"- `{sha}`" for sha in extra],
+                "",
+            ]
+        )
+
+    drift = []
+    if latest_tag != pin_tag:
+        drift.append(f"latest release tag moved past pin ({pin_tag} -> {latest_tag})")
+    if latest_release_sha != pin_release_sha:
+        drift.append(f"latest release SHA moved past pin ({pin_release_sha} -> {latest_release_sha})")
+    if default_branch != pin_branch:
+        drift.append(f"default branch name changed ({pin_branch} -> {default_branch})")
+    if unclassified:
+        drift.append(f"{len(unclassified)} unclassified ET master commit(s)")
+        summary.extend(
+            [
+                "### Unclassified (fail)",
+                "",
+                *[f"- `{row['sha']}` {row.get('message') or ''}" for row in unclassified],
+                "",
+                "Update `.github/upstream-ledger.yml` in a PR. Do not auto-push ledger edits from Actions.",
+                "",
+            ]
+        )
+
+    write_summary("\n".join(summary))
+    write_output("unclassified", "true" if unclassified else "false")
+    write_output("unclassified_count", str(len(unclassified)))
+
+    if unclassified and file_issue:
+        upsert_unclassified_issue(unclassified, baseline, default_branch)
+
+    if drift:
+        for item in drift:
+            print(f"drift: {item}", file=sys.stderr)
+        return 1
+    write_summary(
+        "Release pin and default-branch name still match. "
+        "Every compare SHA is classified.\n"
+    )
+    return 0
+
+
+def self_test() -> int:
+    pin = """
+upstream_owner: MisterTea
+upstream_repo: EternalTerminal
+reviewed_release_tag: et-v7.0.0
+reviewed_release_sha: 7656a32a5bc15c6746726a27a5a4ba1e468fab6e
+reviewed_default_branch: master
+"""
+    ledger = """
+baseline_sha: 7656a32a5bc15c6746726a27a5a4ba1e468fab6e
+commits:
+  - sha: f6cf43707bde07eb6d11495586a35b9f2d64b032
+    date: "2026-07-08"
+    kind: ci
+    status: skip
+    note: "deployment fixes"
+  - sha: 69b33537ab12f324cf619aca04dc483728dc30c3
+    date: "2026-07-30"
+    kind: security
+    status: backlog
+    note: "#784 leftover"
+    et_pr: 784
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        pin_path = Path(tmp) / "pin.yml"
+        ledger_path = Path(tmp) / "ledger.yml"
+        pin_path.write_text(pin, encoding="utf-8")
+        ledger_path.write_text(ledger, encoding="utf-8")
+        parsed_pin = parse_pin(pin_path)
+        meta, rows = parse_ledger(ledger_path)
+        by_sha = validate_commits(rows, "self-test")
+        assert parsed_pin["reviewed_release_tag"] == "et-v7.0.0"
+        assert meta["baseline_sha"] == parsed_pin["reviewed_release_sha"]
+        assert by_sha["69b33537ab12f324cf619aca04dc483728dc30c3"]["status"] == "backlog"
+        assert by_sha["69b33537ab12f324cf619aca04dc483728dc30c3"]["et_pr"] == "784"
+
+        missing = [
+            row
+            for row in [
+                {"sha": "f6cf43707bde07eb6d11495586a35b9f2d64b032"},
+                {"sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+            ]
+            if row["sha"] not in by_sha
+        ]
+        assert [row["sha"] for row in missing] == ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+
+        try:
+            validate_commits(
+                [{"sha": "abc", "date": "2026-01-01", "kind": "ci", "status": "skip", "note": "x"}],
+                "bad",
+            )
+        except LedgerError:
+            pass
+        else:
+            raise AssertionError("short sha must fail")
+
+    real_meta, real_rows = parse_ledger(DEFAULT_LEDGER)
+    validate_commits(real_rows, str(DEFAULT_LEDGER))
+    real_pin = parse_pin(DEFAULT_PIN)
+    if real_meta.get("baseline_sha") != real_pin["reviewed_release_sha"]:
+        raise AssertionError("real ledger baseline != pin release sha")
+    print("self-test ok")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pin", type=Path, default=DEFAULT_PIN)
+    parser.add_argument("--ledger", type=Path, default=DEFAULT_LEDGER)
+    parser.add_argument(
+        "--file-issue",
+        action="store_true",
+        help="open or update the unclassified-drift issue (schedule/dispatch)",
+    )
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    try:
+        if args.self_test:
+            return self_test()
+        return check(args.pin, args.ledger, args.file_issue)
+    except (LedgerError, KeyError, json.JSONDecodeError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Upgrade the EternalTerminal watch from a single-SHA pin equality check into a **commit-port factory**. Not an OpenUsage git-merge factory. No C++ merge remote, subtree, or vendor of MisterTea/EternalTerminal. No `PROTOCOL_VERSION` bump.

Includes main at [`906a7ca`](https://github.com/minpeter/et.rs/commit/906a7ca86691f00a82f88b99b21d7afceb07bf97) ([#31](https://github.com/minpeter/et.rs/pull/31)). `#784` / `69b3353` is now `status: ported` in the ledger. `#788` / `b74a12e` stays `skip`.

## Pattern (hybrid of three real rewrite factories)

| Pattern | What we take |
| --- | --- |
| **uutils/coreutils** | Pin the original; run its suite as the oracle (`fixtures/wire.json` + `cargo test --workspace`). |
| **rustls BoGo** | Fixtures/interop are the contract. Never merge the other language tree. |
| **Linux-stable** | Every ET `master` commit after baseline is **classified** (`skip` / `backlog` / `porting` / `ported`). Unclassified = drift. |

## Machine files

- `.github/upstream-pin.yml` — kept for release tag/SHA, default-branch **name**, protocol versions, last classified tip. **Pin ≠ ported.** Tip stays `b74a12e`.
- `.github/upstream-ledger.yml` — every ET `master` commit after baseline `et-v7.0.0` / `7656a32a5bc15c6746726a27a5a4ba1e468fab6e`. Seeded with the reviewed 11 (`ahead_by` 11). `#784` is `security` / `ported` (landed in et.rs via #31 / 906a7ca).
- `scripts/check-upstream-ledger.py` — `gh` + `python3` stdlib. Parses the ledger without PyYAML.

## Watch gate (`.github/workflows/upstream-watch.yml`)

Still weekday 09:30 KST (`30 0 * * 1-5` UTC) + `workflow_dispatch`.

1. Compare latest release tag/SHA and default-branch **name** to the pin.
2. `gh api repos/MisterTea/EternalTerminal/compare/{baseline}...{master}` (paginated). Every compare SHA must appear in the ledger. Missing SHA = fail + list in the step summary.
3. Classified-but-unported (`status: backlog` and kind `security` / `protocol`) is visibility only — does **not** fail CI.
4. On unclassified drift (schedule / `workflow_dispatch`), open or update a single issue titled `upstream: unclassified ET master commits`. `issues: write`. Actions never auto-push ledger edits.
5. Trigger paths include the ledger file.

Docs rewritten: `docs/upstream-factory.md`, `docs/upstream-pin.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcefeef5-6ae5-4973-b859-b13d725af298?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcefeef5-6ae5-4973-b859-b13d725af298&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the upstream watch’s single-pin equality check with a commit-ledger gate that classifies every EternalTerminal `master` commit since `et-v7.0.0`. Previously, the watch failed only when the latest release or default-branch name/tip drifted; now it also fails if any compare SHA is unclassified, while classified `security`/`protocol` backlog is visibility-only.

- Adds `.github/upstream-ledger.yml` and `scripts/check-upstream-ledger.py` (stdlib + `gh`) to validate the ledger, call `compare {baseline}...{master}`, and list unclassified SHAs; never writes to the repo.
- Updates `.github/workflows/upstream-watch.yml` to run the schema self-test, enforce ledger coverage, and on schedule/dispatch open or update a single issue titled “upstream: unclassified ET master commits”; grants `issues: write` and triggers include the ledger file.
- Keeps the pin in `.github/upstream-pin.yml` as “last reviewed,” not “ported,” and requires the ledger `baseline_sha` to equal the pin’s release SHA; docs detail the factory pattern.
- Marks upstream `#784` as `ported`; `#788` remains `skip`. No `PROTOCOL_VERSION` change.
- Required action: when ET `master` advances, add ledger rows in a PR and (optionally) bump the pin tip to the last classified SHA; do not auto-push ledger edits from Actions and keep ports in separate PRs.

<sup>Written for commit 81eb6a89774ca45a99b4ad0e320a4c30e0875c3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

