### PR TITLE
changelog: move ET #784 notes to et@0.0.13

### DIFF
--- a/crates/et-bin/CHANGELOG.md
+++ b/crates/et-bin/CHANGELOG.md
@@ -1,4 +1,4 @@
-## et@0.0.12
+## et@0.0.13
 
 ### Port EternalTerminal #784 pre-auth / LPE fixes
 
@@ -11,6 +11,8 @@ connect on client-chosen paths drop to the session user (helper +
 `SCM_RIGHTS`) instead of unlink/bind/chown/connect as root. Reconnect
 passkey-before-recover is still omitted: that needs a `PROTOCOL_VERSION`
 bump.
+
+## et@0.0.12
 
 ### Unblock session recovery after blackholed client writes
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
docs-only; unblocks tegami Version Packages for et@0.0.13; no version bump in this PR; cargo test not required for a markdown-only change but fine if CI runs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd0230a2-0081-41ce-b752-4b41ee44b966?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd0230a2-0081-41ce-b752-4b41ee44b966&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the ET #784 pre-auth/LPE changelog notes under a new `et@0.0.13` heading in `crates/et-bin/CHANGELOG.md` so tegami can open a Version Packages PR for `et@0.0.13`. This is a docs-only change; the released `et@0.0.12` notes remain untouched.

<sup>Written for commit 5d2ad4c3bb78828af5f1bf6d4a5f86bb995a1019. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

