### PR TITLE
fix(client): auto-detect Windows login shell

### DIFF
--- a/.tegami/fix-windows-bootstrap-autodetect.md
+++ b/.tegami/fix-windows-bootstrap-autodetect.md
@@ -1,0 +1,15 @@
+---
+packages:
+  et: patch
+---
+
+## Auto-detect Windows OpenSSH bootstrap
+
+Bare `et user@windows-host` connections now probe the login shell without
+including session credentials. Expanded `%ComSpec%` selects the existing
+Cmd-compatible bootstrap and `et.exe` terminal path automatically, while
+POSIX hosts preserve their existing bootstrap.
+
+Explicit `--winserver` and `--remote-shell` overrides remain authoritative.
+PowerShell sessions now pass `ET_SHELL=powershell.exe` only to the remote
+`etterminal` process.

--- a/README.md
+++ b/README.md
@@ -119,13 +119,16 @@ netsh advfirewall firewall add rule name="et" dir=in action=allow protocol=TCP l
 
 ```sh
 # from anywhere
-et --winserver user@windows-host:2022                   # cmd.exe session
+et user@windows-host:2022                               # auto-detects cmd.exe login shell
+et --winserver user@windows-host:2022                   # explicitly force cmd.exe bootstrap
 et --remote-shell powershell user@windows-host:2022     # PowerShell session
 ```
 
-`--winserver` selects a `cmd.exe`-compatible ssh bootstrap (no `printf`, CRLF lines, `&` separator)
-and defaults `--terminal-path` to `et.exe`. The session shell follows `%COMSPEC%`, or `ET_SHELL` if
-set on the server. OpenSSH on Windows must be reachable and its default shell should be `cmd.exe`.
+Bare clients run a credential-free `%ComSpec%` SSH probe before bootstrap. An expanded `cmd.exe`
+path selects the Windows bootstrap (no `printf`, CRLF lines, `&` separator) and defaults
+`--terminal-path` to `et.exe`; a literal `%ComSpec%` preserves POSIX behavior. `--winserver`
+remains the explicit override. The session shell follows `%COMSPEC%`, or `ET_SHELL` if set on the
+server. OpenSSH on Windows must be reachable.
 
 ## Feature set
 

--- a/crates/et-bin/CHANGELOG.md
+++ b/crates/et-bin/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+### Auto-detect Windows OpenSSH bootstrap
+
+Bare `et user@windows-host` connections now probe the login shell without
+session credentials. Expanded `%ComSpec%` selects the existing `cmd.exe`
+bootstrap and `et.exe` terminal path automatically; POSIX hosts retain their
+existing bootstrap. Explicit `--winserver` and `--remote-shell` overrides keep
+their prior behavior.
+
 ## et@0.0.13
 
 ### Port EternalTerminal #784 pre-auth / LPE fixes

--- a/crates/et-bin/src/bootstrap.rs
+++ b/crates/et-bin/src/bootstrap.rs
@@ -4,6 +4,7 @@ use crate::error::ClientError;
 
 const MARKER: &[u8] = b"IDPASSKEY:";
 const CREDENTIAL_LEN: usize = 16 + 1 + 32;
+pub const WINDOWS_SHELL_PROBE_SENTINEL: &str = "__ET_COMSPEC__";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Credentials {
@@ -34,6 +35,7 @@ pub struct BootstrapRequest {
     pub ssh_options: Vec<String>,
     pub term: String,
     pub remote_shell: RemoteShell,
+    pub session_shell: Option<String>,
 }
 
 /// Second bootstrap hop for ET-native jumphosts, mirroring the
@@ -166,6 +168,50 @@ pub fn build_invocation(request: &BootstrapRequest, credentials: &Credentials) -
     }
 }
 
