### PR TITLE
fix(terminal): start Unix sessions as login shells

### DIFF
--- a/.tegami/fix-terminal-login-colors.md
+++ b/.tegami/fix-terminal-login-colors.md
@@ -1,0 +1,14 @@
+---
+packages:
+  et: patch
+---
+
+## Restore colorful shell startup in ET sessions
+
+Unix ET sessions now start the user's shell as a login shell, matching SSH,
+upstream EternalTerminal, and ET's own headless terminal multiplexer. This
+restores profile-provided prompts, aliases, `dircolors`, and other color setup
+that was skipped when ET launched an interactive non-login shell.
+
+Native Windows terminal startup, protocol-v6 bytes, and reconnect behavior are
+unchanged.

--- a/crates/et-bin/src/terminal_pty.rs
+++ b/crates/et-bin/src/terminal_pty.rs
@@ -37,6 +37,8 @@ pub fn run(mut router: LocalStream, term: &str) -> Result<i32, String> {
         })
         .map_err(|error| format!("could not open PTY: {error}"))?;
     let mut command = CommandBuilder::new(default_shell());
+    #[cfg(unix)]
+    command.arg("-l");
     command.env("TERM", term);
     for (name, value) in environment {
         command.env(name, value);

--- a/crates/et-bin/tests/terminal_runtime.rs
+++ b/crates/et-bin/tests/terminal_runtime.rs
@@ -13,7 +13,10 @@ use et_core::proto::{
 };
 use et_net::local_packet::{read_local_packet, write_local_packet};
 use prost::Message;
-use terminal_runtime_support::{read_line_timeout, write_credentials, Fixture};
+use terminal_runtime_support::{
+    collect_until, contains, read_line_timeout, write_credentials, Fixture, LOGIN_COLOR_MARKER,
+    NON_LOGIN_MARKER,
+};
 use wait_timeout::ChildExt;
 
 const ID: &str = "abcdefghijklmnop";
@@ -169,6 +172,97 @@ fn router_disconnect_terminates_the_shell() {
     drop(router);
     let status = child.wait_timeout(TIMEOUT).unwrap().unwrap();
     assert!(!status.success());
+}
+
+#[test]
+fn real_terminal_starts_login_shell_and_loads_profile_color() {
+    let fixture = Fixture::new("login-color");
+    let shell = fixture.login_probe_shell();
+    let mut child = fixture.spawn_with_shell(shell.to_str().unwrap());
+    write_credentials(&mut child);
+    let (mut router, _) = fixture.listener.accept().unwrap();
+    router.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let _ = read_local_packet(&mut router).unwrap();
+    fixture.wait_ready();
+    send(
+        &mut router,
+        TerminalPacketType::TerminalInit,
+        &TermInit {
+            environmentnames: Vec::new(),
+            environmentvalues: Vec::new(),
+        },
+    );
+    send(
+        &mut router,
+        TerminalPacketType::TerminalBuffer,
+        &TerminalBuffer {
+            buffer: Some(b"exit\n".to_vec()),
+        },
+    );
+    let output = collect_until(&mut router, |output| {
+        contains(output, LOGIN_COLOR_MARKER) || contains(output, NON_LOGIN_MARKER)
+    });
+    let _ = child.wait_timeout(TIMEOUT).unwrap();
+    assert!(
+        contains(&output, LOGIN_COLOR_MARKER),
+        "expected ANSI login-shell color marker when SHELL receives -l; got {:?}",
+        String::from_utf8_lossy(&output),
+    );
+    assert!(
+        !contains(&output, NON_LOGIN_MARKER),
+        "login-shell color marker must be emitted only when SHELL receives -l; got {:?}",
+        String::from_utf8_lossy(&output),
+    );
+}
+
+#[test]
+fn real_terminal_login_shell_preserves_term_without_colorterm() {
+    let fixture = Fixture::new("login-term");
+    let shell = fixture.login_probe_shell();
+    let mut child = fixture.spawn_with_shell(shell.to_str().unwrap());
+    write_credentials(&mut child);
+    let (mut router, _) = fixture.listener.accept().unwrap();
+    router.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let _ = read_local_packet(&mut router).unwrap();
+    fixture.wait_ready();
+    send(
+        &mut router,
+        TerminalPacketType::TerminalInit,
+        &TermInit {
+            environmentnames: Vec::new(),
+            environmentvalues: Vec::new(),
+        },
+    );
+    send(
+        &mut router,
+        TerminalPacketType::TerminalBuffer,
+        &TerminalBuffer {
+            buffer: Some(
+                b"printf 'TERM=%s\nCOLORTERM=%s\n' \"$TERM\" \"${COLORTERM-}\"; exit\n".to_vec(),
+            ),
+        },
+    );
+    let output = collect_until(&mut router, |output| {
+        (contains(output, LOGIN_COLOR_MARKER) || contains(output, NON_LOGIN_MARKER))
+            && contains(output, b"TERM=xterm-256color")
+            && contains(output, b"COLORTERM=")
+    });
+    let _ = child.wait_timeout(TIMEOUT).unwrap();
+    assert!(
+        contains(&output, LOGIN_COLOR_MARKER),
+        "expected ANSI login-shell color marker when SHELL receives -l; got {:?}",
+        String::from_utf8_lossy(&output),
+    );
+    assert!(
+        contains(&output, b"TERM=xterm-256color\r\nCOLORTERM=\r\n"),
+        "TERM=xterm-256color must survive empty TermInit with COLORTERM unset; got {:?}",
+        String::from_utf8_lossy(&output),
+    );
+    assert!(
+        !contains(&output, b"COLORTERM=truecolor"),
+        "COLORTERM must remain unset under empty TermInit; got {:?}",
+        String::from_utf8_lossy(&output),
+    );
 }
 
 fn send<M: Message>(router: &mut impl Write, kind: TerminalPacketType, message: &M) {

--- a/crates/et-bin/tests/terminal_runtime_support/mod.rs
+++ b/crates/et-bin/tests/terminal_runtime_support/mod.rs
@@ -1,14 +1,21 @@
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixListener;
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::time::Duration;
 
+use et_core::proto::TerminalBuffer;
+use et_net::local_packet::read_local_packet;
+use prost::Message;
+
 const ID: &str = "abcdefghijklmnop";
 const KEY: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef";
 const TIMEOUT: Duration = Duration::from_secs(5);
+
+pub const LOGIN_COLOR_MARKER: &[u8] = b"\x1b[31mET-LOGIN-COLOR\x1b[0m";
+pub const NON_LOGIN_MARKER: &[u8] = b"ET-NON-LOGIN";
 
 pub struct Fixture {
     directory: std::path::PathBuf,
@@ -53,11 +60,31 @@ impl Fixture {
             ])
             .arg(&self.socket)
             .env("SHELL", shell)
+            .env_remove("COLORTERM")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
             .unwrap()
+    }
+
+    /// Wrapper that emits an ANSI palette color marker only when argv[1] is `-l`.
+    pub fn login_probe_shell(&self) -> std::path::PathBuf {
+        let path = self.directory.join("login-probe-shell");
+        fs::write(
+            &path,
+            "#!/bin/sh\n\
+             if [ \"${1-}\" = \"-l\" ]; then\n\
+             printf '\\033[31mET-LOGIN-COLOR\\033[0m\\n'\n\
+             shift\n\
+             exec /bin/sh \"$@\"\n\
+             fi\n\
+             printf 'ET-NON-LOGIN\\n'\n\
+             exec /bin/sh \"$@\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+        path
     }
 
     pub fn spawn_parent(&self) -> std::process::Child {
@@ -106,4 +133,22 @@ pub fn read_line_timeout(stdout: impl std::io::Read + Send + 'static) -> String 
         let _ = sender.send(result);
     });
     receiver.recv_timeout(TIMEOUT).unwrap().unwrap()
+}
+
+pub fn contains(output: &[u8], marker: &[u8]) -> bool {
+    output.windows(marker.len()).any(|window| window == marker)
+}
+
+pub fn collect_until(router: &mut impl Read, done: impl Fn(&[u8]) -> bool) -> Vec<u8> {
+    let mut output = Vec::new();
+    while !done(&output) {
+        let packet = read_local_packet(router).unwrap();
+        output.extend(
+            TerminalBuffer::decode(packet.payload())
+                .unwrap()
+                .buffer
+                .unwrap(),
+        );
+    }
+    output
 }

--- a/crates/et-bin/tests/tunnel_support/mod.rs
+++ b/crates/et-bin/tests/tunnel_support/mod.rs
@@ -11,6 +11,7 @@ pub struct SingleCutProxy {
     cut: mpsc::SyncSender<()>,
     waiting: mpsc::Receiver<()>,
     resume: mpsc::SyncSender<()>,
+    stop: mpsc::SyncSender<()>,
     worker: Option<thread::JoinHandle<io::Result<()>>>,
 }
 
@@ -21,6 +22,7 @@ impl SingleCutProxy {
         let (cut_tx, cut_rx) = mpsc::sync_channel(1);
         let (waiting_tx, waiting_rx) = mpsc::sync_channel(1);
         let (resume_tx, resume_rx) = mpsc::sync_channel(1);
+        let (stop_tx, stop_rx) = mpsc::sync_channel(1);
         let worker = thread::spawn(move || {
             let (first, _) = listener.accept()?;
             let backend = TcpStream::connect((Ipv4Addr::LOCALHOST, backend_port))?;
@@ -40,13 +42,20 @@ impl SingleCutProxy {
                 .recv_timeout(TIMEOUT)
                 .map_err(|error| io::Error::other(error.to_string()))?;
             let recovered = TcpStream::connect((Ipv4Addr::LOCALHOST, backend_port))?;
-            join(relay(&second, &recovered)?)
+            let relays = relay(&second, &recovered)?;
+            stop_rx
+                .recv_timeout(TIMEOUT)
+                .map_err(|error| io::Error::other(error.to_string()))?;
+            let _ = second.shutdown(Shutdown::Both);
+            let _ = recovered.shutdown(Shutdown::Both);
+            join(relays)
         });
         Self {
             port,
             cut: cut_tx,
             waiting: waiting_rx,
             resume: resume_tx,
+            stop: stop_tx,
             worker: Some(worker),
         }
     }
@@ -61,6 +70,7 @@ impl SingleCutProxy {
     }
 
     pub fn join(mut self) {
+        self.stop.send(()).unwrap();
         self.worker.take().unwrap().join().unwrap().unwrap();
     }
 }

--- a/crates/et-bin/tests/tunnel_support/mod.rs
+++ b/crates/et-bin/tests/tunnel_support/mod.rs
@@ -70,7 +70,7 @@ impl SingleCutProxy {
     }
 
     pub fn join(mut self) {
-        self.stop.send(()).unwrap();
+        let _ = self.stop.send(());
         self.worker.take().unwrap().join().unwrap().unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- start Unix ET session shells with `-l`, matching SSH, upstream EternalTerminal, and ET's own HTM path
- add deterministic real-PTY regressions for profile-sourced color startup and the valid-TERM / unset-COLORTERM edge
- add an `et: patch` Tegami release note

## Root cause

ET created a real interactive PTY but invoked the user's shell as a non-login shell. That skipped profile startup files which commonly initialize prompts, aliases, `dircolors`, and other color setup. TERM was already preserved and terminal bytes were forwarded unchanged.

A real ET stack rendered through Chrome/xterm.js changed from gray to palette colors only when login startup was enabled while TERM and COLORTERM were held constant.

## Compatibility

- protocol-v6 proto sources and `fixtures/wire.json` are byte-identical to `origin/main`
- the new argument is guarded by `#[cfg(unix)]`; native Windows startup is unchanged
- reconnect and same-shell recovery behavior are unchanged

## Verification

- RED -> GREEN: `real_terminal_starts_login_shell_and_loads_profile_color`
- mutation RED -> GREEN: `real_terminal_login_shell_preserves_term_without_colorterm`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `cargo check -p et --target x86_64-pc-windows-gnu`
- real Chrome/xterm.js QA: palette 33, palette 196, RGB `0x0c2238`
- frozen-tree code review: APPROVE; hands-on QA: PASSED; fan-in gate: APPROVE_FOR_PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Starts Unix ET terminal sessions as login shells (`-l`) so profile files load and colors appear as in SSH and upstream EternalTerminal.

- Adds deterministic real-PTY regression tests for profile-sourced color startup and the valid-TERM/unset-COLORTERM edge.
- Makes the reconnect-proxy test shutdown deterministic and preserves its errors.
- Adds an `et: patch` release note.
- Leaves native Windows startup, protocol-v6 bytes, and reconnect behavior unchanged.

<sup>Written for commit c4eefbfea4d42fff934659a26692abf56ed560f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

