### PR TITLE
changelog: remove duplicate Windows bootstrap note

### DIFF
--- a/crates/et-bin/CHANGELOG.md
+++ b/crates/et-bin/CHANGELOG.md
@@ -1,13 +1,3 @@
-## Unreleased
-
-### Auto-detect Windows OpenSSH bootstrap
-
-Bare `et user@windows-host` connections now probe the login shell without
-session credentials. Expanded `%ComSpec%` selects the existing `cmd.exe`
-bootstrap and `et.exe` terminal path automatically; POSIX hosts retain their
-existing bootstrap. Explicit `--winserver` and `--remote-shell` overrides keep
-their prior behavior.
-
 ## et@0.0.13
 
 ### Port EternalTerminal #784 pre-auth / LPE fixes


### PR DESCRIPTION
## Summary

Remove the stale `## Unreleased` Windows bootstrap entry before publishing `et@0.0.14`.

Tegami already generated the canonical Windows bootstrap note under `## et@0.0.14`; keeping both sections would ship duplicate and slightly contradictory release notes.

## Scope

- one changelog file
- no Rust, protocol, dependency, workflow, version, or changeset changes
- no new release-triggering changeset

## Verification

- the base branch contains zero `## Unreleased` sections after this cleanup
- Tegami's regenerated Version Packages PR will contain exactly one Windows bootstrap heading under `et@0.0.14`
- `git diff --check` passes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the stale `## Unreleased` Windows bootstrap entry from `crates/et-bin/CHANGELOG.md` so the `et@0.0.14` release ships only the canonical note already generated under `et@0.0.14`, avoiding duplicate and slightly contradictory release notes. No functional, dependency, or workflow changes; only the changelog file is touched.

<sup>Written for commit 59fdf2317741b09b4d719bd70c02d677681dae87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

