### PR TITLE
test(server): measure each blackholed write timeout

### DIFF
--- a/crates/et-server/tests/runtime_recovery.rs
+++ b/crates/et-server/tests/runtime_recovery.rs
@@ -253,16 +253,16 @@ fn recover_succeeds_while_old_peer_blackholes_writes() {
     let _live = client.try_clone_stream().unwrap();
 
     let payload = vec![b'x'; 32 * 1024];
-    let flood_started = Instant::now();
     for round in 0..1_024u32 {
+        let send_started = Instant::now();
         server
             .handle
             .send_packet(ID_A, 40, &payload)
             .unwrap_or_else(|error| panic!("flood round {round}: {error}"));
         assert!(
-            flood_started.elapsed() < std::time::Duration::from_secs(12),
-            "send_packet blocked for {:?} — live write timeout not applied",
-            flood_started.elapsed()
+            send_started.elapsed() < std::time::Duration::from_secs(8),
+            "send_packet round {round} blocked for {:?} — live write timeout not applied",
+            send_started.elapsed()
         );
     }
 


### PR DESCRIPTION
## Summary

Measure each `send_packet` call independently in the blackholed-write recovery test instead of comparing the aggregate cost of 1,024 encrypted debug-mode sends with one twelve-second bound.

## RED

The final `et@0.0.14` candidate full suite repeatedly failed after roughly 12 seconds even though the focused recovery test passed. The cumulative assertion included encryption, packet construction, backup buffering, and scheduler time for all 1,024 sends.

## GREEN

- focused blackhole recovery: 1 passed
- complete runtime_recovery suite: 9 passed
- workspace clippy with warnings denied: pass
- full workspace serial suite: pass

## Scope

One test-only assertion. Production write timeout, recovery, session, protocol, and release behavior are unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky blackholed-write recovery test by asserting each `send_packet` round times out within 8 seconds instead of bounding the total time of all 1,024 sends at 12 seconds. The flood can now take longer overall, but every individual write must respect the live write timeout.

<sup>Written for commit e68bd551264eb27339d5331e1c10aed105b2e63b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

