### PR TITLE
ci: kick release.yml for et@0.0.13

### DIFF
--- a/docs/upstream-factory.md
+++ b/docs/upstream-factory.md
@@ -21,6 +21,13 @@ This is a hybrid of three real rewrite factories — not a fourth invention:
 | [`.github/upstream-ledger.yml`](../.github/upstream-ledger.yml) | Every ET `master` commit after baseline `et-v7.0.0` / `7656a32a5bc15c6746726a27a5a4ba1e468fab6e`. |
 | [`docs/upstream-pin.md`](upstream-pin.md) | Human record of the pin and the current ledger. `#784` / `69b3353` is `ported` (et.rs [#31](https://github.com/minpeter/et.rs/pull/31) / `906a7ca`). `#788` / `b74a12e` stays `skip`. |
 
+## Release
+
+[`release.yml`](../.github/workflows/release.yml) runs on push to `main` and
+opens a Version Packages PR when changelog has an unreleased `## et@x.y.z`
+heading. Merges by the Cursor GitHub App do not enqueue Actions; a
+`minpeter`-path push to `main` is required to kick tegami.
+
 ## Shape
 
 1. **Watch** — weekday 09:30 KST (`30 0 * * 1-5` UTC) via


### PR DESCRIPTION
Cursor App squash-merges of #32/#33 did not enqueue `release.yml` (Actions still last ran on 1f1ede7). This is a minpeter-path push so tegami can open Version Packages for et@0.0.13.

No protocol bump. No passkey-before-recover.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents that Cursor App squash-merges don't enqueue `release.yml`, so a `minpeter`-path push to `main` is required to trigger the Version Packages PR for `et@0.0.13`.

<sup>Written for commit 9fa7c9cb009144e9a425f9c030599bdeb3b1a163. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

