### PR TITLE
port: ET #784 handshake cap, recover, unix-socket LPE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,7 @@ name = "et-net"
 version = "0.0.12"
 dependencies = [
  "et-core",
+ "nix 0.31.3",
  "prost",
  "rustix",
  "socket2",

--- a/crates/et-bin/CHANGELOG.md
+++ b/crates/et-bin/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## et@0.0.12
 
+### Port EternalTerminal #784 pre-auth / LPE fixes
+
+Handshake protos are now capped at 4 KiB (was 64 KiB), matching ET
+`MAX_HANDSHAKE_PROTO_LENGTH`. Length-prefixed reads enforce both an idle
+gap and an absolute deadline so a slow trickle cannot reset the timer
+forever. Failed reconnect recover no longer disconnects the live victim
+session before recover succeeds. When `etserver` is root, UNIX listen and
+connect on client-chosen paths drop to the session user (helper +
+`SCM_RIGHTS`) instead of unlink/bind/chown/connect as root. Reconnect
+passkey-before-recover is still omitted: that needs a `PROTOCOL_VERSION`
+bump.
+
 ### Unblock session recovery after blackholed client writes
 
 `etserver` no longer lets a blackholed client TCP path (peer stops reading

--- a/crates/et-bin/src/initial_connect.rs
+++ b/crates/et-bin/src/initial_connect.rs
@@ -8,7 +8,7 @@ use et_core::proto::{
 };
 use et_net::connection::Connection;
 use et_net::framing_io::{read_proto_limited, write_proto};
-use et_net::handshake::client_request;
+use et_net::handshake::{client_request, MAX_HANDSHAKE_PROTO_LEN};
 use prost::Message;
 
 use crate::bootstrap::Credentials;
@@ -16,7 +16,6 @@ use crate::deadline::Deadline;
 use crate::error::ClientError;
 use crate::resolver::EndpointResolver;
 
-const MAX_HANDSHAKE_PROTO_LEN: i64 = 64 * 1024;
 const MAX_ENDPOINT_ADDRESSES: usize = 16;
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 const IO_TIMEOUT: Duration = Duration::from_secs(10);

--- a/crates/et-bin/src/main.rs
+++ b/crates/et-bin/src/main.rs
@@ -16,6 +16,10 @@
 use std::ffi::OsString;
 
 fn main() {
+    #[cfg(unix)]
+    if let Some(code) = et_net::user_socket_ops::maybe_run_helper() {
+        std::process::exit(code);
+    }
     let argv: Vec<OsString> = std::env::args_os().collect();
     let prog = argv
         .first()

--- a/crates/et-bin/src/terminal_jump.rs
+++ b/crates/et-bin/src/terminal_jump.rs
@@ -19,7 +19,7 @@ use et_core::proto::{
 };
 use et_net::connection::Connection;
 use et_net::framing_io::{read_proto_limited, write_proto};
-use et_net::handshake::client_request;
+use et_net::handshake::{client_request, MAX_HANDSHAKE_PROTO_LEN};
 use et_net::local_packet::{write_local_packet, LocalPacketDecoder};
 use prost::Message;
 #[cfg(unix)]
@@ -27,7 +27,6 @@ use rustix::event::{poll, PollFd, PollFlags};
 
 use crate::terminal_credentials::CredentialInput;
 
-const MAX_HANDSHAKE_PROTO_LEN: i64 = 64 * 1024;
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 const READ_BUFFER: usize = 16 * 1024;
 /// Upstream retries the destination connection three times before failing.

--- a/crates/et-net/Cargo.toml
+++ b/crates/et-net/Cargo.toml
@@ -16,3 +16,11 @@ et-core = { path = "../et-core" }
 prost = "0.13"
 rustix = { version = "1.1.4", features = ["event"] }
 socket2 = "0.6.1"
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31.3", default-features = false, features = ["user"] }
+rustix = { version = "1.1.4", features = ["event", "fs", "net", "process"] }
+
+[[bin]]
+name = "et-user-socket-helper"
+path = "src/bin/et_user_socket_helper.rs"

--- a/crates/et-net/src/bin/et_user_socket_helper.rs
+++ b/crates/et-net/src/bin/et_user_socket_helper.rs
@@ -1,0 +1,11 @@
+#![forbid(unsafe_code)]
+
+fn main() {
+    #[cfg(unix)]
+    std::process::exit(et_net::user_socket_ops::run_helper());
+    #[cfg(not(unix))]
+    {
+        eprintln!("et-user-socket-helper is Unix-only");
+        std::process::exit(2);
+    }
+}

--- a/crates/et-net/src/connection_recovery.rs
+++ b/crates/et-net/src/connection_recovery.rs
@@ -12,10 +12,10 @@ use super::{ConnError, Connection};
 use crate::framing_io::{
     read_frame_limited_deadline, read_proto_limited_deadline, write_proto_limited_deadline,
 };
+use crate::handshake::MAX_HANDSHAKE_PROTO_LEN;
 
 pub const MAX_RECOVERY_PROTO_LEN: i64 = 80 * 1024 * 1024;
 pub const DEFAULT_RECOVERY_TIMEOUT: Duration = Duration::from_secs(10);
-const MAX_RECOVERY_HEADER_LEN: i64 = 64 * 1024;
 
 impl Connection {
     pub fn recover(&mut self, new_stream: TcpStream) -> Result<(), ConnError> {
@@ -98,11 +98,11 @@ impl Connection {
             &SequenceHeader {
                 sequence_number: Some(wire_sequence),
             },
-            MAX_RECOVERY_HEADER_LEN,
+            MAX_HANDSHAKE_PROTO_LEN,
             deadline,
         )?;
         let remote: SequenceHeader =
-            read_proto_limited_deadline(&mut stream, MAX_RECOVERY_HEADER_LEN, deadline)?;
+            read_proto_limited_deadline(&mut stream, MAX_HANDSHAKE_PROTO_LEN, deadline)?;
         let remote_sequence = match remote.sequence_number {
             Some(sequence) if sequence >= 0 => i64::from(sequence),
             value => return Err(ConnError::InvalidRecoverySequence(value)),

--- a/crates/et-net/src/forward.rs
+++ b/crates/et-net/src/forward.rs
@@ -65,13 +65,14 @@ impl Forwarder {
     /// Bind all forwarding sources and return the forwarder together with the
     /// environment variables created for named-pipe requests, mirroring the
     /// upstream server (`PortForwardHandler::createSource` +
-    /// `TerminalServer::runTerminal`). `owner` is the terminal user that
-    /// created pipes are chowned to.
+    /// `TerminalServer::runTerminal`). `owner` is the session user: UNIX
+    /// listen/connect drop to that user (ET #784).
     pub fn start_with_user(
         sources: Vec<PortForwardSourceRequest>,
         owner: Option<(u32, u32)>,
     ) -> Result<(Self, ForwardEnvironment), ForwardError> {
         let (sources, environment) = bind_sources(sources, owner)?;
+        let session_user = owner;
         let (commands_tx, commands_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
         let (outbound_tx, outbound_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
         #[cfg(unix)]
@@ -98,6 +99,7 @@ impl Forwarder {
                     #[cfg(unix)]
                     wake_writer,
                     listener_stop_reader,
+                    session_user,
                 );
                 #[cfg(unix)]
                 drop(listener_stop);
@@ -218,8 +220,9 @@ fn bind_sources(
             #[cfg(unix)]
             {
                 let path = create_forward_pipe(owner)?;
-                let mut listeners = Endpoint::Unix(path.clone()).bind()?;
-                apply_pipe_ownership(&path, owner)?;
+                // Bind as the session user (ET #784). Do not chmod/chown the
+                // client-visible socket path as root after bind.
+                let mut listeners = Endpoint::Unix(path.clone()).bind_with_user(owner)?;
                 environment.push((variable, path.to_string_lossy().into_owned()));
                 for mut listener in listeners.drain(..) {
                     if let Some(directory) = path.parent() {
@@ -241,7 +244,7 @@ fn bind_sources(
             }
         }
         let source = Endpoint::parse(request.source)?;
-        for listener in source.bind()? {
+        for listener in source.bind_with_user(owner)? {
             bound.push(BoundSource {
                 listener,
                 destination: destination.clone(),
@@ -266,20 +269,6 @@ fn create_forward_pipe(owner: Option<(u32, u32)>) -> Result<std::path::PathBuf, 
         std::os::unix::fs::chown(&directory, Some(uid), Some(gid)).map_err(ForwardError::Io)?;
     }
     Ok(directory.join("sock"))
-}
-
-#[cfg(unix)]
-fn apply_pipe_ownership(
-    path: &std::path::Path,
-    owner: Option<(u32, u32)>,
-) -> Result<(), ForwardError> {
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
-        .map_err(ForwardError::Io)?;
-    if let Some((uid, gid)) = owner {
-        std::os::unix::fs::chown(path, Some(uid), Some(gid)).map_err(ForwardError::Io)?;
-    }
-    Ok(())
 }
 
 #[cfg(unix)]

--- a/crates/et-net/src/forward_endpoint.rs
+++ b/crates/et-net/src/forward_endpoint.rs
@@ -115,6 +115,17 @@ impl Endpoint {
         }
     }
 
+    pub(crate) fn connect_with_user(&self, user: Option<(u32, u32)>) -> io::Result<ForwardStream> {
+        match (self, user) {
+            #[cfg(unix)]
+            (Self::Unix(path), Some((uid, gid))) => {
+                crate::user_socket_ops::connect_unix_as_user(path, uid, gid)
+                    .map(ForwardStream::Unix)
+            }
+            _ => self.connect(),
+        }
+    }
+
     pub(crate) fn connect(&self) -> io::Result<ForwardStream> {
         match self {
             Self::Tcp { host, port } => {
@@ -145,6 +156,25 @@ impl Endpoint {
             }
             #[cfg(unix)]
             Self::Unix(path) => UnixStream::connect(path).map(ForwardStream::Unix),
+        }
+    }
+
+    pub(crate) fn bind_with_user(
+        &self,
+        user: Option<(u32, u32)>,
+    ) -> io::Result<Vec<ForwardListener>> {
+        match (self, user) {
+            #[cfg(unix)]
+            (Self::Unix(path), Some((uid, gid))) => {
+                let listener = crate::user_socket_ops::listen_unix_as_user(path, uid, gid)?;
+                listener.set_nonblocking(true)?;
+                Ok(vec![ForwardListener {
+                    inner: ListenerKind::Unix(listener),
+                    cleanup: Some(path.clone()),
+                    cleanup_dir: None,
+                }])
+            }
+            _ => self.bind(),
         }
     }
 

--- a/crates/et-net/src/forward_io.rs
+++ b/crates/et-net/src/forward_io.rs
@@ -126,9 +126,10 @@ pub(crate) fn spawn_connector(
     socket_id: i32,
     destination: Endpoint,
     commands: mpsc::SyncSender<Command>,
+    session_user: Option<(u32, u32)>,
 ) -> JoinHandle<()> {
     thread::spawn(move || {
-        let result = destination.connect();
+        let result = destination.connect_with_user(session_user);
         let _ = commands.send(Command::Connected {
             client_fd,
             socket_id,

--- a/crates/et-net/src/forward_worker.rs
+++ b/crates/et-net/src/forward_worker.rs
@@ -62,6 +62,7 @@ pub(crate) fn run(
     outbound: mpsc::SyncSender<Outbound>,
     #[cfg(unix)] mut outbound_wake: UnixStream,
     listener_stop: ListenerStop,
+    session_user: Option<(u32, u32)>,
 ) {
     #[cfg(unix)]
     let result = Worker::new(
@@ -69,10 +70,10 @@ pub(crate) fn run(
         outbound.clone(),
         outbound_wake.try_clone().ok(),
     )
-    .and_then(|mut worker| worker.run(sources, commands, listener_stop));
+    .and_then(|mut worker| worker.run(sources, commands, listener_stop, session_user));
     #[cfg(windows)]
     let result = Worker::new(command_sender, outbound.clone())
-        .and_then(|mut worker| worker.run(sources, commands, listener_stop));
+        .and_then(|mut worker| worker.run(sources, commands, listener_stop, session_user));
     if let Err(error) = result {
         let _ = outbound.send(Err(error));
         #[cfg(unix)]
@@ -90,6 +91,7 @@ struct Worker {
     destinations: HashMap<i32, ActiveIo>,
     threads: Vec<JoinHandle<()>>,
     next_socket_id: i32,
+    session_user: Option<(u32, u32)>,
 }
 
 impl Worker {
@@ -114,6 +116,7 @@ impl Worker {
             destinations: HashMap::new(),
             threads: Vec::new(),
             next_socket_id: 1,
+            session_user: None,
         })
     }
 
@@ -122,7 +125,9 @@ impl Worker {
         sources: Vec<BoundSource>,
         commands: mpsc::Receiver<Command>,
         listener_stop: ListenerStop,
+        session_user: Option<(u32, u32)>,
     ) -> Result<(), ForwardError> {
+        self.session_user = session_user;
         let next_client_fd = Arc::new(AtomicI32::new(1));
         for source in sources {
             #[cfg(unix)]

--- a/crates/et-net/src/forward_worker_state.rs
+++ b/crates/et-net/src/forward_worker_state.rs
@@ -109,6 +109,7 @@ impl Worker {
             socket_id,
             destination,
             self.commands.clone(),
+            self.session_user,
         ));
         Ok(())
     }

--- a/crates/et-net/src/framing_io.rs
+++ b/crates/et-net/src/framing_io.rs
@@ -275,9 +275,8 @@ mod tests {
         let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let trickle_stop = stop.clone();
         let writer = thread::spawn(move || {
-            let byte = [b'x'];
             while !trickle_stop.load(std::sync::atomic::Ordering::Relaxed) {
-                if client.write_all(&byte).is_err() {
+                if client.write_all(b"x").is_err() {
                     return;
                 }
                 thread::sleep(Duration::from_millis(80));

--- a/crates/et-net/src/framing_io.rs
+++ b/crates/et-net/src/framing_io.rs
@@ -1,9 +1,17 @@
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use et_core::framing::MAX_PROTO_LEN;
 use prost::Message;
+
+/// Idle-gap timeout used by [`read_exact_with_deadlines`] when the caller
+/// asks for EternalTerminal `readAll(..., true)` behavior. Progress resets
+/// this timer; a slow trickle can keep it from firing.
+pub const SOCKET_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+/// Absolute read deadline used with [`SOCKET_IDLE_TIMEOUT`]. Unlike the idle
+/// timeout, this is never reset when bytes arrive (ANT-2026-5PETM5BV).
+pub const SOCKET_ABSOLUTE_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub fn write_proto<W: Write, M: Message>(writer: &mut W, message: &M) -> io::Result<()> {
     write_proto_limited(writer, message, MAX_PROTO_LEN)
@@ -105,15 +113,56 @@ pub fn read_frame_limited_deadline(
 
 fn read_exact_deadline(
     stream: &mut TcpStream,
-    mut buffer: &mut [u8],
+    buffer: &mut [u8],
     deadline: Instant,
 ) -> io::Result<()> {
+    read_exact_with_deadlines(stream, buffer, Some(SOCKET_IDLE_TIMEOUT), Some(deadline))
+}
+
+/// Read exactly `buffer.len()` bytes, enforcing an idle-gap timeout and/or an
+/// absolute deadline on every loop iteration so a slow trickle cannot reset
+/// the timer forever (EternalTerminal #784 / ANT-2026-5PETM5BV).
+pub fn read_exact_with_deadlines(
+    stream: &mut TcpStream,
+    mut buffer: &mut [u8],
+    idle: Option<Duration>,
+    absolute: Option<Instant>,
+) -> io::Result<()> {
+    let mut idle_deadline = idle.and_then(|idle| Instant::now().checked_add(idle));
     while !buffer.is_empty() {
-        set_deadline_timeout(stream, deadline)?;
+        let now = Instant::now();
+        if idle_deadline.is_some_and(|idle| now >= idle)
+            || absolute.is_some_and(|absolute| now >= absolute)
+        {
+            return Err(io::Error::new(io::ErrorKind::TimedOut, "socket timeout"));
+        }
+        let next = match (idle_deadline, absolute) {
+            (Some(idle), Some(absolute)) => Some(idle.min(absolute)),
+            (Some(idle), None) => Some(idle),
+            (None, Some(absolute)) => Some(absolute),
+            (None, None) => None,
+        };
+        if let Some(next) = next {
+            set_deadline_timeout(stream, next)?;
+        }
         match stream.read(buffer) {
             Ok(0) => return Err(io::ErrorKind::UnexpectedEof.into()),
-            Ok(count) => buffer = &mut buffer[count..],
+            Ok(count) => {
+                buffer = &mut buffer[count..];
+                idle_deadline = idle.and_then(|idle| Instant::now().checked_add(idle));
+            }
             Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error)
+                if next.is_some()
+                    && matches!(
+                        error.kind(),
+                        io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+                    ) =>
+            {
+                // SO_RCVTIMEO and non-blocking reads surface as WouldBlock /
+                // TimedOut. Recheck Instant deadlines on the next iteration
+                // so a trickle cannot reset the absolute timer (ET #784).
+            }
             Err(error) => return Err(error),
         }
     }
@@ -215,6 +264,44 @@ mod tests {
         ));
         assert!(started.elapsed() < Duration::from_millis(200));
         release_tx.send(()).unwrap();
+        writer.join().unwrap();
+    }
+
+    #[test]
+    fn absolute_deadline_fires_under_per_byte_trickle() {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let mut client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (mut server, _) = listener.accept().unwrap();
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let trickle_stop = stop.clone();
+        let writer = thread::spawn(move || {
+            let byte = [b'x'];
+            while !trickle_stop.load(std::sync::atomic::Ordering::Relaxed) {
+                if client.write_all(&byte).is_err() {
+                    return;
+                }
+                thread::sleep(Duration::from_millis(80));
+            }
+        });
+        let started = Instant::now();
+        let mut buffer = [0u8; 256];
+        let error = read_exact_with_deadlines(
+            &mut server,
+            &mut buffer,
+            Some(Duration::from_secs(30)),
+            Some(Instant::now() + Duration::from_millis(400)),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error.kind(),
+            io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+        ));
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "absolute deadline waited {:?}; trickle reset the idle timer",
+            started.elapsed()
+        );
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
         writer.join().unwrap();
     }
 }

--- a/crates/et-net/src/handshake.rs
+++ b/crates/et-net/src/handshake.rs
@@ -11,7 +11,11 @@ use et_core::PROTOCOL_VERSION;
 
 use crate::framing_io::{read_proto_limited, write_proto};
 
-const MAX_HANDSHAKE_PROTO_LEN: i64 = 64 * 1024;
+/// Max length for pre-auth / handshake protos (ConnectRequest, ConnectResponse,
+/// SequenceHeader). Matches EternalTerminal `MAX_HANDSHAKE_PROTO_LENGTH` from
+/// #784 (ANT-2026-5PETM5BV): a large declared length would pin memory on a
+/// handler thread before any auth.
+pub const MAX_HANDSHAKE_PROTO_LEN: i64 = 4 * 1024;
 pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub fn client_request(client_id: &str) -> ConnectRequest {
@@ -89,9 +93,14 @@ mod tests {
 
     #[test]
     fn oversized_request_is_rejected_before_allocation() {
-        let frame = (65_537i64).to_le_bytes();
-        let error = read_request(&mut Cursor::new(frame)).unwrap_err();
-        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        for length in [
+            MAX_HANDSHAKE_PROTO_LEN + 1,
+            64 * 1024 + 1,
+            128 * 1024 * 1024,
+        ] {
+            let error = read_request(&mut Cursor::new(length.to_le_bytes())).unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        }
     }
 
     #[test]

--- a/crates/et-net/src/lib.rs
+++ b/crates/et-net/src/lib.rs
@@ -15,3 +15,5 @@ pub mod handshake;
 pub mod listener;
 pub mod local;
 pub mod local_packet;
+#[cfg(unix)]
+pub mod user_socket_ops;

--- a/crates/et-net/src/user_socket_ops.rs
+++ b/crates/et-net/src/user_socket_ops.rs
@@ -56,9 +56,7 @@ impl Op {
 /// Run the helper if this process was spawned by [`listen_unix_as_user`] or
 /// [`connect_unix_as_user`]. Returns `Some(exit_code)` when handled.
 pub fn maybe_run_helper() -> Option<i32> {
-    if std::env::var_os(OP_ENV).is_none() {
-        return None;
-    }
+    std::env::var_os(OP_ENV)?;
     Some(run_helper())
 }
 

--- a/crates/et-net/src/user_socket_ops.rs
+++ b/crates/et-net/src/user_socket_ops.rs
@@ -1,0 +1,506 @@
+//! Privilege-dropped UNIX listen/connect, porting EternalTerminal #784
+//! `UserSocketOps` (ANT-2026-AVTT7HQH / ANT-2026-A3WQS3AG).
+//!
+//! etserver is multithreaded and must not `seteuid` in-process. Upstream
+//! forks, then `setgroups`/`setgid`/`setuid` to the session user, and
+//! returns the fd via `SCM_RIGHTS`. et.rs cannot call `fork` (that API is
+//! `unsafe`); it re-execs a helper, drops with [`nix`] in that
+//! single-threaded process, and uses the same fd-passing protocol.
+
+use std::fs;
+use std::io::{self, IoSlice, IoSliceMut};
+use std::mem::MaybeUninit;
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use rustix::net::{
+    recvmsg, sendmsg, RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags, SendAncillaryBuffer,
+    SendAncillaryMessage, SendFlags,
+};
+
+const OP_ENV: &str = "ET_RS_USER_SOCKET_OP";
+const PATH_ENV: &str = "ET_RS_USER_SOCKET_PATH";
+const UID_ENV: &str = "ET_RS_USER_SOCKET_UID";
+const GID_ENV: &str = "ET_RS_USER_SOCKET_GID";
+const HELPER_ENV: &str = "ET_RS_USER_SOCKET_HELPER";
+const HELPER_NAME: &str = "et-user-socket-helper";
+/// `sockaddr_un.sun_path` on Linux, including the trailing NUL.
+const UNIX_PATH_MAX: usize = 108;
+
+#[derive(Clone, Copy)]
+enum Op {
+    Listen,
+    Connect,
+}
+
+impl Op {
+    fn as_env(self) -> &'static str {
+        match self {
+            Self::Listen => "listen",
+            Self::Connect => "connect",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "listen" => Some(Self::Listen),
+            "connect" => Some(Self::Connect),
+            _ => None,
+        }
+    }
+}
+
+/// Run the helper if this process was spawned by [`listen_unix_as_user`] or
+/// [`connect_unix_as_user`]. Returns `Some(exit_code)` when handled.
+pub fn maybe_run_helper() -> Option<i32> {
+    if std::env::var_os(OP_ENV).is_none() {
+        return None;
+    }
+    Some(run_helper())
+}
+
+/// Helper entry used by `et` and `et-user-socket-helper`.
+pub fn run_helper() -> i32 {
+    let stdin = io::stdin();
+    let channel = stdin.as_fd();
+    if let Err(error) = drop_helper_privileges() {
+        return send_error(channel, &error);
+    }
+    let op = std::env::var(OP_ENV)
+        .ok()
+        .and_then(|value| Op::parse(&value));
+    let path = std::env::var(PATH_ENV).unwrap_or_default();
+    match (op, path.is_empty()) {
+        (Some(Op::Listen), false) => match listen_at_path(Path::new(&path)) {
+            Ok(listener) => send_result(channel, Some(listener.as_fd()), 0, 0),
+            Err(error) => send_error(channel, &error),
+        },
+        (Some(Op::Connect), false) => match connect_at_path(Path::new(&path)) {
+            Ok(stream) => send_result(channel, Some(stream.as_fd()), 0, 0),
+            Err(error) => send_error(channel, &error),
+        },
+        _ => send_result(channel, None, -1, rustix::io::Errno::INVAL.raw_os_error()),
+    }
+}
+
+/// unlink/bind/listen/fchmod a UNIX socket path with the current credentials.
+pub fn listen_at_path(path: &Path) -> io::Result<UnixListener> {
+    if path_too_long(path) {
+        return Err(io::Error::from_raw_os_error(
+            rustix::io::Errno::NAMETOOLONG.raw_os_error(),
+        ));
+    }
+    let _ = fs::remove_file(path);
+    let listener = UnixListener::bind(path)?;
+    if rustix::fs::fchmod(&listener, rustix::fs::Mode::from_raw_mode(0o700)).is_err() {
+        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o700));
+    }
+    Ok(listener)
+}
+
+/// connect() to a UNIX socket path with the current credentials.
+pub fn connect_at_path(path: &Path) -> io::Result<UnixStream> {
+    if path_too_long(path) {
+        return Err(io::Error::from_raw_os_error(
+            rustix::io::Errno::NAMETOOLONG.raw_os_error(),
+        ));
+    }
+    UnixStream::connect(path)
+}
+
+/// unlink/bind/listen as `uid`/`gid`, returning the listening socket.
+pub fn listen_unix_as_user(path: impl AsRef<Path>, uid: u32, gid: u32) -> io::Result<UnixListener> {
+    let path = path.as_ref();
+    if already_session_user(uid, gid) {
+        return listen_at_path(path);
+    }
+    Ok(UnixListener::from(run_as_user(Op::Listen, path, uid, gid)?))
+}
+
+/// connect() as `uid`/`gid`, returning the connected socket.
+pub fn connect_unix_as_user(path: impl AsRef<Path>, uid: u32, gid: u32) -> io::Result<UnixStream> {
+    let path = path.as_ref();
+    if already_session_user(uid, gid) {
+        return connect_at_path(path);
+    }
+    Ok(UnixStream::from(run_as_user(Op::Connect, path, uid, gid)?))
+}
+
+fn already_session_user(uid: u32, gid: u32) -> bool {
+    rustix::process::geteuid().as_raw() == uid && rustix::process::getegid().as_raw() == gid
+}
+
+fn run_as_user(op: Op, path: &Path, uid: u32, gid: u32) -> io::Result<OwnedFd> {
+    if path_too_long(path) {
+        return Err(io::Error::from_raw_os_error(
+            rustix::io::Errno::NAMETOOLONG.raw_os_error(),
+        ));
+    }
+    let helper = helper_exe()?;
+    let (parent, child) = UnixStream::pair()?;
+    let mut command = Command::new(helper);
+    command
+        .env(OP_ENV, op.as_env())
+        .env(PATH_ENV, path)
+        .env(UID_ENV, uid.to_string())
+        .env(GID_ENV, gid.to_string())
+        .stdin(Stdio::from(OwnedFd::from(child)))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child_proc = command.spawn()?;
+    let result = recv_result(&parent);
+    let _ = child_proc.wait();
+    result
+}
+
+fn drop_helper_privileges() -> io::Result<()> {
+    let uid = std::env::var(UID_ENV)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or_else(|| rustix::process::getuid().as_raw());
+    let gid = std::env::var(GID_ENV)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or_else(|| rustix::process::getgid().as_raw());
+    let uid = nix::unistd::Uid::from_raw(uid);
+    let gid = nix::unistd::Gid::from_raw(gid);
+    // Match ET: setgroups/setgid/setuid while still root. nix `setgroups` is
+    // unavailable on Apple targets; Linux is the etserver-as-root case.
+    if nix::unistd::geteuid().as_raw() == 0 {
+        #[cfg(target_os = "linux")]
+        nix::unistd::setgroups(&[gid]).map_err(from_nix)?;
+    }
+    nix::unistd::setgid(gid).map_err(from_nix)?;
+    nix::unistd::setuid(uid).map_err(from_nix)?;
+    Ok(())
+}
+
+fn from_nix(error: nix::errno::Errno) -> io::Error {
+    io::Error::from_raw_os_error(error as i32)
+}
+
+fn helper_exe() -> io::Result<PathBuf> {
+    for candidate in helper_candidates() {
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        "et-user-socket-helper not found",
+    ))
+}
+
+fn helper_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(path) = std::env::var_os(HELPER_ENV) {
+        candidates.push(PathBuf::from(path));
+    }
+    if let Some(path) = option_env!("CARGO_BIN_EXE_et_user_socket_helper") {
+        candidates.push(PathBuf::from(path));
+    }
+    if let Ok(current) = std::env::current_exe() {
+        if let Some(dir) = current.parent() {
+            candidates.push(dir.join(HELPER_NAME));
+            if let Some(parent) = dir.parent() {
+                candidates.push(parent.join(HELPER_NAME));
+            }
+        }
+        if !looks_like_rustc_test_exe(&current) {
+            candidates.push(current);
+        }
+    }
+    if let Ok(manifest) = std::env::var("CARGO_MANIFEST_DIR") {
+        let crate_dir = PathBuf::from(manifest);
+        for profile in ["debug", "release"] {
+            candidates.push(crate_dir.join(format!("../../target/{profile}/{HELPER_NAME}")));
+            candidates.push(crate_dir.join(format!("target/{profile}/{HELPER_NAME}")));
+        }
+    }
+    candidates
+}
+
+fn looks_like_rustc_test_exe(path: &Path) -> bool {
+    path.components()
+        .any(|component| component.as_os_str() == "deps")
+}
+
+fn path_too_long(path: &Path) -> bool {
+    path.as_os_str().len() >= UNIX_PATH_MAX
+}
+
+fn send_error(channel: BorrowedFd<'_>, error: &io::Error) -> i32 {
+    send_result(
+        channel,
+        None,
+        -1,
+        error
+            .raw_os_error()
+            .unwrap_or_else(|| rustix::io::Errno::IO.raw_os_error()),
+    )
+}
+
+fn send_result(channel: BorrowedFd<'_>, fd: Option<BorrowedFd<'_>>, status: i32, err: i32) -> i32 {
+    let mut header = [0u8; 8];
+    header[..4].copy_from_slice(&status.to_ne_bytes());
+    header[4..].copy_from_slice(&err.to_ne_bytes());
+    let mut space = [MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(1))];
+    let mut control = SendAncillaryBuffer::new(&mut space);
+    let rights;
+    if status == 0 {
+        if let Some(fd) = fd {
+            rights = [fd];
+            let _ = control.push(SendAncillaryMessage::ScmRights(&rights));
+        }
+    }
+    match sendmsg(
+        channel,
+        &[IoSlice::new(&header)],
+        &mut control,
+        SendFlags::empty(),
+    ) {
+        Ok(_) => i32::from(status != 0),
+        Err(_) => 1,
+    }
+}
+
+fn recv_result(channel: &UnixStream) -> io::Result<OwnedFd> {
+    let mut header = [0u8; 8];
+    let mut space = [MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(1))];
+    let mut control = RecvAncillaryBuffer::new(&mut space);
+    let received = recvmsg(
+        channel,
+        &mut [IoSliceMut::new(&mut header)],
+        &mut control,
+        RecvFlags::empty(),
+    )?;
+    if received.bytes != header.len() {
+        return Err(io::Error::other(
+            "user-socket helper returned a short reply",
+        ));
+    }
+    let status = i32::from_ne_bytes(header[..4].try_into().expect("header status"));
+    let err = i32::from_ne_bytes(header[4..].try_into().expect("header errno"));
+    if status != 0 {
+        return Err(if err != 0 {
+            io::Error::from_raw_os_error(err)
+        } else {
+            io::Error::other("user-socket helper failed")
+        });
+    }
+    for message in control.drain() {
+        if let RecvAncillaryMessage::ScmRights(mut rights) = message {
+            if let Some(fd) = rights.next() {
+                return Ok(fd);
+            }
+        }
+    }
+    Err(io::Error::other("user-socket helper omitted the socket fd"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::os::unix::fs::FileTypeExt;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir() -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("et_user_sock_{stamp}"));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn long_unix_path() -> PathBuf {
+        PathBuf::from("x".repeat(UNIX_PATH_MAX + 8))
+    }
+
+    #[test]
+    fn listen_and_connect_at_path_roundtrip() {
+        let dir = temp_dir();
+        let path = dir.join("sock");
+        let listener = listen_at_path(&path).unwrap();
+        let metadata = fs::metadata(&path).unwrap();
+        assert!(metadata.file_type().is_socket());
+        let mut client = connect_at_path(&path).unwrap();
+        let (mut accepted, _) = listener.accept().unwrap();
+        client.write_all(b"ok").unwrap();
+        let mut buf = [0u8; 2];
+        accepted.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"ok");
+        drop(listener);
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn listen_and_connect_as_current_user() {
+        let dir = temp_dir();
+        let path = dir.join("sock");
+        let uid = rustix::process::getuid().as_raw();
+        let gid = rustix::process::getgid().as_raw();
+        let listener = listen_unix_as_user(&path, uid, gid).unwrap();
+        let mut client = connect_unix_as_user(&path, uid, gid).unwrap();
+        let (mut accepted, _) = listener.accept().unwrap();
+        client.write_all(b"ping").unwrap();
+        let mut buf = [0u8; 4];
+        accepted.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"ping");
+        drop(listener);
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn listen_at_path_rejects_oversized_path() {
+        let error = listen_at_path(&long_unix_path()).unwrap_err();
+        assert_eq!(
+            error.raw_os_error(),
+            Some(rustix::io::Errno::NAMETOOLONG.raw_os_error())
+        );
+    }
+
+    #[test]
+    fn connect_at_path_rejects_oversized_path() {
+        let error = connect_at_path(&long_unix_path()).unwrap_err();
+        assert_eq!(
+            error.raw_os_error(),
+            Some(rustix::io::Errno::NAMETOOLONG.raw_os_error())
+        );
+    }
+
+    #[test]
+    fn listen_unix_as_user_rejects_oversized_path() {
+        let uid = rustix::process::getuid().as_raw();
+        let gid = rustix::process::getgid().as_raw();
+        let error = listen_unix_as_user(long_unix_path(), uid, gid).unwrap_err();
+        assert_eq!(
+            error.raw_os_error(),
+            Some(rustix::io::Errno::NAMETOOLONG.raw_os_error())
+        );
+    }
+
+    #[test]
+    fn connect_unix_as_user_rejects_oversized_path() {
+        let uid = rustix::process::getuid().as_raw();
+        let gid = rustix::process::getgid().as_raw();
+        let error = connect_unix_as_user(long_unix_path(), uid, gid).unwrap_err();
+        assert_eq!(
+            error.raw_os_error(),
+            Some(rustix::io::Errno::NAMETOOLONG.raw_os_error())
+        );
+    }
+
+    #[test]
+    fn listen_at_path_fails_when_path_is_a_directory() {
+        let dir = temp_dir();
+        assert!(listen_at_path(&dir).is_err());
+        let _ = fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn connect_at_path_fails_when_nothing_listens() {
+        let dir = temp_dir();
+        let path = dir.join("missing");
+        assert!(connect_at_path(&path).is_err());
+        let _ = fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn listen_at_path_replaces_an_existing_socket() {
+        let dir = temp_dir();
+        let path = dir.join("sock");
+        let first = listen_at_path(&path).unwrap();
+        drop(first);
+        let second = listen_at_path(&path).unwrap();
+        drop(second);
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_dir(&dir);
+    }
+
+    fn unprivileged_drop_user() -> Option<(u32, u32)> {
+        if rustix::process::getuid().as_raw() != 0 {
+            return None;
+        }
+        for name in ["nobody", "nfsnobody"] {
+            if let Some(ids) = passwd_ids(name) {
+                if ids.0 != 0 && ids.0 <= 65534 {
+                    return Some(ids);
+                }
+            }
+        }
+        None
+    }
+
+    fn passwd_ids(name: &str) -> Option<(u32, u32)> {
+        let text = fs::read_to_string("/etc/passwd").ok()?;
+        for line in text.lines() {
+            let mut fields = line.split(':');
+            if fields.next()? != name {
+                continue;
+            }
+            let _ = fields.next()?;
+            let uid = fields.next()?.parse().ok()?;
+            let gid = fields.next()?.parse().ok()?;
+            return Some((uid, gid));
+        }
+        None
+    }
+
+    /// ANT-2026-AVTT7HQH: privilege-dropped listen cannot unlink a root-owned
+    /// file. Skips when not root (no setuid drop), like ET's nobody-user tests.
+    #[test]
+    fn listen_as_user_does_not_destroy_root_only_file() {
+        let Some((uid, gid)) = unprivileged_drop_user() else {
+            eprintln!("skipping privilege-drop listen test: not root or no nobody user");
+            return;
+        };
+        let dir = temp_dir();
+        let victim = dir.join("victim_file");
+        fs::write(&victim, b"keepme").unwrap();
+        rustix::fs::chown(
+            &dir,
+            Some(rustix::fs::Uid::ROOT),
+            Some(rustix::fs::Gid::ROOT),
+        )
+        .unwrap();
+        rustix::fs::chmod(&dir, rustix::fs::Mode::from_raw_mode(0o755)).unwrap();
+        rustix::fs::chown(
+            &victim,
+            Some(rustix::fs::Uid::ROOT),
+            Some(rustix::fs::Gid::ROOT),
+        )
+        .unwrap();
+        assert!(listen_unix_as_user(&victim, uid, gid).is_err());
+        assert!(victim.is_file());
+        let _ = fs::remove_file(&victim);
+        let _ = fs::remove_dir(&dir);
+    }
+
+    /// ANT-2026-A3WQS3AG: privilege-dropped connect cannot open a mode-000
+    /// socket. Skips when not root.
+    #[test]
+    fn connect_as_user_cannot_open_mode_000_socket() {
+        let Some((uid, gid)) = unprivileged_drop_user() else {
+            eprintln!("skipping privilege-drop connect test: not root or no nobody user");
+            return;
+        };
+        let dir = temp_dir();
+        rustix::fs::chmod(&dir, rustix::fs::Mode::from_raw_mode(0o777)).unwrap();
+        let path = dir.join("denied.sock");
+        let listener = listen_at_path(&path).unwrap();
+        rustix::fs::chmod(&path, rustix::fs::Mode::from_raw_mode(0)).unwrap();
+        assert!(connect_unix_as_user(&path, uid, gid).is_err());
+        drop(listener);
+        let _ = rustix::fs::chmod(&path, rustix::fs::Mode::from_raw_mode(0o700));
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_dir(&dir);
+    }
+}

--- a/crates/et-net/tests/connection_resilience.rs
+++ b/crates/et-net/tests/connection_resilience.rs
@@ -130,3 +130,44 @@ fn detected_disconnect_buffers_write_exactly_once() {
     assert_eq!(packet.payload(), b"once");
     assert_eq!(server.writer_sequence(), 1);
 }
+
+/// ANT-2026-VAMER5RC: a bad attacker-supplied sequence is a caught error, and
+/// the live victim socket is not closed before recover succeeds.
+#[test]
+fn recover_does_not_displace_live_session_on_bad_sequence() {
+    use std::io::Write;
+
+    let live_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let live_client = TcpStream::connect(live_listener.local_addr().unwrap()).unwrap();
+    let (live_server, _) = live_listener.accept().unwrap();
+    let mut server = Connection::new_server(live_server, &[6; 32]);
+    let mut client = Connection::new_client(live_client, &[6; 32]);
+    client.write_packet(1, b"hello").unwrap();
+    let hello = server.read_packet().unwrap();
+    assert_eq!(hello.payload(), b"hello");
+    assert!(server.connected());
+
+    let attack_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let attack_address = attack_listener.local_addr().unwrap();
+    let attacker = thread::spawn(move || {
+        let (mut stream, _) = attack_listener.accept().unwrap();
+        let _: et_core::proto::SequenceHeader =
+            et_net::framing_io::read_proto_limited(&mut stream, 4 * 1024).unwrap();
+        let bad = et_core::proto::SequenceHeader {
+            sequence_number: Some(999_999),
+        };
+        et_net::framing_io::write_proto(&mut stream, &bad).unwrap();
+        stream
+    });
+    let attack = TcpStream::connect(attack_address).unwrap();
+    assert!(server.recover(attack).is_err());
+    assert!(
+        server.connected(),
+        "failed recover must leave the live session connected"
+    );
+    let _ = attacker.join();
+
+    client.write_packet(2, b"still-here").unwrap();
+    let still = server.read_packet().unwrap();
+    assert_eq!(still.payload(), b"still-here");
+}

--- a/crates/et-net/tests/connection_resilience.rs
+++ b/crates/et-net/tests/connection_resilience.rs
@@ -135,8 +135,6 @@ fn detected_disconnect_buffers_write_exactly_once() {
 /// the live victim socket is not closed before recover succeeds.
 #[test]
 fn recover_does_not_displace_live_session_on_bad_sequence() {
-    use std::io::Write;
-
     let live_listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let live_client = TcpStream::connect(live_listener.local_addr().unwrap()).unwrap();
     let (live_server, _) = live_listener.accept().unwrap();

--- a/crates/et-server/src/session.rs
+++ b/crates/et-server/src/session.rs
@@ -168,10 +168,12 @@ impl ActiveSession {
     fn recover_body(&self, stream: TcpStream) -> Result<(), SessionError> {
         // Phase 1: soft-disconnect and snapshot under a short lock.
         let mut candidate = {
-            let mut connection = lock_timeout(&self.connection, RECOVERY_LOCK_TIMEOUT)?;
-            // Soft-disconnect the old live path; terminal output during the
-            // off-lock handshake is queued in `recover_hold`.
-            connection.disconnect();
+            let connection = lock_timeout(&self.connection, RECOVERY_LOCK_TIMEOUT)?;
+            // Snapshot onto the new stream without closing or disconnecting
+            // the live victim socket (ET #784 / ANT-2026-VAMER5RC). Terminal
+            // output during the off-lock handshake is queued in
+            // `recover_hold` because `recovering` is set. A failed recover
+            // must leave the existing session intact.
             connection.prepare_recovery_candidate(stream)
         };
 

--- a/crates/et-server/tests/runtime_adversarial.rs
+++ b/crates/et-server/tests/runtime_adversarial.rs
@@ -109,7 +109,9 @@ fn capped_malformed_unknown_and_mismatched_handshakes_are_typed() {
 
     let cases = [
         (
-            (64 * 1024 + 1i64).to_le_bytes().to_vec(),
+            (et_net::handshake::MAX_HANDSHAKE_PROTO_LEN + 1)
+                .to_le_bytes()
+                .to_vec(),
             ConnectStatus::InvalidKey,
         ),
         (

--- a/crates/et-server/tests/runtime_recovery.rs
+++ b/crates/et-server/tests/runtime_recovery.rs
@@ -378,6 +378,62 @@ fn concurrent_returning_recover_does_not_block_accept_path() {
     server.runtime.shutdown().unwrap();
 }
 
+/// ANT-2026-VAMER5RC: a returning client that supplies an ahead-of-server
+/// sequence must not close or displace the live victim session.
+#[test]
+fn failed_recover_leaves_live_session_intact() {
+    use et_core::proto::SequenceHeader;
+    use std::io::Write;
+
+    let mut server = TestRuntime::start();
+    let mut terminal = server.register(ID_A, KEY_A);
+    terminal.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let (stream, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    let key = passkey_to_key(KEY_A).unwrap();
+    let (mut client, initial) = initialize(stream, &key, default_payload());
+    assert_eq!(initial.error, None);
+    server
+        .handle
+        .wait_for_state(ID_A, SessionState::Active, TIMEOUT)
+        .unwrap();
+    let _ = read_local_packet(&mut terminal).unwrap();
+
+    let address = server.address;
+    let attacker = thread::spawn(move || {
+        let mut stream = std::net::TcpStream::connect(address).unwrap();
+        runtime_support::bound(&stream);
+        write_proto(&mut stream, &client_request(ID_A)).unwrap();
+        let response: ConnectResponse = read_proto_limited(&mut stream, 4 * 1024).unwrap();
+        assert_eq!(response.status, Some(ConnectStatus::ReturningClient as i32));
+        let _: SequenceHeader = read_proto_limited(&mut stream, 4 * 1024).unwrap();
+        write_proto(
+            &mut stream,
+            &SequenceHeader {
+                sequence_number: Some(999_999),
+            },
+        )
+        .unwrap();
+        // Hold the attack socket briefly so the server observes the bad sequence.
+        thread::sleep(std::time::Duration::from_millis(200));
+        let _ = stream.write(&[]);
+    });
+
+    attacker.join().unwrap();
+    thread::sleep(std::time::Duration::from_millis(150));
+    assert_eq!(
+        server.handle.session_state(ID_A).unwrap(),
+        Some(SessionState::Active)
+    );
+
+    client
+        .write_packet(TerminalPacketType::TerminalInfo as u8, b"still-live")
+        .unwrap();
+    let forwarded = read_local_packet(&mut terminal).unwrap();
+    assert_eq!(forwarded.payload(), b"still-live");
+    server.runtime.shutdown().unwrap();
+}
+
 #[test]
 fn keepalive_echo_acknowledges_everything_read_from_the_client() {
     let mut server = TestRuntime::start();

--- a/docs/upstream-pin.md
+++ b/docs/upstream-pin.md
@@ -27,7 +27,7 @@ green light to bump `PROTOCOL_VERSION` or land a v7 port.
 
 Notable unported `master` work after `et-v7.0.0`:
 
-- [`69b3353`](https://github.com/MisterTea/EternalTerminal/commit/69b33537ab12f324cf619aca04dc483728dc30c3) (`#784`) — four pre-auth / privilege-escalation fixes (handshake size + absolute read deadlines; reconnect recover crash; unix-socket LPE). Upstream left reconnect passkey-before-recover for a future `PROTOCOL_VERSION` bump.
+- [`69b3353`](https://github.com/MisterTea/EternalTerminal/commit/69b33537ab12f324cf619aca04dc483728dc30c3) (`#784`) — **ported in et.rs** (handshake 4 KiB cap + idle/absolute read deadlines; recover does not displace on failure; unix-socket listen/connect as the session user). Upstream left reconnect passkey-before-recover for a future `PROTOCOL_VERSION` bump; that residual is still unported.
 - [`b74a12e`](https://github.com/MisterTea/EternalTerminal/commit/b74a12efc567dbc1360ac0846f889c945a2eba60) (`#788`) — keep the client alive when the console fd is not a tty.
 
 Review those against the conflict policy in


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reimplement [EternalTerminal #784](https://github.com/MisterTea/EternalTerminal/pull/784) (merge `69b33537ab12f324cf619aca04dc483728dc30c3`) in Rust. This is not a C++ merge. Wire stays protocol v6; `PROTOCOL_VERSION` is not bumped.

Verified against ET master at that merge: `MAX_HANDSHAKE_PROTO_LENGTH = 4 KiB`, `readAll` idle 30s + absolute 60s (absolute never resets), recover must not close the live victim socket before success, and unix listen/connect/unlink/chmod on client-chosen paths must run as the session user (`UserSocketOps`: drop via `setgroups`/`setgid`/`setuid`, return fd via `SCM_RIGHTS`). Path-based `chown` after bind is gone. Upstream explicitly left reconnect passkey-before-recover for a future protocol bump.

## What matched ET

- Handshake / `SequenceHeader` length cap tightened from 64 KiB to **4 KiB**.
- Length-prefixed TCP reads enforce an idle gap **and** an absolute deadline on every loop iteration, so a slow trickle cannot reset the timer forever (`SOCKET_IDLE_TIMEOUT` 30s, `SOCKET_ABSOLUTE_TIMEOUT` 60s; server handshake still uses the tighter 5s absolute).
- Failed recover leaves the existing session intact: `ActiveSession::recover_body` no longer `disconnect()`s the live connection before the candidate handshake. A bad attacker-supplied sequence stays a caught `RecoverError`, not a fatal abort.
- When `etserver` is root, unix source listen and destination connect drop to the session `(uid, gid)` in a helper process (`nix` `setgroups`/`setgid`/`setuid` + `SCM_RIGHTS`). et.rs cannot `fork` (`unsafe` is forbidden); the helper is a re-exec of `et` / `et-user-socket-helper`.

## What et.rs already had

- `BackedWriter::recover` already returned `Err(RecoverError::AheadOfServer)` instead of aborting.
- `Connection::recover_with_timeout` already installed the new stream only after the candidate handshake succeeded.
- Server `ConnectRequest` already used a deadline reader; the remaining DoS gap was the 64 KiB cap and idle-only timeouts on the framing primitive.
- The close-order bug was in the session recover path (soft-disconnect before handshake), not in `BackedWriter`.

## Residual (intentionally not done)

- **Passkey-before-recover** is still omitted. Upstream left it for a future `PROTOCOL_VERSION` bump; inventing a v7 wire change would break v6 peers. An on-path observer who sniffs `clientId` and supplies an acceptable sequence can still displace that session’s TCP connection, but cannot speak the encrypted session.

## Tests

- 4 KiB handshake cap (including the old 64 KiB / 128 MiB sizes)
- Absolute deadline under a per-byte trickle
- Recover does not displace the live session on a bad sequence (connection + server runtime)
- Privilege-dropped unix listen/connect as root (skips cleanly when not root / no `nobody`, like ET’s nobody-user tests)

`cargo test --workspace` is the gate; `fixtures/wire.json` is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a16c9fc2-233a-4dbf-993f-4880f9566581?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a16c9fc2-233a-4dbf-993f-4880f9566581&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports EternalTerminal #784 security hardening to Rust without changing the wire version. Tightens pre-auth limits, prevents live-session displacement on failed recover, and drops privileges for client-chosen UNIX sockets.

- Handshake cap: `MAX_HANDSHAKE_PROTO_LEN` is 4 KiB (was 64 KiB) for Connect{Request,Response} and `SequenceHeader`; oversized frames are rejected before allocation.
- Read deadlines: length‑prefixed TCP reads enforce both idle 30s and absolute 60s deadlines; server handshake keeps a 5s absolute limit to block slow‑trickle DoS.
- Recover semantics: the server no longer disconnects the live session before a candidate recover succeeds; ahead/bad sequences return a typed error and leave the session intact.
- UNIX sockets: listen/connect on client‑chosen paths now run as the session user via a helper re‑exec (`et-user-socket-helper`) with `SCM_RIGHTS`; post‑bind path `chown`/`chmod` as root is removed.
- Protocol stays v6; recovery headers now use the same 4 KiB limit; tests cover caps, deadlines, recover behavior, and privilege‑dropped UNIX ops.

**Rollout**
- Ship the Unix‑only helper binary `et-user-socket-helper` alongside `et` (or set `ET_RS_USER_SOCKET_HELPER`); it is required only when `etserver` runs as root.
- New dependency: `nix` in `et-net`; no configuration or protocol migrations are required.

<sup>Written for commit 04aab30a7bc42b42da1c756c08e4d7e51cf2c66a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

