### PR TITLE
fix(release): add tegami changeset for ET #784 notes

### DIFF
--- a/.tegami/et-784-preauth-lpe.md
+++ b/.tegami/et-784-preauth-lpe.md
@@ -1,0 +1,17 @@
+---
+packages:
+  et:
+    type: patch
+---
+
+## Port EternalTerminal #784 pre-auth / LPE fixes
+
+Handshake protos are now capped at 4 KiB (was 64 KiB), matching ET
+`MAX_HANDSHAKE_PROTO_LENGTH`. Length-prefixed reads enforce both an idle
+gap and an absolute deadline so a slow trickle cannot reset the timer
+forever. Failed reconnect recover no longer disconnects the live victim
+session before recover succeeds. When `etserver` is root, UNIX listen and
+connect on client-chosen paths drop to the session user (helper +
+`SCM_RIGHTS`) instead of unlink/bind/chown/connect as root. Reconnect
+passkey-before-recover is still omitted: that needs a `PROTOCOL_VERSION`
+bump.

--- a/crates/et-bin/CHANGELOG.md
+++ b/crates/et-bin/CHANGELOG.md
@@ -1,17 +1,3 @@
-## et@0.0.13
-
-### Port EternalTerminal #784 pre-auth / LPE fixes
-
-Handshake protos are now capped at 4 KiB (was 64 KiB), matching ET
-`MAX_HANDSHAKE_PROTO_LENGTH`. Length-prefixed reads enforce both an idle
-gap and an absolute deadline so a slow trickle cannot reset the timer
-forever. Failed reconnect recover no longer disconnects the live victim
-session before recover succeeds. When `etserver` is root, UNIX listen and
-connect on client-chosen paths drop to the session user (helper +
-`SCM_RIGHTS`) instead of unlink/bind/chown/connect as root. Reconnect
-passkey-before-recover is still omitted: that needs a `PROTOCOL_VERSION`
-bump.
-
 ## et@0.0.12
 
 ### Unblock session recovery after blackholed client writes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Release finally ran on `1141313` / `c18de9a` / `7b340b6` (delayed ~20 minutes). `node scripts/tegami.mts ci` printed **Nothing to version** — no Version Packages PR, no `et@0.0.13` tag.

Existing pipeline (see Version Packages #24/#26): tegami versions from pending `.tegami/*.md` files, then writes `## et@x.y.z` into `crates/et-bin/CHANGELOG.md`. #31/#32 put the #784 notes in the changelog heading instead, so tegami had nothing to match.

This PR:
- Adds `.tegami/et-784-preauth-lpe.md` (`et` patch) with the same #784 notes
- Removes the premature `## et@0.0.13` block so tegami can write it on the Version Packages PR
- Leaves the shipped **0.0.12** body unchanged
- Does not bump `PROTOCOL_VERSION` (stays 6), does not touch `fixtures/wire.json`, no C++, no tegami rewrite

After this is squash-merged, `release.yml` on main should open the github-actions Version Packages PR. Merge that only if `cargo test --workspace` is green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-430bb382-012b-4676-84ed-fe20561a19df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-430bb382-012b-4676-84ed-fe20561a19df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release pipeline so the #784 notes get versioned by tegami instead of being stuck in a changelog heading.

- Moves the #784 notes from the premature `## et@0.0.13` changelog block into a `.tegami/et-784-preauth-lpe.md` patch changeset.
- Leaves the shipped `0.0.12` changelog body unchanged.
- No `PROTOCOL_VERSION` bump, no fixture or C++ changes.

After merge, `release.yml` should open a Version Packages PR; merge it only if `cargo test --workspace` passes.

<sup>Written for commit 6372bbb8fd9462a2345df177fa332534fa4f401f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

