### PR TITLE
fix(client): restore colors for Ghostty terminals

### DIFF
--- a/.tegami/fix-ghostty-term-fallback.md
+++ b/.tegami/fix-ghostty-term-fallback.md
@@ -1,0 +1,11 @@
+---
+packages:
+  et: patch
+---
+
+## Restore remote colors for Ghostty clients
+
+ET clients launched from Ghostty now send the widely supported
+`TERM=xterm-256color` fallback instead of `xterm-ghostty`. This restores
+ordinary remote prompt and application colors on hosts without Ghostty's
+terminfo entry. Other terminal types remain unchanged.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ path selects the Windows bootstrap (no `printf`, CRLF lines, `&` separator) and 
 remains the explicit override. The session shell follows `%COMSPEC%`, or `ET_SHELL` if set on the
 server. OpenSSH on Windows must be reachable.
 
+### Connecting from Ghostty
+
+Ghostty identifies itself as `TERM=xterm-ghostty`, but many remote hosts do not have that terminfo
+entry and stock shell profiles may not recognize it as color-capable. ET sends
+`TERM=xterm-256color` for Ghostty clients so remote prompts and applications retain broadly
+supported 256-color behavior. Other terminal types are forwarded unchanged.
+
 ## Feature set
 
 - Protocol v6 handshake, `crypto_secretbox` (XSalsa20-Poly1305) framing, sequence numbers, and

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -51,6 +51,13 @@ fn resolve_remote_mode(args: &ClientArgs, detected_shell: Option<RemoteShell>) -
     }
 }
 
