### PR TITLE
fix(client): return cleanly after terminal exit

### DIFF
--- a/.tegami/fix-clean-terminal-exit.md
+++ b/.tegami/fix-clean-terminal-exit.md
@@ -1,0 +1,12 @@
+---
+packages:
+  et: patch
+---
+
+## Return cleanly to the local prompt after exit
+
+Interactive sessions now finish with an SSH-style `Connection to … closed.`
+line and keep the local prompt on the current screen. Graceful shell exits no
+longer issue an unmatched alternate-screen restore that could move the cursor
+to an old position, while abrupt failures retain the stronger terminal-mode
+cleanup needed for crashed full-screen applications.

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -244,6 +244,7 @@ fn run_client(
             keepalive: args.keepalive,
             terminal_enabled: !args.no_terminal,
             lines: crate::client_terminal::RemoteLines::from(remote_mode.terminal_shell),
+            connection_name: &request.host_alias,
         },
         forwarder,
         |connection| reconnect_with_retry(connection, &endpoint, &credentials, resolver),

--- a/crates/et-bin/src/client_terminal.rs
+++ b/crates/et-bin/src/client_terminal.rs
@@ -71,10 +71,11 @@ where
     } else {
         RawMode {
             enabled: false,
-            reset: TerminalReset::Abrupt,
+            reset: TerminalReset::LeaveAlternate,
         }
     };
     let close_message = (raw_mode.enabled && command.is_none()).then_some(connection_name);
+    let mut terminal_modes = TerminalModeState::default();
     // The network can disappear immediately after the initial handshake (a
     // laptop waking up is particularly prone to this).  These writes are
     // replay-buffered by `Connection`, so once recovery succeeds they must
@@ -88,7 +89,7 @@ where
             terminal_enabled,
             initial_size,
         )? {
-            return raw_mode.finish(Ok(()), close_message);
+            return raw_mode.finish(Ok(()), close_message, terminal_modes.alternate_screen);
         }
     }
     if terminal_enabled {
@@ -100,7 +101,7 @@ where
                 terminal_enabled,
                 initial_command,
             )? {
-                return raw_mode.finish(Ok(()), close_message);
+                return raw_mode.finish(Ok(()), close_message, terminal_modes.alternate_screen);
             }
         }
     }
@@ -147,6 +148,7 @@ where
                 keepalive_seconds: keepalive,
                 terminal_enabled,
                 auto_cursor_report,
+                terminal_modes: &mut terminal_modes,
             },
             &forwarder,
             reconnect,
@@ -163,11 +165,12 @@ where
             keepalive_seconds: keepalive,
             terminal_enabled,
             auto_cursor_report,
+            terminal_modes: &mut terminal_modes,
         },
         &forwarder,
         reconnect,
     );
-    raw_mode.finish(result, close_message)
+    raw_mode.finish(result, close_message, terminal_modes.alternate_screen)
 }
 
 /// Device Status Report request (`ESC [ 6 n`).
@@ -181,7 +184,10 @@ pub(crate) const CURSOR_REPORT_REPLY: &[u8] = b"\x1b[1;1R";
 /// emits that request on startup and waits for the answer, which an interactive
 /// terminal emulator provides. Non-interactive sessions have no emulator to
 /// answer, so the caller replies on their behalf (see `auto_cursor_report`).
