### PR TITLE
test(ssh): make output-limit fixture deterministic

### DIFF
--- a/crates/et-bin/src/ssh_process.rs
+++ b/crates/et-bin/src/ssh_process.rs
@@ -694,14 +694,9 @@ exit 0
 
     #[test]
     fn system_runner_stops_output_flood_at_limit() {
-        let runner = SystemSsh::with_timeout(Duration::from_secs(2));
-        let invocation = invocation(
-            "/bin/sh",
-            &["-c", "while :; do printf 0123456789abcdef; done"],
-        );
-        let started = Instant::now();
+        let runner = SystemSsh::with_timeout(Duration::from_secs(10));
+        let invocation = invocation("/bin/cat", &["/dev/zero"]);
         let result = runner.run(&invocation, runner.deadline());
         assert!(matches!(result, Err(ClientError::SshOutputTooLarge(_))));
-        assert!(started.elapsed() < Duration::from_secs(2));
     }
 }


### PR DESCRIPTION
## Summary

- replace the timing-sensitive 16-byte shell loop in the SSH output-limit test with `/bin/cat /dev/zero`
- use a 10-second timeout only as a bounded deadman
- keep the exact `SshOutputTooLarge` assertion and leave production behavior unchanged

## Why

A post-merge five-lane review plus ultrabrain gate initially approved PR #37, but the lead's mandatory full-workspace gate found `system_runner_stops_output_flood_at_limit` failing deterministically. `rust-gdb` confirmed the actual result was `SshTimeout("testing bootstrap")`: the interpreted shell loop did not always generate 1 MiB within two seconds.

Ultrabrain then returned `REQUEST_CHANGES`. A deep agent made this test-only fix, and ultrabrain round 3 returned unconditional `APPROVE`.

## RED -> GREEN

- RED focused test: exit 101, expected `SshOutputTooLarge`, actual `SshTimeout`
- GREEN focused test: 1 passed
- all `ssh_process` tests: 5 passed
- full workspace serial suite: passed

## Verification

- `cargo fmt --all --check`
- changed-file rust-analyzer diagnostics: clean
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check -p et --target x86_64-pc-windows-gnu`
- `cargo test --workspace -- --test-threads=1`
- protocol fixture/proto diff: empty
- ultrabrain final verdict: APPROVE, blockers: none

## Scope

One test-only file; no production, protocol, terminal, reconnect, Windows, dependency, release-note, or PR #38 file changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `system_runner_stops_output_flood_at_limit` deterministic by replacing a timing-sensitive shell loop with `/bin/cat /dev/zero` and a 10-second deadman timeout. The test now reliably asserts `SshOutputTooLarge` without depending on shell performance, and production behavior is unchanged.

<sup>Written for commit 8a259f18d3b43f0bdf52a1f7bf334f7562675c46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