+pub fn build_shell_probe(request: &BootstrapRequest) -> SshInvocation {
+    let mut args = Vec::new();
+    if let Some(jumphost) = request.jumphost.as_deref() {
+        args.push("-J".to_string());
+        args.push(jumphost.to_string());
+    }
+    let destination = match request.user.as_deref() {
+        Some(user) => format!("{user}@{}", request.host_alias),
+        None => request.host_alias.clone(),
+    };
+    args.push(destination);
+    args.extend(
+        request
+            .ssh_options
+            .iter()
+            .map(|option| format!("-o{option}")),
+    );
+    args.push("-oLogLevel=ERROR".to_owned());
+    args.push(format!("echo {WINDOWS_SHELL_PROBE_SENTINEL}%ComSpec%"));
+    SshInvocation {
+        program: "ssh".to_owned(),
+        args,
+        operation: "detecting the remote login shell",
+    }
+}
+
+pub fn parse_shell_probe(stdout: &[u8]) -> Result<RemoteShell, ClientError> {
+    for line in String::from_utf8_lossy(stdout).lines() {
+        let Some(value) = line.trim().strip_prefix(WINDOWS_SHELL_PROBE_SENTINEL) else {
+            continue;
+        };
+        if value.eq_ignore_ascii_case("%ComSpec%") {
+            return Ok(RemoteShell::Posix);
+        }
+        if value.to_ascii_lowercase().ends_with("cmd.exe") {
+            return Ok(RemoteShell::Cmd);
+        }
+        break;
+    }
+    Err(ClientError::Unsupported(
+        "remote shell probe returned unexpected output",
+    ))
+}
+
 pub fn validate_ssh_destination(host: &str, user: Option<&str>) -> Result<(), ClientError> {
     if host.starts_with('-') {
         return Err(ClientError::InvalidSshComponent("host"));
@@ -275,6 +321,9 @@ fn remote_command(request: &BootstrapRequest, credentials: &Credentials) -> Stri
 /// escaped: everything in it is ASCII-alphanumeric plus `/`, `_`, `-`, and `.`.
 fn cmd_remote_command(request: &BootstrapRequest, terminal: &str, input: &str) -> String {
     let mut command = String::new();
+    if let Some(shell) = request.session_shell.as_deref() {
+        command.push_str(&format!("set \"ET_SHELL={shell}\" & "));
+    }
     if request.kill_other_sessions {
         // Best-effort equivalent of `pkill etterminal -u <user>`.
         command.push_str("taskkill /F /FI \"USERNAME eq %USERNAME%\" /IM et.exe >nul 2>&1 & ");
@@ -339,6 +388,7 @@ mod tests {
             ssh_options: vec!["Port=2222".into()],
             term: "xterm-256color".into(),
             remote_shell: RemoteShell::Posix,
+            session_shell: None,
         }
     }
 
@@ -375,6 +425,38 @@ mod tests {
                 "-oPort=2222"
             ]
         );
+    }
+
+    #[test]
+    fn shell_probe_has_no_credentials_and_uses_cmd_sentinel() {
+        let credentials = Credentials {
+            id: "XXXdefghijklmnop".into(),
+            passkey: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef".into(),
+        };
+        let invocation = build_shell_probe(&request());
+        let command = invocation.args.last().unwrap();
+        assert_eq!(command, "echo __ET_COMSPEC__%ComSpec%");
+        assert!(!command.contains(&credentials.id));
+        assert!(!command.contains(&credentials.passkey));
+        assert!(invocation.args.iter().any(|arg| arg == "-oLogLevel=ERROR"));
+        assert_eq!(invocation.operation, "detecting the remote login shell");
+    }
+
+    #[test]
+    fn shell_probe_parser_requires_exact_sentinel_line() {
+        assert_eq!(
+            parse_shell_probe(b"banner\r\n__ET_COMSPEC__C:\\Windows\\System32\\cmd.exe\r\n")
+                .unwrap(),
+            RemoteShell::Cmd
+        );
+        assert_eq!(
+            parse_shell_probe(b"__ET_COMSPEC__%ComSpec%\n").unwrap(),
+            RemoteShell::Posix
+        );
+        assert!(matches!(
+            parse_shell_probe(b"__ET_COMSPEC__powershell\n"),
+            Err(ClientError::Unsupported(_))
+        ));
     }
 
     #[test]
@@ -442,6 +524,22 @@ mod tests {
         request.terminal_path = Some("C:\\tools\\etterminal.exe".into());
         let command = build_invocation(&request, &credentials).args.pop().unwrap();
         assert!(!command.contains(" terminal \""), "{command}");
+    }
+
+    #[test]
+    fn cmd_bootstrap_exports_requested_session_shell() {
+        let credentials = Credentials {
+            id: "XXXdefghijklmnop".into(),
+            passkey: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef".into(),
+        };
+        let mut request = request();
+        request.remote_shell = RemoteShell::Cmd;
+        request.session_shell = Some("powershell.exe".to_owned());
+        let command = build_invocation(&request, &credentials).args.pop().unwrap();
+        assert_eq!(
+            command,
+            "set \"ET_SHELL=powershell.exe\" & echo XXXdefghijklmnop/ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef_xterm-256color| \"et.exe\" terminal \"--verbose=2\""
+        );
     }
 
     #[test]

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -2,13 +2,13 @@ use std::ffi::OsString;
 use std::time::Duration;
 
 use clap::Parser;
-use et_cli::client::ClientArgs;
+use et_cli::client::{ClientArgs, RemoteShellKind};
 use et_cli::host::parse_positional_host;
 
 use et_net::connection::Connection;
 
 use crate::bootstrap::{
-    build_invocation, build_jump_invocation, cmd_safe, provisional_credentials,
+    build_invocation, build_jump_invocation, build_shell_probe, cmd_safe, provisional_credentials,
     validate_ssh_destination, BootstrapRequest, Credentials, JumpBootstrapRequest, RemoteShell,
 };
 use crate::deadline::Deadline;
@@ -16,10 +16,40 @@ use crate::error::ClientError;
 use crate::initial_connect::{connect_initial, reconnect, Endpoint, ReconnectOutcome};
 use crate::resolver::{EndpointResolver, SystemResolver};
 use crate::ssh_config::resolve_ssh_config;
-use crate::ssh_process::{run_bootstrap, SshRunner, SystemSsh};
+use crate::ssh_process::{run_bootstrap, run_shell_probe, SshRunner, SystemSsh};
 
 const RECONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const RECONNECT_RETRY_DELAY: Duration = Duration::from_secs(1);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RemoteMode {
+    bootstrap_shell: RemoteShell,
+    terminal_shell: RemoteShellKind,
+    terminal_path: Option<String>,
+}
+
+fn resolve_remote_mode(args: &ClientArgs, detected_shell: Option<RemoteShell>) -> RemoteMode {
+    let bootstrap_shell = if args.remote_is_windows() {
+        RemoteShell::Cmd
+    } else {
+        detected_shell.unwrap_or(RemoteShell::Posix)
+    };
+    let terminal_shell = if args.remote_shell.is_some() || args.winserver {
+        args.effective_remote_shell()
+    } else {
+        match bootstrap_shell {
+            RemoteShell::Posix => RemoteShellKind::Posix,
+            RemoteShell::Cmd => RemoteShellKind::Cmd,
+        }
+    };
+    RemoteMode {
+        bootstrap_shell,
+        terminal_shell,
+        terminal_path: args
+            .effective_terminal_path()
+            .or_else(|| (bootstrap_shell == RemoteShell::Cmd).then(|| "et.exe".to_owned())),
+    }
+}
 
 pub fn run(args: &[OsString]) -> Result<i32, clap::Error> {
     let mut parsed = ClientArgs::try_parse_from(
@@ -53,7 +83,6 @@ fn run_client(
 ) -> Result<(), ClientError> {
     let destination = parse_positional_host(&args.host, args.port)?;
     validate_bootstrap_mode(args)?;
-    let provisional = provisional_credentials()?;
     let forward_config =
         crate::forward_config::build(args, std::env::var("SSH_AUTH_SOCK").ok().as_deref())?;
     let has_forwarding = !forward_config.local_sources.is_empty()
@@ -73,25 +102,44 @@ fn run_client(
     )?;
     let user = requested_user.or(resolved.user);
     validate_ssh_destination(&destination.host, user.as_deref())?;
-
     let term = std::env::var("TERM").unwrap_or_else(|_| "xterm-256color".to_string());
+    let probe_request = BootstrapRequest {
+        user: user.clone(),
+        host_alias: destination.host.clone(),
+        jumphost: args.jumphost.clone(),
+        terminal_path: None,
+        server_fifo: None,
+        kill_other_sessions: false,
+        verbose: args.verbose,
+        ssh_options: args.ssh_option.clone(),
+        term: term.clone(),
+        remote_shell: RemoteShell::Posix,
+        session_shell: None,
+    };
+    let detected_shell = if args.remote_is_windows() {
+        None
+    } else {
+        let probe = build_shell_probe(&probe_request);
+        Some(run_shell_probe(runner, &probe, deadline)?)
+    };
+    let remote_mode = resolve_remote_mode(args, detected_shell);
+    let provisional = provisional_credentials()?;
+
     let request = BootstrapRequest {
         user,
         host_alias: destination.host,
         jumphost: args.jumphost.clone(),
-        terminal_path: args.effective_terminal_path(),
+        terminal_path: remote_mode.terminal_path.clone(),
         server_fifo: args.serverfifo.clone(),
         kill_other_sessions: args.kill_other_sessions,
         verbose: args.verbose,
         ssh_options: args.ssh_option.clone(),
         term,
-        remote_shell: if args.remote_is_windows() {
-            RemoteShell::Cmd
-        } else {
-            RemoteShell::Posix
-        },
+        remote_shell: remote_mode.bootstrap_shell,
+        session_shell: (remote_mode.terminal_shell == RemoteShellKind::Powershell)
+            .then(|| "powershell.exe".to_owned()),
     };
-    if args.remote_is_windows() {
+    if remote_mode.bootstrap_shell == RemoteShell::Cmd {
         // cmd.exe cannot quote the credential line, so anything unusual in
         // TERM or the paths must be rejected before it reaches the remote.
         for value in [
@@ -134,7 +182,7 @@ fn run_client(
             destination_host: endpoint.host.clone(),
             destination_port: endpoint.port,
             jump_server_fifo: args.jserverfifo.clone(),
-            terminal_path: args.effective_terminal_path(),
+            terminal_path: remote_mode.terminal_path.clone(),
             kill_other_sessions: args.kill_other_sessions,
             verbose: args.verbose,
             ssh_options: args.ssh_option.clone(),
@@ -171,7 +219,7 @@ fn run_client(
             no_exit: args.no_exit,
             keepalive: args.keepalive,
             terminal_enabled: !args.no_terminal,
-            lines: crate::client_terminal::RemoteLines::from(args.effective_remote_shell()),
+            lines: crate::client_terminal::RemoteLines::from(remote_mode.terminal_shell),
         },
         forwarder,
         |connection| reconnect_with_retry(connection, &endpoint, &credentials, resolver),
@@ -521,6 +569,7 @@ mod tests {
             ssh_options: vec!["Compression=yes".to_owned()],
             term: "xterm".to_owned(),
             remote_shell: RemoteShell::Posix,
+            session_shell: None,
         };
         let credentials = Credentials {
             id: "abcdefghijklmnop".to_owned(),
@@ -532,6 +581,72 @@ mod tests {
         assert_eq!(
             message,
             "starting SSH bootstrap host=host.example options=1"
+        );
+    }
+
+    #[test]
+    fn remote_mode_refactor_preserves_bare_posix_defaults() {
+        let args = ClientArgs::try_parse_from(["et", "host"]).unwrap();
+        assert_eq!(
+            resolve_remote_mode(&args, None),
+            RemoteMode {
+                bootstrap_shell: RemoteShell::Posix,
+                terminal_shell: RemoteShellKind::Posix,
+                terminal_path: None,
+            }
+        );
+    }
+
+    #[test]
+    fn remote_mode_refactor_preserves_explicit_windows_defaults() {
+        let args = ClientArgs::try_parse_from(["et", "host", "--winserver"]).unwrap();
+        assert_eq!(
+            resolve_remote_mode(&args, Some(RemoteShell::Posix)),
+            RemoteMode {
+                bootstrap_shell: RemoteShell::Cmd,
+                terminal_shell: RemoteShellKind::Cmd,
+                terminal_path: Some("et.exe".to_owned()),
+            }
+        );
+    }
+
+    #[test]
+    fn explicit_powershell_preserves_terminal_override() {
+        let args =
+            ClientArgs::try_parse_from(["et", "host", "--remote-shell", "powershell"]).unwrap();
+        assert_eq!(
+            resolve_remote_mode(&args, Some(RemoteShell::Posix)),
+            RemoteMode {
+                bootstrap_shell: RemoteShell::Cmd,
+                terminal_shell: RemoteShellKind::Powershell,
+                terminal_path: Some("et.exe".to_owned()),
+            }
+        );
+    }
+
+    #[test]
+    fn bare_detected_windows_uses_cmd_defaults() {
+        let args = ClientArgs::try_parse_from(["et", "host"]).unwrap();
+        assert_eq!(
+            resolve_remote_mode(&args, Some(RemoteShell::Cmd)),
+            RemoteMode {
+                bootstrap_shell: RemoteShell::Cmd,
+                terminal_shell: RemoteShellKind::Cmd,
+                terminal_path: Some("et.exe".to_owned()),
+            }
+        );
+    }
+
+    #[test]
+    fn bare_detected_posix_preserves_posix_defaults() {
+        let args = ClientArgs::try_parse_from(["et", "host"]).unwrap();
+        assert_eq!(
+            resolve_remote_mode(&args, Some(RemoteShell::Posix)),
+            RemoteMode {
+                bootstrap_shell: RemoteShell::Posix,
+                terminal_shell: RemoteShellKind::Posix,
+                terminal_path: None,
+            }
         );
     }
 }

--- a/crates/et-bin/src/ssh_process.rs
+++ b/crates/et-bin/src/ssh_process.rs
@@ -6,7 +6,9 @@ use std::time::Duration;
 
 use wait_timeout::ChildExt;
 
-use crate::bootstrap::{parse_id_passkey, Credentials, SshInvocation};
+use crate::bootstrap::{
+    parse_id_passkey, parse_shell_probe, Credentials, RemoteShell, SshInvocation,
+};
 use crate::deadline::Deadline;
 use crate::error::ClientError;
 
@@ -154,6 +156,19 @@ pub fn run_checked<R: SshRunner + ?Sized>(
         }
     }
     Ok(output.stdout)
+}
+
+pub fn run_shell_probe<R: SshRunner + ?Sized>(
+    runner: &R,
+    invocation: &SshInvocation,
+    deadline: Deadline,
+) -> Result<RemoteShell, ClientError> {
+    let output = runner.run(invocation, deadline)?;
+    let status = output.status.ok_or(ClientError::SshNonZero(None))?;
+    if status.success() {
+        return parse_shell_probe(&output.stdout);
+    }
+    Err(ClientError::SshNonZero(status.code()))
 }
 
 pub fn run_bootstrap<R: SshRunner + ?Sized>(
@@ -467,6 +482,101 @@ mod tests {
     };
 
     use super::*;
+
+    #[cfg(unix)]
+    fn exit_status(code: i32) -> ExitStatus {
+        use std::os::unix::process::ExitStatusExt;
+        ExitStatus::from_raw(code << 8)
+    }
+
+    #[cfg(windows)]
+    fn exit_status(code: i32) -> ExitStatus {
+        use std::os::windows::process::ExitStatusExt;
+        ExitStatus::from_raw(code as u32)
+    }
+
+    struct ProbeRunner {
+        status: i32,
+        stdout: &'static [u8],
+    }
+
+    impl SshRunner for ProbeRunner {
+        fn run(
+            &self,
+            _invocation: &SshInvocation,
+            _deadline: Deadline,
+        ) -> Result<SshOutput, ClientError> {
+            Ok(SshOutput {
+                status: Some(exit_status(self.status)),
+                stdout: self.stdout.to_vec(),
+            })
+        }
+    }
+
+    #[test]
+    fn shell_probe_detects_windows_cmd() {
+        let runner = ProbeRunner {
+            status: 0,
+            stdout: b"__ET_COMSPEC__C:\\WINDOWS\\system32\\cmd.exe\r\n",
+        };
+        let invocation = SshInvocation {
+            program: "ssh".into(),
+            args: Vec::new(),
+            operation: "probe",
+        };
+        assert_eq!(
+            run_shell_probe(
+                &runner,
+                &invocation,
+                Deadline::after(Duration::from_secs(1)),
+            )
+            .unwrap(),
+            RemoteShell::Cmd
+        );
+    }
+
+    #[test]
+    fn shell_probe_detects_posix_literal() {
+        let runner = ProbeRunner {
+            status: 0,
+            stdout: b"__ET_COMSPEC__%ComSpec%\n",
+        };
+        let invocation = SshInvocation {
+            program: "ssh".into(),
+            args: Vec::new(),
+            operation: "probe",
+        };
+        assert_eq!(
+            run_shell_probe(
+                &runner,
+                &invocation,
+                Deadline::after(Duration::from_secs(1)),
+            )
+            .unwrap(),
+            RemoteShell::Posix
+        );
+    }
+
+    #[test]
+    fn shell_probe_propagates_ssh_255() {
+        let runner = ProbeRunner {
+            status: 255,
+            stdout: b"",
+        };
+        let invocation = SshInvocation {
+            program: "ssh".into(),
+            args: Vec::new(),
+            operation: "probe",
+        };
+        assert!(matches!(
+            run_shell_probe(
+                &runner,
+                &invocation,
+                Deadline::after(Duration::from_secs(1))
+            ),
+            Err(ClientError::SshNonZero(Some(255)))
+        ));
+    }
 
     #[cfg(target_os = "linux")]
     const EVENT_WAIT_MILLIS: u16 = 1_000;

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -60,6 +60,14 @@ if [ "$1" = "-G" ]; then
   printf "%s" "$ET_FAKE_CONFIG"
   exit 0
 fi
+last=
+for arg in "$@"; do last=$arg; done
+case "$last" in
+  *"__ET_COMSPEC__"*)
+    printf "%s" "$ET_FAKE_PROBE_STDOUT"
+    exit "$ET_FAKE_PROBE_EXIT"
+    ;;
+esac
 /bin/cat > "$ET_FAKE_STDIN"
 printf "%s" "$ET_FAKE_STDOUT"
 printf "%s" "$ET_FAKE_STDERR" >&2
@@ -84,6 +92,8 @@ exit "$ET_FAKE_EXIT"
             .env("ET_FAKE_STDOUT", stdout)
             .env("ET_FAKE_STDERR", stderr)
             .env("ET_FAKE_EXIT", exit.to_string())
+            .env("ET_FAKE_PROBE_STDOUT", "__ET_COMSPEC__%ComSpec%\n")
+            .env("ET_FAKE_PROBE_EXIT", "0")
             .stdin(Stdio::null());
         command
     }
@@ -167,12 +177,13 @@ fn cli_proves_exact_ssh_bootstrap_v6_and_encrypted_initial_payload() {
     assert!(fs::read(&fake.stdin).unwrap().is_empty());
 
     let invocations = fake.invocations();
-    assert_eq!(invocations.len(), 2);
+    assert_eq!(invocations.len(), 3);
     assert_eq!(
         invocations[0],
         ["-G", "-oStrictHostKeyChecking=no", "test-user@server-alias"]
     );
-    let argv = &invocations[1];
+    assert!(invocations[1].last().unwrap().contains("__ET_COMSPEC__"));
+    let argv = &invocations[2];
     assert_eq!(
         &argv[..2],
         ["test-user@server-alias", "-oStrictHostKeyChecking=no"]
@@ -190,6 +201,50 @@ fn cli_proves_exact_ssh_bootstrap_v6_and_encrypted_initial_payload() {
             "printf '%s\\n' '{provisional}_xterm-test' | '/opt/et terminal' '--verbose=2' '--serverfifo=/tmp/server fifo'"
         )
     );
+}
+
+#[test]
+fn bare_windows_login_shell_is_detected_before_bootstrap() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        bound(&stream);
+        assert_eq!(read_request(&mut stream).unwrap().version, Some(6));
+        write_response(&mut stream, &response_status(ConnectStatus::NewClient)).unwrap();
+        let key = passkey_to_key(SERVER_KEY).unwrap();
+        let mut connection = Connection::new_server(stream, &key);
+        let packet = connection.read_packet().unwrap();
+        assert_eq!(packet.header(), EtPacketType::InitialPayload as u8);
+        connection
+            .write_packet(
+                EtPacketType::InitialResponse as u8,
+                &InitialResponse { error: None }.encode_to_vec(),
+            )
+            .unwrap();
+    });
+
+    let fake = FakeSsh::new();
+    let output = fake
+        .command(RESOLVED_CONFIG, VALID_MARKER, 0, "")
+        .env(
+            "ET_FAKE_PROBE_STDOUT",
+            "__ET_COMSPEC__C:\\WINDOWS\\system32\\cmd.exe\r\n",
+        )
+        .env("ET_FAKE_PROBE_EXIT", "0")
+        .args(["-N".to_owned(), address.to_string()])
+        .output()
+        .unwrap();
+    server.join().unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+
+    let invocations = fake.invocations();
+    assert_eq!(invocations.len(), 3, "{invocations:?}");
+    assert!(invocations[1].last().unwrap().contains("__ET_COMSPEC__"));
+    let bootstrap = invocations[2].last().unwrap();
+    assert!(bootstrap.starts_with("echo "), "{bootstrap}");
+    assert!(bootstrap.contains("\"et.exe\""), "{bootstrap}");
+    assert!(!bootstrap.contains("printf"), "{bootstrap}");
 }
 
 #[test]
@@ -384,10 +439,12 @@ fn jumphost_starts_a_jump_terminal_and_connects_to_the_jumphost() {
     assert!(output.status.success(), "{}", stderr(&output));
 
     let invocations = fake.invocations();
-    // -G dst, dst bootstrap through -J, -G jumphost, jump bootstrap.
-    assert_eq!(invocations.len(), 4, "{invocations:?}");
+    // -G dst, login-shell probe, dst bootstrap through -J, -G jumphost,
+    // jump bootstrap.
+    assert_eq!(invocations.len(), 5, "{invocations:?}");
     assert_eq!(invocations[0], ["-G", "test-user@server-alias"]);
-    let destination = &invocations[1];
+    assert!(invocations[1].last().unwrap().contains("__ET_COMSPEC__"));
+    let destination = &invocations[2];
     assert_eq!(destination[0], "-J");
     assert_eq!(destination[1], "jump.example");
     assert_eq!(destination[2], "test-user@server-alias");
@@ -396,8 +453,8 @@ fn jumphost_starts_a_jump_terminal_and_connects_to_the_jumphost() {
         "remote command missing: {:?}",
         destination[3]
     );
-    assert_eq!(invocations[2], ["-G", "jump.example"]);
-    let jump = &invocations[3];
+    assert_eq!(invocations[3], ["-G", "jump.example"]);
+    let jump = &invocations[4];
     assert_eq!(jump[0], "jump.example");
     // The jump terminal receives the relay destination and its own fifo.
     assert!(jump[1].contains("'--jump'"), "{:?}", jump[1]);

--- a/crates/et-bin/tests/reconnect_end_to_end.rs
+++ b/crates/et-bin/tests/reconnect_end_to_end.rs
@@ -162,7 +162,9 @@ fn real_client_recovers_same_shell_and_once_only_buffered_output() {
     assert!(text.contains("RECONNECT-TERMIOS:"), "output={text}");
     assert!(text.contains(":CODE:0:"), "output={text}");
     assert!(termios_restored(&text), "output={text}");
-    assert_eq!(fs::read_to_string(&stack.ssh_count).unwrap(), "x");
+    // One credential-free login-shell probe plus one credential bootstrap.
+    // Reconnects stay on the encrypted ET transport and must not invoke SSH.
+    assert_eq!(fs::read_to_string(&stack.ssh_count).unwrap(), "xx");
     proxy.join();
     stack.shutdown();
 }


### PR DESCRIPTION
## Summary
- Probe the remote login grammar before generating ET session credentials.
- Auto-select Cmd bootstrap and `et.exe` when `%ComSpec%` expands on Windows.
- Preserve POSIX behavior and explicit `--winserver` / `--remote-shell` overrides.
- Pass `ET_SHELL=powershell.exe` only to the remote `etterminal` for explicit PowerShell sessions.

## RED -> GREEN
- Installed `et 0.0.12` bare Windows session failed on POSIX `printf`.
- Candidate bare `et -c hostname minpeter@windows` exits 0 and returns `WINDOWS`.
- Deterministic RED pinned client selection ignoring detected Cmd; GREEN tests cover Cmd, POSIX literal, SSH 255 propagation, credential-free probe, and explicit overrides.

## Validation
- Local serial workspace tests, fmt, clippy, and workspace build pass.
- Linux Bunshin full workspace test/build pass.
- macOS arm64 Bunshin repository CI-parity tests/build pass.
- Windows x86_64 Bunshin: Rust 1.98 + MSVC 17.14 + protoc 33.4; `et-cli` client tests and production `cargo build -p et` pass.
- Real sessions pass: Linux, macOS, Windows bare, `--winserver`, and `--remote-shell powershell`.

## Safety
- Probe carries no session ID/passkey or terminal command.
- SSH/auth/network failures never silently fall back.
- Remote QA clones/tasks/temp files were removed.
- Existing main checkout and PR #37 worktree were not modified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes bare `et user@windows-host` sessions, which previously failed because the POSIX-`printf` bootstrap doesn't work in Windows OpenSSH shells. The client now probes the remote login shell—without sending any session credentials—and selects the Cmd bootstrap and `et.exe` terminal path when `%ComSpec%` expands to `cmd.exe`.

**Bug Fixes**
- POSIX hosts keep their existing bootstrap; a literal `%ComSpec%` preserves POSIX behavior.
- Explicit `--winserver` and `--remote-shell` overrides remain authoritative.
- PowerShell sessions pass `ET_SHELL=powershell.exe` only to the remote `etterminal`.
- SSH/auth failures propagate and never silently fall back; reconnects stay on the encrypted ET transport.

<sup>Written for commit faddc96edb095db6bebc7a9015f6dd1bfa5bca58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