-pub(crate) fn display_packet(packet: et_core::packet::Packet) -> Result<bool, ClientError> {
+pub(crate) fn display_packet(
+    packet: et_core::packet::Packet,
+    terminal_modes: &mut TerminalModeState,
+) -> Result<bool, ClientError> {
     match packet.header() {
         value if value == TerminalPacketType::TerminalBuffer as u8 => {
             let message = TerminalBuffer::decode(packet.payload())
@@ -189,6 +195,7 @@ pub(crate) fn display_packet(packet: et_core::packet::Packet) -> Result<bool, Cl
             let bytes = message
                 .buffer
                 .ok_or_else(|| terminal_text("terminal output is missing bytes"))?;
+            terminal_modes.observe(&bytes);
             io::stdout()
                 .lock()
                 .write_all(&bytes)
@@ -335,32 +342,58 @@ where
 const TERMINAL_MODE_RESET: &[u8] = b"\x1b[<64u\x1b[=0;1u\x1b[?1049l\x1b[<64u\x1b[=0;1u\
 \x1b[>4;0m\x1b[?2004l\x1b[?1004l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?25h";
 
-/// Normal remote-shell exit. The remote side had an opportunity to restore
-/// its screen, so leaving the alternate screen here would restore an
-/// unrelated saved cursor in the local emulator. Keep the input-mode cleanup
-/// that is safe and idempotent on the current main screen.
+/// Cleanup when the remote byte stream left no alternate screen active.
+/// Sending an unmatched alternate-screen leave would restore an unrelated
+/// saved cursor in the local emulator, so only the idempotent input-mode
+/// cleanup runs on the current main screen.
 const GRACEFUL_TERMINAL_MODE_RESET: &[u8] = b"\x1b[<64u\x1b[=0;1u\
 \x1b[>4;0m\x1b[?2004l\x1b[?1004l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?25h";
 
+#[derive(Default)]
+pub(crate) struct TerminalModeState {
+    alternate_prefix_len: usize,
+    alternate_screen: bool,
+}
+
+impl TerminalModeState {
+    fn observe(&mut self, bytes: &[u8]) {
+        const PREFIX: &[u8] = b"\x1b[?1049";
+        for &byte in bytes {
+            if self.alternate_prefix_len == PREFIX.len() {
+                match byte {
+                    b'h' => self.alternate_screen = true,
+                    b'l' => self.alternate_screen = false,
+                    _ => {}
+                }
+                self.alternate_prefix_len = usize::from(byte == PREFIX[0]);
+            } else if byte == PREFIX[self.alternate_prefix_len] {
+                self.alternate_prefix_len += 1;
+            } else {
+                self.alternate_prefix_len = usize::from(byte == PREFIX[0]);
+            }
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum TerminalReset {
-    Abrupt,
-    Graceful,
+    LeaveAlternate,
+    KeepCurrentScreen,
 }
 
 impl TerminalReset {
-    fn for_result(result: &Result<(), ClientError>) -> Self {
-        if result.is_ok() {
-            Self::Graceful
+    const fn for_alternate_screen(alternate_screen: bool) -> Self {
+        if alternate_screen {
+            Self::LeaveAlternate
         } else {
-            Self::Abrupt
+            Self::KeepCurrentScreen
         }
     }
 
     const fn bytes(self) -> &'static [u8] {
         match self {
-            Self::Abrupt => TERMINAL_MODE_RESET,
-            Self::Graceful => GRACEFUL_TERMINAL_MODE_RESET,
+            Self::LeaveAlternate => TERMINAL_MODE_RESET,
+            Self::KeepCurrentScreen => GRACEFUL_TERMINAL_MODE_RESET,
         }
     }
 }
@@ -378,7 +411,7 @@ impl RawMode {
         }
         Ok(Self {
             enabled,
-            reset: TerminalReset::Abrupt,
+            reset: TerminalReset::LeaveAlternate,
         })
     }
 
@@ -386,12 +419,16 @@ impl RawMode {
         mut self,
         result: Result<(), ClientError>,
         connection_name: Option<&str>,
+        alternate_screen: bool,
     ) -> Result<(), ClientError> {
-        self.reset = TerminalReset::for_result(&result);
+        self.reset = TerminalReset::for_alternate_screen(alternate_screen);
         drop(self);
         if result.is_ok() {
             if let Some(connection_name) = connection_name {
-                eprintln!("Connection to {connection_name} closed.");
+                let _ = writeln!(
+                    io::stderr().lock(),
+                    "Connection to {connection_name} closed."
+                );
             }
         }
         result

--- a/crates/et-bin/src/client_terminal.rs
+++ b/crates/et-bin/src/client_terminal.rs
@@ -46,6 +46,7 @@ pub struct TerminalOptions<'a> {
     pub keepalive: u32,
     pub terminal_enabled: bool,
     pub lines: RemoteLines,
+    pub connection_name: &'a str,
 }
 
 pub fn run<F>(
@@ -63,12 +64,17 @@ where
         keepalive,
         terminal_enabled,
         lines,
+        connection_name,
     } = options;
     let raw_mode = if terminal_enabled {
         RawMode::enter()?
     } else {
-        RawMode { enabled: false }
+        RawMode {
+            enabled: false,
+            reset: TerminalReset::Abrupt,
+        }
     };
+    let close_message = (raw_mode.enabled && command.is_none()).then_some(connection_name);
     // The network can disappear immediately after the initial handshake (a
     // laptop waking up is particularly prone to this).  These writes are
     // replay-buffered by `Connection`, so once recovery succeeds they must
@@ -82,7 +88,7 @@ where
             terminal_enabled,
             initial_size,
         )? {
-            return Ok(());
+            return raw_mode.finish(Ok(()), close_message);
         }
     }
     if terminal_enabled {
@@ -94,7 +100,7 @@ where
                 terminal_enabled,
                 initial_command,
             )? {
-                return Ok(());
+                return raw_mode.finish(Ok(()), close_message);
             }
         }
     }
@@ -161,8 +167,7 @@ where
         &forwarder,
         reconnect,
     );
-    drop(raw_mode);
-    result
+    raw_mode.finish(result, close_message)
 }
 
 /// Device Status Report request (`ESC [ 6 n`).
@@ -330,8 +335,39 @@ where
 const TERMINAL_MODE_RESET: &[u8] = b"\x1b[<64u\x1b[=0;1u\x1b[?1049l\x1b[<64u\x1b[=0;1u\
 \x1b[>4;0m\x1b[?2004l\x1b[?1004l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?25h";
 
+/// Normal remote-shell exit. The remote side had an opportunity to restore
+/// its screen, so leaving the alternate screen here would restore an
+/// unrelated saved cursor in the local emulator. Keep the input-mode cleanup
+/// that is safe and idempotent on the current main screen.
+const GRACEFUL_TERMINAL_MODE_RESET: &[u8] = b"\x1b[<64u\x1b[=0;1u\
+\x1b[>4;0m\x1b[?2004l\x1b[?1004l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?25h";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TerminalReset {
+    Abrupt,
+    Graceful,
+}
+
+impl TerminalReset {
+    fn for_result(result: &Result<(), ClientError>) -> Self {
+        if result.is_ok() {
+            Self::Graceful
+        } else {
+            Self::Abrupt
+        }
+    }
+
+    const fn bytes(self) -> &'static [u8] {
+        match self {
+            Self::Abrupt => TERMINAL_MODE_RESET,
+            Self::Graceful => GRACEFUL_TERMINAL_MODE_RESET,
+        }
+    }
+}
+
 struct RawMode {
     enabled: bool,
+    reset: TerminalReset,
 }
 
 impl RawMode {
@@ -340,7 +376,25 @@ impl RawMode {
         if enabled {
             enable_raw_mode().map_err(|error| terminal_io("enabling raw terminal mode", error))?;
         }
-        Ok(Self { enabled })
+        Ok(Self {
+            enabled,
+            reset: TerminalReset::Abrupt,
+        })
+    }
+
+    fn finish(
+        mut self,
+        result: Result<(), ClientError>,
+        connection_name: Option<&str>,
+    ) -> Result<(), ClientError> {
+        self.reset = TerminalReset::for_result(&result);
+        drop(self);
+        if result.is_ok() {
+            if let Some(connection_name) = connection_name {
+                eprintln!("Connection to {connection_name} closed.");
+            }
+        }
+        result
     }
 }
 