+fn normalize_terminal_type(term: Option<&str>) -> String {
+    match term {
+        None | Some("xterm-ghostty") => "xterm-256color".to_owned(),
+        Some(term) => term.to_owned(),
+    }
+}
+
 pub fn run(args: &[OsString]) -> Result<i32, clap::Error> {
     let mut parsed = ClientArgs::try_parse_from(
         ["et"]
@@ -102,7 +109,8 @@ fn run_client(
     )?;
     let user = requested_user.or(resolved.user);
     validate_ssh_destination(&destination.host, user.as_deref())?;
-    let term = std::env::var("TERM").unwrap_or_else(|_| "xterm-256color".to_string());
+    let local_term = std::env::var("TERM").ok();
+    let term = normalize_terminal_type(local_term.as_deref());
     let probe_request = BootstrapRequest {
         user: user.clone(),
         host_alias: destination.host.clone(),
@@ -648,5 +656,23 @@ mod tests {
                 terminal_path: None,
             }
         );
+    }
+
+    #[test]
+    fn ghostty_term_uses_compatible_remote_fallback() {
+        assert_eq!(normalize_terminal_type(None), "xterm-256color");
+        assert_eq!(
+            normalize_terminal_type(Some("xterm-ghostty")),
+            "xterm-256color"
+        );
+        for term in [
+            "xterm-256color",
+            "screen-256color",
+            "linux",
+            "xterm-kitty",
+            "arbitrary-term",
+        ] {
+            assert_eq!(normalize_terminal_type(Some(term)), term);
+        }
     }
 }

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -227,6 +227,7 @@ fn bare_windows_login_shell_is_detected_before_bootstrap() {
     let fake = FakeSsh::new();
     let output = fake
         .command(RESOLVED_CONFIG, VALID_MARKER, 0, "")
+        .env("TERM", "xterm-ghostty")
         .env(
             "ET_FAKE_PROBE_STDOUT",
             "__ET_COMSPEC__C:\\WINDOWS\\system32\\cmd.exe\r\n",
@@ -244,6 +245,8 @@ fn bare_windows_login_shell_is_detected_before_bootstrap() {
     let bootstrap = invocations[2].last().unwrap();
     assert!(bootstrap.starts_with("echo "), "{bootstrap}");
     assert!(bootstrap.contains("\"et.exe\""), "{bootstrap}");
+    assert!(bootstrap.contains("_xterm-256color|"), "{bootstrap}");
+    assert!(!bootstrap.contains("_xterm-ghostty"), "{bootstrap}");
     assert!(!bootstrap.contains("printf"), "{bootstrap}");
 }
 
@@ -271,7 +274,7 @@ fn explicit_posix_shell_skips_probe_and_uses_exact_posix_bootstrap() {
     let fake = FakeSsh::new();
     let output = fake
         .command(RESOLVED_CONFIG, VALID_MARKER, 0, "")
-        .env("TERM", "xterm-256color")
+        .env("TERM", "xterm-ghostty")
         .env(
             "ET_FAKE_PROBE_STDOUT",
             "__ET_COMSPEC__C:\\WINDOWS\\system32\\cmd.exe\r\n",
@@ -479,6 +482,7 @@ fn jumphost_starts_a_jump_terminal_and_connects_to_the_jumphost() {
     let fake = FakeSsh::new();
     let output = fake
         .command(RESOLVED_CONFIG, VALID_MARKER, 0, "")
+        .env("TERM", "xterm-ghostty")
         .env(
             "ET_FAKE_PROBE_STDOUT",
             "__ET_COMSPEC__C:\\WINDOWS\\system32\\cmd.exe\r\n",
@@ -513,12 +517,24 @@ fn jumphost_starts_a_jump_terminal_and_connects_to_the_jumphost() {
         "{:?}",
         destination[3]
     );
+    assert!(
+        destination[3].contains("_xterm-256color|"),
+        "{:?}",
+        destination[3]
+    );
+    assert!(
+        !destination[3].contains("_xterm-ghostty"),
+        "{:?}",
+        destination[3]
+    );
     assert_eq!(invocations[3], ["-G", "jump.example"]);
     let jump = &invocations[4];
     assert_eq!(jump[0], "jump.example");
     // The jumphost remains POSIX even when the destination probe selects Cmd.
     assert!(jump[1].contains("'etterminal'"), "{:?}", jump[1]);
     assert!(!jump[1].contains("et.exe"), "{:?}", jump[1]);
+    assert!(jump[1].contains("_xterm-256color'"), "{:?}", jump[1]);
+    assert!(!jump[1].contains("_xterm-ghostty"), "{:?}", jump[1]);
     assert!(jump[1].contains("'--jump'"), "{:?}", jump[1]);
     assert!(jump[1].contains("'--dsthost=127.0.0.1'"), "{:?}", jump[1]);
     assert!(jump[1].contains("'--dstport=2022'"), "{:?}", jump[1]);

--- a/crates/et-bin/tests/terminal_end_to_end.rs
+++ b/crates/et-bin/tests/terminal_end_to_end.rs
@@ -15,7 +15,7 @@ use wait_timeout::ChildExt;
 const TIMEOUT: Duration = Duration::from_secs(10);
 
 #[test]
-fn real_client_bootstrap_server_bridge_and_pty_execute_command() {
+fn real_client_ghostty_fallback_bootstrap_server_bridge_and_pty_emit_color() {
     let directory = std::env::temp_dir().join(format!("et-rs-terminal-e2e-{}", std::process::id()));
     let _ = fs::remove_dir_all(&directory);
     fs::create_dir(&directory).unwrap();
@@ -60,14 +60,18 @@ fn real_client_bootstrap_server_bridge_and_pty_execute_command() {
     let existing_path = std::env::var("PATH").unwrap();
     let mut client = Command::new(env!("CARGO_BIN_EXE_et"))
         .env("PATH", format!("{}:{existing_path}", directory.display()))
-        .env("TERM", "xterm-256color")
+        .env("TERM", "xterm-ghostty")
         .args(["--terminal-path"])
         .arg(&terminal)
         .args(["--serverfifo"])
         .arg(&router)
         .arg("-p")
         .arg(port.to_string())
-        .args(["-c", "printf 'FULL-PTY:%s\\n' \"$TERM\"", "127.0.0.1"])
+        .args([
+            "-c",
+            "case \"$TERM\" in xterm-color|*-256color) printf '\\033[01;32mGHOSTTY-GREEN\\033[00m:\\033[01;34mGHOSTTY-BLUE\\033[00m\\n';; esac; printf 'FULL-PTY:%s\\n' \"$TERM\"",
+            "127.0.0.1",
+        ])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -91,6 +95,14 @@ fn real_client_bootstrap_server_bridge_and_pty_execute_command() {
     assert!(status.success(), "{stderr_text}");
     assert!(
         stdout_text.contains("FULL-PTY:xterm-256color"),
+        "{stdout_text:?}"
+    );
+    assert!(
+        stdout_text.contains("\u{1b}[01;32mGHOSTTY-GREEN\u{1b}[00m"),
+        "{stdout_text:?}"
+    );
+    assert!(
+        stdout_text.contains("\u{1b}[01;34mGHOSTTY-BLUE\u{1b}[00m"),
         "{stdout_text:?}"
     );
 


### PR DESCRIPTION
## Summary
- normalize only `TERM=xterm-ghostty` to broadly supported `xterm-256color` before ET bootstrap
- preserve every other TERM unchanged, including Windows/Cmd and ET-native jumphost paths
- cover the wire-visible fallback and real client/server/PTY ANSI output
- document the Ghostty compatibility boundary and patch changeset

## Reproduction
On Jerry, the same real xterm.js/node-pty PTY produced:

- baseline official et 0.0.15: `TERM_RESULT=xterm-ghostty`, `GHOSTTY-COLOR-MISSING`, zero prompt SGR
- candidate: `TERM_RESULT=xterm-256color`, rendered `GHOSTTY-GREEN:GHOSTTY-BLUE`, real `ESC[01;32m` / `ESC[01;34m`

Jerry has no `xterm-ghostty` terminfo and its stock Bash profile enables colors for `xterm-color|*-256color`. The fix follows Ghostty documented fallback behavior without remote negotiation or extra SSH round trips.

## Validation
- pure TERM policy: 1 passed
- client bootstrap integration: 11 passed
- full client/server/PTY color E2E: 1 passed
- full serial workspace tests: pass
- clippy `-D warnings`: pass
- workspace build: pass
- fmt, diff-check, metadata, LSP: pass
- fresh real xterm.js + node-pty + headless Chrome baseline/candidate captures
- independent terminal Visual QA A/B: PASS / HIGH

## Scope
Non-Ghostty TERM values remain unchanged. Full Ghostty-specific capabilities still require remote `xterm-ghostty` terminfo; this patch intentionally provides the documented broadly compatible fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remote terminal colors for Ghostty clients by sending `TERM=xterm-256color` instead of `xterm-ghostty` during bootstrap. Hosts without Ghostty's terminfo entry and shell profiles that only colorize `xterm-color|*-256color` now render ANSI output correctly; all other TERM values are forwarded unchanged.

- Normalizes only `xterm-ghostty` (and unset `TERM`) to `xterm-256color` before the bootstrap request; Windows/Cmd and ET-native jumphost paths keep their existing behavior.
- Covers the wire-visible fallback in client bootstrap, the jump terminal, and the real client/server/PTY E2E test with ANSI color assertions.
- Documents the Ghostty compatibility boundary in `README.md` and adds a changeset entry.

<sup>Written for commit 6fdfb46b9be36fbb75857acfa77c5db2a24d9320. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

