### PR TITLE
test(terminal): wait for complete environment output

### DIFF
--- a/crates/et-bin/tests/terminal_runtime.rs
+++ b/crates/et-bin/tests/terminal_runtime.rs
@@ -244,8 +244,7 @@ fn real_terminal_login_shell_preserves_term_without_colorterm() {
     );
     let output = collect_until(&mut router, |output| {
         (contains(output, LOGIN_COLOR_MARKER) || contains(output, NON_LOGIN_MARKER))
-            && contains(output, b"TERM=xterm-256color")
-            && contains(output, b"COLORTERM=")
+            && contains(output, b"TERM=xterm-256color\r\nCOLORTERM=\r\n")
     });
     let _ = child.wait_timeout(TIMEOUT).unwrap();
     assert!(


### PR DESCRIPTION
## Summary

Make the login-shell environment test wait for the complete adjacent `TERM=xterm-256color\r\nCOLORTERM=\r\n` bytes instead of returning as soon as the login marker and echoed command fragments appear.

## RED

PR #41 Ubuntu CI failed because the collector returned with the login marker and partial `TERM` output before the empty `COLORTERM` line arrived.

## GREEN

- focused login environment test: 1 passed
- full terminal_runtime suite: 6 passed
- rustfmt: pass
- rust-analyzer errors: none
- `cargo clippy -p et --all-targets -- -D warnings`: pass

## Scope

One test-only predicate; no production, protocol, release-note, version, dependency, or workflow changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the login-shell environment test so it waits for the full `TERM=xterm-256color\r\nCOLORTERM=\r\n` output instead of returning on the login marker and partial `TERM` bytes, which caused CI failures on Ubuntu. This is a test-only change with no production or protocol impact.

<sup>Written for commit bb2ec47c04ac54b45ce5945ef5b6d694ad94955f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

