### PR TITLE
fix(client): preserve Ghostty truecolor detection

### DIFF
--- a/.tegami/fix-ghostty-colorterm.md
+++ b/.tegami/fix-ghostty-colorterm.md
@@ -1,0 +1,11 @@
+---
+packages:
+  et: patch
+---
+
+## Preserve Ghostty truecolor detection
+
+Ghostty clients now forward the standard `COLORTERM=truecolor` hint to POSIX
+sessions while continuing to use the compatible `TERM=xterm-256color`
+fallback. Applications such as Neovim and tmux can retain automatic 24-bit
+color detection on remote hosts without Ghostty's terminfo entry.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ server. OpenSSH on Windows must be reachable.
 Ghostty identifies itself as `TERM=xterm-ghostty`, but many remote hosts do not have that terminfo
 entry and stock shell profiles may not recognize it as color-capable. ET sends
 `TERM=xterm-256color` for Ghostty clients so remote prompts and applications retain broadly
-supported 256-color behavior. Other terminal types are forwarded unchanged.
+supported 256-color behavior. Ghostty's standard `COLORTERM=truecolor` hint is also forwarded to
+POSIX sessions so applications that use it for 24-bit color detection do not downgrade. Other
+terminal types are forwarded unchanged.
 
 ## Feature set
 

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -58,6 +58,13 @@ fn normalize_terminal_type(term: Option<&str>) -> String {
     }
 }
 
