### PR TITLE
fix(client): stabilize remote shell detection

### DIFF
--- a/.tegami/fix-shell-probe-completion.md
+++ b/.tegami/fix-shell-probe-completion.md
@@ -1,0 +1,13 @@
+---
+packages:
+  et: patch
+---
+
+## Stabilize remote shell detection
+
+Remote shell probing now ignores sentinel text embedded in banner lines,
+finishes as soon as a complete valid sentinel line arrives, and preserves a
+nonzero SSH exit status observed before that line.
+
+Explicit `--remote-shell` choices remain authoritative, and Windows
+destinations no longer pass their `et.exe` default to POSIX jumphosts.

--- a/crates/et-bin/src/bootstrap.rs
+++ b/crates/et-bin/src/bootstrap.rs
@@ -84,6 +84,7 @@ pub fn build_jump_invocation(
         program: "ssh".to_string(),
         args,
         operation: "starting the jumphost etterminal",
+        completion: InvocationCompletion::Credentials,
     }
 }
 
@@ -125,11 +126,19 @@ fn jump_remote_command(request: &JumpBootstrapRequest, credentials: &Credentials
     command
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvocationCompletion {
+    Exit,
+    Credentials,
+    ShellProbe,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SshInvocation {
     pub program: String,
     pub args: Vec<String>,
     pub operation: &'static str,
+    pub completion: InvocationCompletion,
 }
 
 pub fn provisional_credentials() -> Result<Credentials, ClientError> {
@@ -165,6 +174,7 @@ pub fn build_invocation(request: &BootstrapRequest, credentials: &Credentials) -
         program: "ssh".to_string(),
         args,
         operation: "starting the remote etterminal",
+        completion: InvocationCompletion::Credentials,
     }
 }
 
@@ -191,11 +201,16 @@ pub fn build_shell_probe(request: &BootstrapRequest) -> SshInvocation {
         program: "ssh".to_owned(),
         args,
         operation: "detecting the remote login shell",
+        completion: InvocationCompletion::ShellProbe,
     }
 }
 
 pub fn parse_shell_probe(stdout: &[u8]) -> Result<RemoteShell, ClientError> {
-    for line in String::from_utf8_lossy(stdout).lines() {
+    let stdout = String::from_utf8_lossy(stdout);
+    for line in stdout.split_inclusive('\n') {
+        if !line.ends_with('\n') {
+            continue;
+        }
         let Some(value) = line.trim().strip_prefix(WINDOWS_SHELL_PROBE_SENTINEL) else {
             continue;
         };
@@ -455,6 +470,10 @@ mod tests {
         );
         assert!(matches!(
             parse_shell_probe(b"__ET_COMSPEC__powershell\n"),
+            Err(ClientError::Unsupported(_))
+        ));
+        assert!(matches!(
+            parse_shell_probe(b"__ET_COMSPEC__C:\\Windows\\System32\\cmd.exe"),
             Err(ClientError::Unsupported(_))
         ));
     }

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -116,7 +116,7 @@ fn run_client(
         remote_shell: RemoteShell::Posix,
         session_shell: None,
     };
-    let detected_shell = if args.remote_is_windows() {
+    let detected_shell = if args.remote_shell.is_some() || args.winserver {
         None
     } else {
         let probe = build_shell_probe(&probe_request);
@@ -182,7 +182,7 @@ fn run_client(
             destination_host: endpoint.host.clone(),
             destination_port: endpoint.port,
             jump_server_fifo: args.jserverfifo.clone(),
-            terminal_path: remote_mode.terminal_path.clone(),
+            terminal_path: args.terminal_path.clone(),
             kill_other_sessions: args.kill_other_sessions,
             verbose: args.verbose,
             ssh_options: args.ssh_option.clone(),

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -1,4 +1,4 @@
-use crate::bootstrap::{validate_ssh_destination, SshInvocation};
+use crate::bootstrap::{validate_ssh_destination, InvocationCompletion, SshInvocation};
 use crate::deadline::Deadline;
 use crate::error::ClientError;
 use crate::ssh_process::{run_checked, SshRunner};
@@ -28,6 +28,7 @@ pub fn resolve_ssh_config(
         program: "ssh".to_string(),
         args,
         operation: "resolving SSH configuration",
+        completion: InvocationCompletion::Exit,
     };
     parse_ssh_config(&run_checked(runner, &invocation, deadline)?)
 }

--- a/crates/et-bin/src/ssh_process.rs
+++ b/crates/et-bin/src/ssh_process.rs
@@ -7,7 +7,8 @@ use std::time::Duration;
 use wait_timeout::ChildExt;
 
 use crate::bootstrap::{
-    parse_id_passkey, parse_shell_probe, Credentials, RemoteShell, SshInvocation,
+    parse_id_passkey, parse_shell_probe, Credentials, InvocationCompletion, RemoteShell,
+    SshInvocation,
 };
 use crate::deadline::Deadline;
 use crate::error::ClientError;
@@ -17,8 +18,8 @@ pub const DEFAULT_BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Debug)]
 pub struct SshOutput {
-    /// Exit status, or `None` when the bootstrap finished early because the
-    /// `IDPASSKEY:` marker had already arrived.
+    /// Exit status, or `None` when an invocation-specific completion marker
+    /// arrived before the SSH process exited.
     pub status: Option<ExitStatus>,
     pub stdout: Vec<u8>,
 }
@@ -84,7 +85,7 @@ impl SshRunner for SystemSsh {
         // Identify the stdout pipe so descendants that outlive ssh while still
         // holding it can be found even after they re-parent to init.
         let pipe = pipe_identity(&stdout);
-        let (receiver, reader) = match spawn_reader(stdout) {
+        let (receiver, reader) = match spawn_reader(stdout, invocation.completion) {
             Ok(reader) => reader,
             Err(error) => {
                 terminate_and_reap(&mut child, child_pid, pipe)?;
@@ -113,13 +114,19 @@ impl SshRunner for SystemSsh {
                 })
             }
             Ok(Capture::Marker(stdout)) => {
+                // Preserve a direct child's status when it exited before a
+                // pipe-holding descendant emitted the completion marker.
+                let status = match child.try_wait() {
+                    Ok(status) => status,
+                    Err(error) => {
+                        stop_child(&mut child, child_pid, pipe, reader)?;
+                        return Err(ClientError::SshWait(error));
+                    }
+                };
                 // The remote terminal is registered and detached; stop waiting
                 // on a channel a detached child may keep open.
                 stop_child(&mut child, child_pid, pipe, reader)?;
-                Ok(SshOutput {
-                    status: None,
-                    stdout,
-                })
+                Ok(SshOutput { status, stdout })
             }
             Ok(Capture::TooLarge) => {
                 stop_child(&mut child, child_pid, pipe, reader)?;
@@ -164,11 +171,12 @@ pub fn run_shell_probe<R: SshRunner + ?Sized>(
     deadline: Deadline,
 ) -> Result<RemoteShell, ClientError> {
     let output = runner.run(invocation, deadline)?;
-    let status = output.status.ok_or(ClientError::SshNonZero(None))?;
-    if status.success() {
-        return parse_shell_probe(&output.stdout);
+    if let Some(status) = output.status {
+        if !status.success() {
+            return Err(ClientError::SshNonZero(status.code()));
+        }
     }
-    Err(ClientError::SshNonZero(status.code()))
+    parse_shell_probe(&output.stdout)
 }
 
 pub fn run_bootstrap<R: SshRunner + ?Sized>(
@@ -181,8 +189,8 @@ pub fn run_bootstrap<R: SshRunner + ?Sized>(
 
 enum Capture {
     Complete(Vec<u8>),
-    /// The credential marker arrived, so the remote terminal is registered and
-    /// detached; nothing else on that channel matters.
+    /// The invocation-specific completion marker arrived, so a descendant
+    /// holding stdout open cannot delay completion.
     Marker(Vec<u8>),
     TooLarge,
     Failed(io::Error),
@@ -201,19 +209,45 @@ fn marker_end(captured: &[u8]) -> Option<usize> {
         .filter(|end| *end <= captured.len())
 }
 
-fn spawn_reader(mut stdout: ChildStdout) -> io::Result<(mpsc::Receiver<Capture>, JoinHandle<()>)> {
+fn shell_probe_end(captured: &[u8]) -> Option<usize> {
+    let mut line_start = 0;
+    for line_end in captured
+        .iter()
+        .enumerate()
+        .filter_map(|(index, byte)| (*byte == b'\n').then_some(index + 1))
+    {
+        if parse_shell_probe(&captured[line_start..line_end]).is_ok() {
+            return Some(line_end);
+        }
+        line_start = line_end;
+    }
+    None
+}
+
+fn completion_end(captured: &[u8], completion: InvocationCompletion) -> Option<usize> {
+    match completion {
+        InvocationCompletion::Exit => None,
+        InvocationCompletion::Credentials => marker_end(captured),
+        InvocationCompletion::ShellProbe => shell_probe_end(captured),
+    }
+}
+
+fn spawn_reader(
+    mut stdout: ChildStdout,
+    completion: InvocationCompletion,
+) -> io::Result<(mpsc::Receiver<Capture>, JoinHandle<()>)> {
     let (sender, receiver) = mpsc::sync_channel(1);
     let reader = thread::Builder::new()
         .name("ssh-stdout".to_string())
         .spawn(move || {
-            let capture = capture_bounded(&mut stdout);
+            let capture = capture_bounded(&mut stdout, completion);
             drop(stdout);
             let _ = sender.send(capture);
         })?;
     Ok((receiver, reader))
 }
 
-fn capture_bounded(reader: &mut impl Read) -> Capture {
+fn capture_bounded(reader: &mut impl Read, completion: InvocationCompletion) -> Capture {
     let mut captured = Vec::new();
     let mut buffer = [0u8; 8192];
     loop {
@@ -227,7 +261,7 @@ fn capture_bounded(reader: &mut impl Read) -> Capture {
                 // Waiting for EOF is not reliable everywhere: on Windows the
                 // detached session process can inherit this pipe, so the
                 // channel never closes even though the session is ready.
-                if marker_end(&captured).is_some() {
+                if completion_end(&captured, completion).is_some() {
                     return Capture::Marker(captured);
                 }
             }
@@ -523,6 +557,7 @@ mod tests {
             program: "ssh".into(),
             args: Vec::new(),
             operation: "probe",
+            completion: InvocationCompletion::ShellProbe,
         };
         assert_eq!(
             run_shell_probe(
@@ -545,6 +580,7 @@ mod tests {
             program: "ssh".into(),
             args: Vec::new(),
             operation: "probe",
+            completion: InvocationCompletion::ShellProbe,
         };
         assert_eq!(
             run_shell_probe(
@@ -567,6 +603,7 @@ mod tests {
             program: "ssh".into(),
             args: Vec::new(),
             operation: "probe",
+            completion: InvocationCompletion::ShellProbe,
         };
         assert!(matches!(
             run_shell_probe(
@@ -640,6 +677,7 @@ mod tests {
             program: program.into(),
             args: args.iter().map(|arg| (*arg).to_string()).collect(),
             operation: "testing bootstrap",
+            completion: InvocationCompletion::Exit,
         }
     }
 
@@ -800,6 +838,164 @@ exit 0
             descendant_exited,
             "SSH descendant survived process-group cleanup"
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn shell_probe_preserves_naturally_completed_nonzero_status() {
+        const SCRIPT: &str = r#"
+(IFS= read -r _ < "$3"; printf '__ET_COMSPEC__C:\\Windows\\System32\\cmd.exe\n') &
+descendant=$!
+printf '%s %s\n' "$$" "$descendant" > "$1"
+IFS= read -r _ < "$2"
+exit 255
+"#;
+
+        let dir = ProcessGroupTestDir::new();
+        let pid_fifo = dir.fifo("probe-status-pid");
+        let exit_fifo = dir.fifo("probe-status-exit");
+        let release_fifo = dir.fifo("probe-status-release");
+        let _pid_control = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&pid_fifo)
+            .unwrap();
+        let pid_pipe = File::open(&pid_fifo).unwrap();
+        let _exit_control = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&exit_fifo)
+            .unwrap();
+        let mut exit_pipe = OpenOptions::new().write(true).open(&exit_fifo).unwrap();
+        let _release_control = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&release_fifo)
+            .unwrap();
+        let mut release_pipe = OpenOptions::new().write(true).open(&release_fifo).unwrap();
+        let runner = SystemSsh::with_timeout(Duration::from_secs(3));
+        let mut invocation = invocation(
+            "/bin/sh",
+            &[
+                "-c",
+                SCRIPT,
+                "shell-probe-status-test",
+                pid_fifo.to_str().unwrap(),
+                exit_fifo.to_str().unwrap(),
+                release_fifo.to_str().unwrap(),
+            ],
+        );
+        invocation.completion = InvocationCompletion::ShellProbe;
+        let (result_sender, result_receiver) = mpsc::sync_channel(1);
+        let worker = thread::spawn(move || {
+            let result = run_shell_probe(&runner, &invocation, runner.deadline());
+            let _ = result_sender.send(result);
+        });
+
+        assert!(
+            poll_readable(&pid_pipe),
+            "probe processes were not reported"
+        );
+        let mut process_ids = String::new();
+        assert_ne!(
+            BufReader::new(pid_pipe)
+                .read_line(&mut process_ids)
+                .unwrap(),
+            0
+        );
+        let mut process_ids = process_ids.split_whitespace();
+        let direct_pid = process_ids.next().unwrap().parse::<i32>().unwrap();
+        let descendant_pid = process_ids.next().unwrap().parse::<i32>().unwrap();
+        assert_eq!(process_ids.next(), None);
+        let direct_pidfd = pidfd_open(
+            RustixPid::from_raw(direct_pid).unwrap(),
+            PidfdFlags::empty(),
+        )
+        .unwrap();
+        let descendant_pidfd = pidfd_open(
+            RustixPid::from_raw(descendant_pid).unwrap(),
+            PidfdFlags::empty(),
+        )
+        .unwrap();
+
+        exit_pipe.write_all(b"exit\n").unwrap();
+        drop(exit_pipe);
+        assert!(
+            poll_readable(&direct_pidfd),
+            "direct SSH child did not exit before the sentinel"
+        );
+        release_pipe.write_all(b"emit\n").unwrap();
+        drop(release_pipe);
+        let result = result_receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("probe did not complete after the descendant sentinel");
+        worker.join().unwrap();
+        let descendant_exited = poll_readable(&descendant_pidfd);
+        if !descendant_exited {
+            pidfd_send_signal(&descendant_pidfd, RustixSignal::KILL).unwrap();
+        }
+
+        assert!(
+            descendant_exited,
+            "stdout-holding descendant survived cleanup"
+        );
+        assert!(matches!(result, Err(ClientError::SshNonZero(Some(255)))));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn shell_probe_completes_when_descendant_holds_stdout_open() {
+        const SCRIPT: &str = r#"
+(IFS= read -r _ < "$1") &
+printf '__ET_COMSPEC__C:\\Windows\\System32\\cmd.exe\n'
+exit 0
+"#;
+
+        let dir = ProcessGroupTestDir::new();
+        let hold_fifo = dir.fifo("probe-hold");
+        let hold_control = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&hold_fifo)
+            .unwrap();
+        let runner = SystemSsh::with_timeout(Duration::from_secs(2));
+        let mut invocation = invocation(
+            "/bin/sh",
+            &[
+                "-c",
+                SCRIPT,
+                "shell-probe-test",
+                hold_fifo.to_str().unwrap(),
+            ],
+        );
+        invocation.completion = InvocationCompletion::ShellProbe;
+
+        let result = run_shell_probe(&runner, &invocation, runner.deadline());
+        drop(hold_control);
+
+        assert_eq!(result.unwrap(), RemoteShell::Cmd);
+    }
+
+    #[test]
+    fn shell_probe_matcher_ignores_complete_decoy_line() {
+        let captured = b"audit: echo __ET_COMSPEC__%ComSpec%\n";
+
+        assert_eq!(shell_probe_end(captured), None);
+    }
+
+    #[test]
+    fn shell_probe_matcher_returns_end_of_valid_line_after_decoy() {
+        let captured = b"audit: echo __ET_COMSPEC__%ComSpec%\n\
+                         __ET_COMSPEC__C:\\Windows\\System32\\cmd.exe\n";
+
+        assert_eq!(shell_probe_end(captured), Some(captured.len()));
+    }
+
+    #[test]
+    fn shell_probe_matcher_rejects_partial_valid_line() {
+        let captured = b"__ET_COMSPEC__C:\\Windows\\System32\\cmd.exe";
+
+        assert_eq!(shell_probe_end(captured), None);
     }
 
     #[test]

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -248,6 +248,61 @@ fn bare_windows_login_shell_is_detected_before_bootstrap() {
 }
 
 #[test]
+fn explicit_posix_shell_skips_probe_and_uses_exact_posix_bootstrap() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        bound(&stream);
+        assert_eq!(read_request(&mut stream).unwrap().version, Some(6));
+        write_response(&mut stream, &response_status(ConnectStatus::NewClient)).unwrap();
+        let key = passkey_to_key(SERVER_KEY).unwrap();
+        let mut connection = Connection::new_server(stream, &key);
+        let packet = connection.read_packet().unwrap();
+        assert_eq!(packet.header(), EtPacketType::InitialPayload as u8);
+        connection
+            .write_packet(
+                EtPacketType::InitialResponse as u8,
+                &InitialResponse { error: None }.encode_to_vec(),
+            )
+            .unwrap();
+    });
+
+    let fake = FakeSsh::new();
+    let output = fake
+        .command(RESOLVED_CONFIG, VALID_MARKER, 0, "")
+        .env("TERM", "xterm-256color")
+        .env(
+            "ET_FAKE_PROBE_STDOUT",
+            "__ET_COMSPEC__C:\\WINDOWS\\system32\\cmd.exe\r\n",
+        )
+        .args([
+            "-N".to_owned(),
+            "--remote-shell=posix".to_owned(),
+            address.to_string(),
+        ])
+        .output()
+        .unwrap();
+    server.join().unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+
+    let invocations = fake.invocations();
+    assert_eq!(invocations.len(), 2, "{invocations:?}");
+    assert_eq!(invocations[0], ["-G", "127.0.0.1"]);
+    let bootstrap = &invocations[1];
+    assert_eq!(bootstrap[0], "config-user@127.0.0.1");
+    let input = bootstrap[1]
+        .strip_prefix("printf '%s\\n' '")
+        .unwrap()
+        .strip_suffix("_xterm-256color' | 'etterminal' '--verbose=0'")
+        .unwrap();
+    let (id, passkey) = parse_id_passkey(input).unwrap();
+    assert!(id.starts_with("XXX"));
+    assert_eq!(id.len(), 16);
+    assert_eq!(passkey.len(), 32);
+}
+
+#[test]
 fn ssh_process_failures_are_typed() {
     let no_ssh = TestDir::new("no-ssh");
     let output = Command::new(env!("CARGO_BIN_EXE_et"))
@@ -424,6 +479,10 @@ fn jumphost_starts_a_jump_terminal_and_connects_to_the_jumphost() {
     let fake = FakeSsh::new();
     let output = fake
         .command(RESOLVED_CONFIG, VALID_MARKER, 0, "")
+        .env(
+            "ET_FAKE_PROBE_STDOUT",
+            "__ET_COMSPEC__C:\\WINDOWS\\system32\\cmd.exe\r\n",
+        )
         .args([
             "-N",
             "--jumphost",
@@ -448,15 +507,18 @@ fn jumphost_starts_a_jump_terminal_and_connects_to_the_jumphost() {
     assert_eq!(destination[0], "-J");
     assert_eq!(destination[1], "jump.example");
     assert_eq!(destination[2], "test-user@server-alias");
+    assert!(destination[3].starts_with("echo "), "{:?}", destination[3]);
     assert!(
-        destination[3].contains("etterminal") || destination[3].starts_with("printf"),
-        "remote command missing: {:?}",
+        destination[3].contains("\"et.exe\""),
+        "{:?}",
         destination[3]
     );
     assert_eq!(invocations[3], ["-G", "jump.example"]);
     let jump = &invocations[4];
     assert_eq!(jump[0], "jump.example");
-    // The jump terminal receives the relay destination and its own fifo.
+    // The jumphost remains POSIX even when the destination probe selects Cmd.
+    assert!(jump[1].contains("'etterminal'"), "{:?}", jump[1]);
+    assert!(!jump[1].contains("et.exe"), "{:?}", jump[1]);
     assert!(jump[1].contains("'--jump'"), "{:?}", jump[1]);
     assert!(jump[1].contains("'--dsthost=127.0.0.1'"), "{:?}", jump[1]);
     assert!(jump[1].contains("'--dstport=2022'"), "{:?}", jump[1]);

--- a/crates/et-bin/tests/terminal_runtime.rs
+++ b/crates/et-bin/tests/terminal_runtime.rs
@@ -22,6 +22,7 @@ use wait_timeout::ChildExt;
 const ID: &str = "abcdefghijklmnop";
 const KEY: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef";
 const TIMEOUT: Duration = Duration::from_secs(5);
+const LOGIN_TERM_COMPLETION: &[u8] = b"__ET_LOGIN_TERM_COMPLETE__\r\n";
 
 #[test]
 fn bootstrap_parent_reports_marker_and_leaves_registered_session_running() {
@@ -202,7 +203,8 @@ fn real_terminal_starts_login_shell_and_loads_profile_color() {
     let output = collect_until(&mut router, |output| {
         contains(output, LOGIN_COLOR_MARKER) || contains(output, NON_LOGIN_MARKER)
     });
-    let _ = child.wait_timeout(TIMEOUT).unwrap();
+    let status = child.wait_timeout(TIMEOUT).unwrap().unwrap();
+    assert!(status.success());
     assert!(
         contains(&output, LOGIN_COLOR_MARKER),
         "expected ANSI login-shell color marker when SHELL receives -l; got {:?}",
@@ -238,28 +240,34 @@ fn real_terminal_login_shell_preserves_term_without_colorterm() {
         TerminalPacketType::TerminalBuffer,
         &TerminalBuffer {
             buffer: Some(
-                b"printf 'TERM=%s\nCOLORTERM=%s\n' \"$TERM\" \"${COLORTERM-}\"; exit\n".to_vec(),
+                b"printf '\\nTERM=%s\\nCOLORTERM=%s\\n' \"$TERM\" \"${COLORTERM-}\"; printf '__ET_LOGIN_TERM_%s__\\n' COMPLETE; exit\n".to_vec(),
             ),
         },
     );
     let output = collect_until(&mut router, |output| {
-        (contains(output, LOGIN_COLOR_MARKER) || contains(output, NON_LOGIN_MARKER))
-            && contains(output, b"TERM=xterm-256color\r\nCOLORTERM=\r\n")
+        contains(output, LOGIN_TERM_COMPLETION)
     });
-    let _ = child.wait_timeout(TIMEOUT).unwrap();
+    let status = child.wait_timeout(TIMEOUT).unwrap().unwrap();
+    assert!(status.success());
     assert!(
         contains(&output, LOGIN_COLOR_MARKER),
         "expected ANSI login-shell color marker when SHELL receives -l; got {:?}",
         String::from_utf8_lossy(&output),
     );
+    let lines: Vec<&[u8]> = output
+        .split(|byte| *byte == b'\n')
+        .map(|line| line.strip_suffix(b"\r").unwrap_or(line))
+        .collect();
     assert!(
-        contains(&output, b"TERM=xterm-256color\r\nCOLORTERM=\r\n"),
-        "TERM=xterm-256color must survive empty TermInit with COLORTERM unset; got {:?}",
-        String::from_utf8_lossy(&output),
-    );
-    assert!(
-        !contains(&output, b"COLORTERM=truecolor"),
-        "COLORTERM must remain unset under empty TermInit; got {:?}",
+        lines.windows(3).any(|record| {
+            record
+                == [
+                    b"TERM=xterm-256color".as_slice(),
+                    b"COLORTERM=".as_slice(),
+                    b"__ET_LOGIN_TERM_COMPLETE__".as_slice(),
+                ]
+        }),
+        "expected complete TERM/COLORTERM record; got {:?}",
         String::from_utf8_lossy(&output),
     );
 }


### PR DESCRIPTION
## Summary
- keep Windows destination defaults separate from POSIX jumphost bootstrap paths
- make explicit `--remote-shell` choices authoritative and probe-free
- finish shell probing only on valid complete sentinel lines while preserving an already-observed SSH failure
- replace timing-dependent probe and PTY assertions with deterministic completion signals

## Context
`et@0.0.14` was published before the adversarial release review completed. The same resident ultrabrain reviewer requested three rounds of changes and explicitly approved this final corrective patch. This PR queues a patch changeset for `0.0.15`; it does not rewrite the existing `0.0.14` tag or assets.

## RED -> GREEN
- Cmd destination through a POSIX jumphost previously invoked `et.exe` on the jumphost
- explicit `--remote-shell posix` still probed and could switch to Cmd
- a valid probe sentinel could wait on descendant-held stdout
- sentinel text inside a banner line could complete capture early
- a direct SSH exit 255 could be discarded when a descendant emitted the sentinel
- probe tests depended on expected timeouts and one client test inherited ambient `TERM`

Deterministic regressions now cover each path, including mutation-sensitive pure matcher assertions.

## Validation
- `cargo test --workspace --locked -- --test-threads=1`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo build --workspace --locked`
- `cargo fmt --all -- --check`
- `git diff --check`
- Rust LSP diagnostics clean on all six Rust files
- Tegami patch changeset preview validated

## Review gate
Final resident ultrabrain verdict: `VERDICT: APPROVE` — no unresolved code, test, or release-metadata blocker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes remote shell detection: probes now finish only on complete valid sentinel lines, preserve an SSH exit status observed before completion, and explicit `--remote-shell` choices skip probing entirely.

**Bug Fixes**
- Probe capture ignores sentinel text embedded in banner lines and waits for a complete sentinel line.
- A nonzero SSH exit observed before a sentinel completes is preserved instead of discarded.
- Windows destination defaults stay separate from POSIX jumphost bootstrap paths, so `et.exe` no longer leaks into jumphost commands.
- Probe and PTY assertions use deterministic completion markers instead of timing-dependent expectations.

<sup>Written for commit acd423df8b0c60ca13c881ea965f5ffb978f69e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