@@ -348,7 +402,7 @@ impl Drop for RawMode {
     fn drop(&mut self) {
         if self.enabled {
             let mut stdout = io::stdout().lock();
-            let _ = stdout.write_all(TERMINAL_MODE_RESET);
+            let _ = stdout.write_all(self.reset.bytes());
             let _ = stdout.flush();
             let _ = disable_raw_mode();
         }

--- a/crates/et-bin/src/client_terminal_loop.rs
+++ b/crates/et-bin/src/client_terminal_loop.rs
@@ -16,6 +16,7 @@ use rustix::event::{poll, PollFd, PollFlags};
 #[cfg(unix)]
 use rustix::time::Timespec;
 
+use crate::client_terminal::TerminalModeState;
 #[cfg(unix)]
 use crate::client_terminal::{
     connection_ended, display_packet, recover_transport, send_buffer, send_size, terminal_error,
@@ -32,18 +33,19 @@ const INPUT_CHUNK: usize = 16 * 1024;
 const MISSED_KEEPALIVES: u32 = 3;
 
 /// Loop configuration resolved by [`crate::client_terminal::run`].
-pub(crate) struct PumpOptions {
+pub(crate) struct PumpOptions<'a> {
     pub(crate) read_stdin: bool,
     pub(crate) keepalive_seconds: u32,
     pub(crate) terminal_enabled: bool,
     pub(crate) auto_cursor_report: bool,
+    pub(crate) terminal_modes: &'a mut TerminalModeState,
 }
 
 #[cfg(unix)]
 pub fn pump<F>(
     connection: &mut Connection,
     wake: &mut UnixStream,
-    options: PumpOptions,
+    options: PumpOptions<'_>,
     forwarder: &Forwarder,
     mut reconnect: F,
 ) -> Result<(), ClientError>
@@ -55,6 +57,7 @@ where
         keepalive_seconds,
         terminal_enabled,
         auto_cursor_report,
+        terminal_modes,
     } = options;
     let stdin = io::stdin();
     let interval = Duration::from_secs(u64::from(keepalive_seconds.max(1)));
@@ -167,7 +170,9 @@ where
                         pending_forward = forwarder
                             .try_receive(packet)
                             .map_err(|error| terminal_text(error.to_string()))?;
-                    } else if route_server_packet(packet, terminal_enabled)? && auto_cursor_report {
+                    } else if route_server_packet(packet, terminal_enabled, terminal_modes)?
+                        && auto_cursor_report
+                    {
                         let _ =
                             send_buffer(connection, crate::client_terminal::CURSOR_REPORT_REPLY);
                     }
@@ -253,9 +258,10 @@ where
 fn route_server_packet(
     packet: et_core::packet::Packet,
     terminal_enabled: bool,
+    terminal_modes: &mut TerminalModeState,
 ) -> Result<bool, ClientError> {
     if terminal_enabled || packet.header() == TerminalPacketType::KeepAlive as u8 {
-        return display_packet(packet);
+        return display_packet(packet, terminal_modes);
     }
     if packet.header() == TerminalPacketType::TerminalBuffer as u8 {
         return Ok(false);

--- a/crates/et-bin/src/client_terminal_tests.rs
+++ b/crates/et-bin/src/client_terminal_tests.rs
@@ -5,7 +5,10 @@ use et_core::proto::{TerminalBuffer, TerminalPacketType};
 use et_net::connection::{ConnError, Connection};
 use prost::Message;
 
-use super::{recover_initial_transport, recover_transport, send_command};
+use super::{
+    recover_initial_transport, recover_transport, send_command, TerminalReset,
+    GRACEFUL_TERMINAL_MODE_RESET, TERMINAL_MODE_RESET,
+};
 use crate::client_terminal::{connection_ended, RemoteLines};
 use crate::error::ClientError;
 use crate::initial_connect::ReconnectOutcome;
@@ -95,6 +98,45 @@ fn recovery_rechecks_terminal_setup_before_returning_to_the_pump() {
     // operation before it declares the socket usable to the pump.
     assert!(recovered);
     assert_eq!(attempts, 1);
+}
+
+#[test]
+fn abrupt_terminal_mode_reset_leaves_the_alternate_screen() {
+    assert!(TERMINAL_MODE_RESET
+        .windows(b"\x1b[?1049l".len())
+        .any(|window| window == b"\x1b[?1049l"));
+}
+
+#[test]
+fn graceful_terminal_mode_reset_keeps_the_main_screen() {
+    assert!(!GRACEFUL_TERMINAL_MODE_RESET
+        .windows(b"\x1b[?1049l".len())
+        .any(|window| window == b"\x1b[?1049l"));
+    for sequence in [
+        b"\x1b[<64u".as_slice(),
+        b"\x1b[=0;1u".as_slice(),
+        b"\x1b[>4;0m".as_slice(),
+        b"\x1b[?2004l".as_slice(),
+        b"\x1b[?1004l".as_slice(),
+        b"\x1b[?1000l".as_slice(),
+        b"\x1b[?1002l".as_slice(),
+        b"\x1b[?1003l".as_slice(),
+        b"\x1b[?1006l".as_slice(),
+        b"\x1b[?25h".as_slice(),
+    ] {
+        assert!(GRACEFUL_TERMINAL_MODE_RESET
+            .windows(sequence.len())
+            .any(|window| window == sequence));
+    }
+}
+
+#[test]
+fn terminal_result_selects_graceful_or_abrupt_reset() {
+    assert_eq!(TerminalReset::for_result(&Ok(())), TerminalReset::Graceful);
+    assert_eq!(
+        TerminalReset::for_result(&Err(super::terminal_text("broken terminal"))),
+        TerminalReset::Abrupt
+    );
 }
 
 fn tcp_pair() -> (TcpStream, TcpStream) {

--- a/crates/et-bin/src/client_terminal_tests.rs
+++ b/crates/et-bin/src/client_terminal_tests.rs
@@ -6,7 +6,7 @@ use et_net::connection::{ConnError, Connection};
 use prost::Message;
 
 use super::{
-    recover_initial_transport, recover_transport, send_command, TerminalReset,
+    recover_initial_transport, recover_transport, send_command, TerminalModeState, TerminalReset,
     GRACEFUL_TERMINAL_MODE_RESET, TERMINAL_MODE_RESET,
 };
 use crate::client_terminal::{connection_ended, RemoteLines};
@@ -131,12 +131,28 @@ fn graceful_terminal_mode_reset_keeps_the_main_screen() {
 }
 
 #[test]
-fn terminal_result_selects_graceful_or_abrupt_reset() {
-    assert_eq!(TerminalReset::for_result(&Ok(())), TerminalReset::Graceful);
+fn observed_alternate_screen_selects_graceful_or_abrupt_reset() {
     assert_eq!(
-        TerminalReset::for_result(&Err(super::terminal_text("broken terminal"))),
-        TerminalReset::Abrupt
+        TerminalReset::for_alternate_screen(false),
+        TerminalReset::KeepCurrentScreen
     );
+    assert_eq!(
+        TerminalReset::for_alternate_screen(true),
+        TerminalReset::LeaveAlternate
+    );
+}
+
+#[test]
+fn alternate_screen_tracking_handles_split_enter_and_leave_sequences() {
+    let mut modes = TerminalModeState::default();
+    modes.observe(b"before\x1b[?10");
+    assert!(!modes.alternate_screen);
+    modes.observe(b"49hinside");
+    assert!(modes.alternate_screen);
+    modes.observe(b"\x1b[?104");
+    assert!(modes.alternate_screen);
+    modes.observe(b"9lafter");
+    assert!(!modes.alternate_screen);
 }
 
 fn tcp_pair() -> (TcpStream, TcpStream) {

--- a/crates/et-bin/src/client_terminal_windows.rs
+++ b/crates/et-bin/src/client_terminal_windows.rs
@@ -20,7 +20,7 @@ use et_net::forward::{is_forward_packet, Forwarder};
 
 use crate::client_terminal::{
     connection_ended, display_packet, recover_transport, send_buffer, send_size, terminal_error,
-    terminal_text,
+    terminal_text, TerminalModeState,
 };
 use crate::error::ClientError;
 use crate::initial_connect::ReconnectOutcome;
@@ -31,7 +31,7 @@ const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 pub fn pump<F>(
     connection: &mut Connection,
-    options: crate::client_terminal_loop::PumpOptions,
+    options: crate::client_terminal_loop::PumpOptions<'_>,
     forwarder: &Forwarder,
     mut reconnect: F,
 ) -> Result<(), ClientError>
@@ -43,6 +43,7 @@ where
         keepalive_seconds,
         terminal_enabled,
         auto_cursor_report,
+        terminal_modes,
     } = options;
     let interval = Duration::from_secs(u64::from(keepalive_seconds.max(1)));
     let silence = interval.saturating_mul(MISSED_KEEPALIVES);
@@ -112,7 +113,9 @@ where
                         pending_forward = forwarder
                             .try_receive(packet)
                             .map_err(|error| terminal_text(error.to_string()))?;
-                    } else if route_server_packet(packet, terminal_enabled)? && auto_cursor_report {
+                    } else if route_server_packet(packet, terminal_enabled, terminal_modes)?
+                        && auto_cursor_report
+                    {
                         let _ =
                             send_buffer(connection, crate::client_terminal::CURSOR_REPORT_REPLY);
                     }
@@ -181,9 +184,10 @@ where
 fn route_server_packet(
     packet: et_core::packet::Packet,
     terminal_enabled: bool,
+    terminal_modes: &mut TerminalModeState,
 ) -> Result<bool, ClientError> {
     if terminal_enabled || packet.header() == TerminalPacketType::KeepAlive as u8 {
-        return display_packet(packet);
+        return display_packet(packet, terminal_modes);
     }
     if packet.header() == TerminalPacketType::TerminalBuffer as u8 {
         return Ok(false);

--- a/crates/et-bin/tests/terminal_end_to_end.rs
+++ b/crates/et-bin/tests/terminal_end_to_end.rs
@@ -100,6 +100,7 @@ fn real_client_ghostty_fallback_bootstrap_server_bridge_and_pty_emit_color() {
     stdout.read_to_string(&mut stdout_text).unwrap();
     stderr.read_to_string(&mut stderr_text).unwrap();
     assert!(status.success(), "{stderr_text}");
+    assert!(!stderr_text.contains("Connection to "), "{stderr_text:?}");
     assert!(
         stdout_text.contains("FULL-PTY:xterm-256color:truecolor"),
         "{stdout_text:?}"
@@ -149,6 +150,10 @@ fn real_client_ghostty_fallback_bootstrap_server_bridge_and_pty_emit_color() {
         .read_to_string(&mut no_exit_stderr)
         .unwrap();
     assert!(status.success(), "{no_exit_stderr}");
+    assert!(
+        !no_exit_stderr.contains("Connection to "),
+        "{no_exit_stderr:?}"
+    );
     assert!(
         no_exit_stdout.contains("NOEXIT:xterm-256color"),
         "{no_exit_stdout:?}"

--- a/crates/et-bin/tests/terminal_tty_qa.rs
+++ b/crates/et-bin/tests/terminal_tty_qa.rs
@@ -181,6 +181,63 @@ fn real_tty_forwards_input_control_bytes_and_live_resize() {
     assert!(output.windows(4).any(|window| window == b"CTRL"));
 }
 
+#[test]
+fn real_tty_graceful_exit_keeps_the_main_screen_and_reports_close() {
+    let stack = Stack::start();
+    let pair = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 800,
+            pixel_height: 480,
+        })
+        .unwrap();
+    let mut client = CommandBuilder::new(env!("CARGO_BIN_EXE_et"));
+    client.args([
+        "--terminal-path",
+        stack.terminal.to_str().unwrap(),
+        "--serverfifo",
+        stack.router.to_str().unwrap(),
+        "-p",
+        &stack.port.to_string(),
+        "127.0.0.1",
+    ]);
+    client.env(
+        "PATH",
+        format!(
+            "{}:{}",
+            stack.directory.display(),
+            std::env::var("PATH").unwrap()
+        ),
+    );
+    client.env("TERM", "xterm-256color");
+    let mut child = pair.slave.spawn_command(client).unwrap();
+    drop(pair.slave);
+    let mut writer = pair.master.take_writer().unwrap();
+    let mut output = Vec::new();
+    writer.write_all(b"exit\n").unwrap();
+    drop(writer);
+    pair.master
+        .try_clone_reader()
+        .unwrap()
+        .read_to_end(&mut output)
+        .unwrap();
+    let status = child.wait().unwrap();
+    assert!(status.success(), "status={status:?} output={output:?}");
+    assert!(
+        !output
+            .windows(b"\x1b[?1049l".len())
+            .any(|window| window == b"\x1b[?1049l"),
+        "graceful exit must not restore a stale alternate-screen cursor: {output:?}"
+    );
+    assert!(
+        output
+            .windows(b"Connection to 127.0.0.1 closed.\r\n".len())
+            .any(|window| window == b"Connection to 127.0.0.1 closed.\r\n"),
+        "graceful exit must visibly separate the remote session: {output:?}"
+    );
+}
+
 fn receive_until(
     receiver: &mpsc::Receiver<Vec<u8>>,
     mut output: Vec<u8>,


### PR DESCRIPTION
## Summary
- keep graceful interactive exits on the current main screen instead of issuing an unmatched alternate-screen restore
- retain the full defensive terminal reset for abrupt/error paths and restore raw/console mode before printing an SSH-style close line
- keep noninteractive command and `--no-exit` output banner-free
- add deterministic real-PTY coverage and a patch changeset

## Root cause
`RawMode::drop` always emitted `ESC[?1049l`, even when the remote session never entered the alternate screen. xterm.js restored a stale saved cursor: SSH ended at row 23 with a clean local prompt, while ET ended at row 3 with `logout` stranded below it. A synthetic control changed only that sequence and reproduced the teleport.

## RED -> GREEN
- RED: real PTY test exited 101 because graceful output contained unmatched `ESC[?1049l` and lacked `Connection to 127.0.0.1 closed.`
- GREEN: same test passes; abrupt-reset characterization remains green
- xterm.js/Chrome: `1049h=0`, `1049l=0`, clean `LOCAL_EXIT_PROBE`, cursor on final local prompt row
- actual Ghostty: clean `logout` -> `Connection to localhost closed.` -> local prompt ordering

## Verification
- changed-file rust-analyzer diagnostics clean
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `cargo check -p et --target x86_64-pc-windows-gnu`
- protocol-v6 proto and `fixtures/wire.json` diff empty
- Bunshin cursor exact commit: 7 unit + 3 real TTY + 1 command E2E passed; cleanup done
- Bunshin swing exact commit: 7 unit + 3 real TTY + 1 command E2E passed; cleanup done
- independent functional visual review: PASS / HIGH / no blockers
- independent terminal-grid visual review: PASS / HIGH / no blockers

## Compatibility boundary
The existing ET protocol-v6 exit-status limitation is unchanged: remote `exit 7` is still not transported by the terminal protocol. This PR fixes visual/session cleanup only and does not alter wire bytes, reconnect semantics, or noninteractive output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes graceful shell exits so the local prompt returns on the current screen instead of restoring a stale alternate-screen cursor. The client now tracks whether the remote session entered the alternate screen and only issues the full screen restore (`ESC[?1049l`) when it did; interactive exits also print an SSH-style close line.

- Graceful exits skip the unmatched alternate-screen leave, while abrupt failures keep the full defensive reset.
- Noninteractive and `--no-exit` output stays banner-free, with real-PTY tests and a patch changeset.

<sup>Written for commit ec957373ca7c58d62b7f1b47c4d4fa312c3baddc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