+fn ghostty_colorterm<'a>(term: Option<&str>, colorterm: Option<&'a str>) -> Option<&'a str> {
+    match (term, colorterm) {
+        (Some("xterm-ghostty"), Some(value @ ("truecolor" | "24bit"))) => Some(value),
+        _ => None,
+    }
+}
+
 pub fn run(args: &[OsString]) -> Result<i32, clap::Error> {
     let mut parsed = ClientArgs::try_parse_from(
         ["et"]
@@ -110,7 +117,9 @@ fn run_client(
     let user = requested_user.or(resolved.user);
     validate_ssh_destination(&destination.host, user.as_deref())?;
     let local_term = std::env::var("TERM").ok();
+    let local_colorterm = std::env::var("COLORTERM").ok();
     let term = normalize_terminal_type(local_term.as_deref());
+    let colorterm = ghostty_colorterm(local_term.as_deref(), local_colorterm.as_deref());
     let probe_request = BootstrapRequest {
         user: user.clone(),
         host_alias: destination.host.clone(),
@@ -205,6 +214,13 @@ fn run_client(
         // The jumphost etserver dispatches on this flag and hands the payload
         // to the jump terminal instead of starting a shell.
         initial_payload.jumphost = Some(true);
+    }
+    if remote_mode.terminal_shell == RemoteShellKind::Posix {
+        if let Some(value) = colorterm {
+            initial_payload
+                .environmentvariables
+                .insert("COLORTERM".to_owned(), value.to_owned());
+        }
     }
     et_cli::logging::info(format!("Connecting to {endpoint}"));
     let connection = connect_initial(
@@ -674,5 +690,26 @@ mod tests {
         ] {
             assert_eq!(normalize_terminal_type(Some(term)), term);
         }
+    }
+
+    #[test]
+    fn ghostty_truecolor_hint_is_forwarded_only_for_known_values() {
+        assert_eq!(
+            ghostty_colorterm(Some("xterm-ghostty"), Some("truecolor")),
+            Some("truecolor")
+        );
+        assert_eq!(
+            ghostty_colorterm(Some("xterm-ghostty"), Some("24bit")),
+            Some("24bit")
+        );
+        assert_eq!(
+            ghostty_colorterm(Some("xterm-ghostty"), Some("unexpected")),
+            None
+        );
+        assert_eq!(
+            ghostty_colorterm(Some("xterm-256color"), Some("truecolor")),
+            None
+        );
+        assert_eq!(ghostty_colorterm(Some("xterm-ghostty"), None), None);
     }
 }

--- a/crates/et-bin/tests/terminal_end_to_end.rs
+++ b/crates/et-bin/tests/terminal_end_to_end.rs
@@ -22,6 +22,8 @@ fn real_client_ghostty_fallback_bootstrap_server_bridge_and_pty_emit_color() {
     fs::set_permissions(&directory, fs::Permissions::from_mode(0o700)).unwrap();
     let router = directory.join("router.sock");
     let config = directory.join("et.cfg");
+    let home = directory.join("home");
+    fs::create_dir(&home).unwrap();
     let reserved = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let port = reserved.local_addr().unwrap().port();
     drop(reserved);
@@ -34,6 +36,8 @@ fn real_client_ghostty_fallback_bootstrap_server_bridge_and_pty_emit_color() {
     )
     .unwrap();
     let mut server = Command::new(env!("CARGO_BIN_EXE_et"))
+        .env_remove("COLORTERM")
+        .env("HOME", &home)
         .args(["server", "--cfgfile"])
         .arg(&config)
         .stdout(Stdio::piped())
@@ -51,6 +55,7 @@ fn real_client_ghostty_fallback_bootstrap_server_bridge_and_pty_emit_color() {
            exit 0\n\
          fi\n\
          for last do :; done\n\
+         unset COLORTERM\n\
          exec /bin/sh -c \"$last\"\n",
     )
     .unwrap();
@@ -60,7 +65,9 @@ fn real_client_ghostty_fallback_bootstrap_server_bridge_and_pty_emit_color() {
     let existing_path = std::env::var("PATH").unwrap();
     let mut client = Command::new(env!("CARGO_BIN_EXE_et"))
         .env("PATH", format!("{}:{existing_path}", directory.display()))
+        .env("HOME", &home)
         .env("TERM", "xterm-ghostty")
+        .env("COLORTERM", "truecolor")
         .args(["--terminal-path"])
         .arg(&terminal)
         .args(["--serverfifo"])
@@ -69,7 +76,7 @@ fn real_client_ghostty_fallback_bootstrap_server_bridge_and_pty_emit_color() {
         .arg(port.to_string())
         .args([
             "-c",
-            "case \"$TERM\" in xterm-color|*-256color) printf '\\033[01;32mGHOSTTY-GREEN\\033[00m:\\033[01;34mGHOSTTY-BLUE\\033[00m\\n';; esac; printf 'FULL-PTY:%s\\n' \"$TERM\"",
+            "case \"$TERM\" in xterm-color|*-256color) printf '\\033[01;32mGHOSTTY-GREEN\\033[00m:\\033[01;34mGHOSTTY-BLUE\\033[00m\\n';; esac; printf 'FULL-PTY:%s:%s\\n' \"$TERM\" \"${COLORTERM-}\"",
             "127.0.0.1",
         ])
         .stdin(Stdio::null())
@@ -94,7 +101,7 @@ fn real_client_ghostty_fallback_bootstrap_server_bridge_and_pty_emit_color() {
     stderr.read_to_string(&mut stderr_text).unwrap();
     assert!(status.success(), "{stderr_text}");
     assert!(
-        stdout_text.contains("FULL-PTY:xterm-256color"),
+        stdout_text.contains("FULL-PTY:xterm-256color:truecolor"),
         "{stdout_text:?}"
     );
     assert!(


### PR DESCRIPTION
## Summary
- forward Ghostty standard `COLORTERM=truecolor` or `24bit` hints to POSIX sessions
- retain the remote `TERM=xterm-256color` compatibility fallback and leave Windows/other terminals unchanged
- isolate the E2E server, SSH shim, and HOME so the truecolor assertion cannot pass from inherited environment
- document the behavior and include an `et: patch` Tegami changeset

## Verification
- RED: isolated real client/server/PTY test observed `FULL-PTY:xterm-256color:` and exited 101
- GREEN: the same test observed `FULL-PTY:xterm-256color:truecolor`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `cargo check -p et --target x86_64-pc-windows-gnu`
- protocol-v6 proto and wire fixture diff: empty
- actual Ghostty GTK RED→GREEN screenshots plus xterm.js/Chrome corroboration; exact truecolor pixels and CJK width verified
- two independent visual reviewers: PASS / HIGH / zero blockers
- Bunshin swing exact commit: 2 Ghostty unit tests + real client/server/PTY E2E passed; cleanup complete

## Compatibility boundary
Only local `TERM=xterm-ghostty` with `COLORTERM=truecolor` or `24bit` is forwarded, and only for POSIX remote shells. Arbitrary values, `TERM_PROGRAM`, Cmd, PowerShell, and other terminal types are not forwarded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards Ghostty's standard `COLORTERM=truecolor` or `24bit` value to POSIX remote sessions so applications like Neovim and tmux keep automatic 24-bit color detection. Previously Ghostty clients only received `TERM=xterm-256color` without a `COLORTERM` hint, so those apps downgraded to 256 colors.

- Forwards only when the local `TERM` is `xterm-ghostty` and `COLORTERM` is exactly `truecolor` or `24bit`; other terminals, Windows shells, and arbitrary values are passed through unchanged.
- Keeps the `TERM=xterm-256color` compatibility fallback for all Ghostty clients.
- Isolates the E2E test server, SSH shim, and `HOME` so the truecolor assertion can't pass from an inherited environment.
- Adds an `et: patch` Tegami changeset and updates the README's color behavior note.

<sup>Written for commit 831636a7cb2992cb27ad9d3d1e84c466e251adbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

