### PR TITLE
fix(client): preserve UTF-8 locale detection

### DIFF
--- a/.tegami/fix-posix-locale-forwarding.md
+++ b/.tegami/fix-posix-locale-forwarding.md
@@ -1,0 +1,10 @@
+---
+packages:
+  et: patch
+---
+
+## Preserve client locales in POSIX sessions
+
+Clients now forward `LANG` and `LC_*` values to each new POSIX session, matching
+the environment behavior users expect from SSH. Locale-sensitive applications
+such as btop can detect UTF-8 without changing Windows session environments.

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -11,6 +11,9 @@ use crate::bootstrap::{
     build_invocation, build_jump_invocation, build_shell_probe, cmd_safe, provisional_credentials,
     validate_ssh_destination, BootstrapRequest, Credentials, JumpBootstrapRequest, RemoteShell,
 };
+use crate::client_environment::{
+    ghostty_colorterm, normalize_terminal_type, ssh_locale_environment,
+};
 use crate::deadline::Deadline;
 use crate::error::ClientError;
 use crate::initial_connect::{connect_initial, reconnect, Endpoint, ReconnectOutcome};
@@ -48,20 +51,6 @@ fn resolve_remote_mode(args: &ClientArgs, detected_shell: Option<RemoteShell>) -
         terminal_path: args
             .effective_terminal_path()
             .or_else(|| (bootstrap_shell == RemoteShell::Cmd).then(|| "et.exe".to_owned())),
-    }
-}
-
-fn normalize_terminal_type(term: Option<&str>) -> String {
-    match term {
-        None | Some("xterm-ghostty") => "xterm-256color".to_owned(),
-        Some(term) => term.to_owned(),
-    }
-}
-
-fn ghostty_colorterm<'a>(term: Option<&str>, colorterm: Option<&'a str>) -> Option<&'a str> {
-    match (term, colorterm) {
-        (Some("xterm-ghostty"), Some(value @ ("truecolor" | "24bit"))) => Some(value),
-        _ => None,
     }
 }
 
@@ -216,6 +205,9 @@ fn run_client(
         initial_payload.jumphost = Some(true);
     }
     if remote_mode.terminal_shell == RemoteShellKind::Posix {
+        initial_payload
+            .environmentvariables
+            .extend(ssh_locale_environment());
         if let Some(value) = colorterm {
             initial_payload
                 .environmentvariables
@@ -672,44 +664,5 @@ mod tests {
                 terminal_path: None,
             }
         );
-    }
-
-    #[test]
-    fn ghostty_term_uses_compatible_remote_fallback() {
-        assert_eq!(normalize_terminal_type(None), "xterm-256color");
-        assert_eq!(
-            normalize_terminal_type(Some("xterm-ghostty")),
-            "xterm-256color"
-        );
-        for term in [
-            "xterm-256color",
-            "screen-256color",
-            "linux",
-            "xterm-kitty",
-            "arbitrary-term",
-        ] {
-            assert_eq!(normalize_terminal_type(Some(term)), term);
-        }
-    }
-
-    #[test]
-    fn ghostty_truecolor_hint_is_forwarded_only_for_known_values() {
-        assert_eq!(
-            ghostty_colorterm(Some("xterm-ghostty"), Some("truecolor")),
-            Some("truecolor")
-        );
-        assert_eq!(
-            ghostty_colorterm(Some("xterm-ghostty"), Some("24bit")),
-            Some("24bit")
-        );
-        assert_eq!(
-            ghostty_colorterm(Some("xterm-ghostty"), Some("unexpected")),
-            None
-        );
-        assert_eq!(
-            ghostty_colorterm(Some("xterm-256color"), Some("truecolor")),
-            None
-        );
-        assert_eq!(ghostty_colorterm(Some("xterm-ghostty"), None), None);
     }
 }

--- a/crates/et-bin/src/client_environment.rs
+++ b/crates/et-bin/src/client_environment.rs
@@ -1,0 +1,71 @@
+pub(crate) fn normalize_terminal_type(term: Option<&str>) -> String {
+    match term {
+        None | Some("xterm-ghostty") => "xterm-256color".to_owned(),
+        Some(term) => term.to_owned(),
+    }
+}
+
+pub(crate) fn ghostty_colorterm<'a>(
+    term: Option<&str>,
+    colorterm: Option<&'a str>,
+) -> Option<&'a str> {
+    match (term, colorterm) {
+        (Some("xterm-ghostty"), Some(value @ ("truecolor" | "24bit"))) => Some(value),
+        _ => None,
+    }
+}
+
+/// Collect locale variables matched by OpenSSH's `SendEnv LANG LC_*`.
+pub(crate) fn ssh_locale_environment() -> impl Iterator<Item = (String, String)> {
+    std::env::vars_os().filter_map(|(name, value)| {
+        let name = name.into_string().ok()?;
+        if name != "LANG" && !name.starts_with("LC_") {
+            return None;
+        }
+        Some((name, value.into_string().ok()?))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ghostty_colorterm, normalize_terminal_type};
+
+    #[test]
+    fn ghostty_term_uses_compatible_remote_fallback() {
+        assert_eq!(normalize_terminal_type(None), "xterm-256color");
+        assert_eq!(
+            normalize_terminal_type(Some("xterm-ghostty")),
+            "xterm-256color"
+        );
+        for term in [
+            "xterm-256color",
+            "screen-256color",
+            "linux",
+            "xterm-kitty",
+            "arbitrary-term",
+        ] {
+            assert_eq!(normalize_terminal_type(Some(term)), term);
+        }
+    }
+
+    #[test]
+    fn ghostty_truecolor_hint_is_forwarded_only_for_known_values() {
+        assert_eq!(
+            ghostty_colorterm(Some("xterm-ghostty"), Some("truecolor")),
+            Some("truecolor")
+        );
+        assert_eq!(
+            ghostty_colorterm(Some("xterm-ghostty"), Some("24bit")),
+            Some("24bit")
+        );
+        assert_eq!(
+            ghostty_colorterm(Some("xterm-ghostty"), Some("unexpected")),
+            None
+        );
+        assert_eq!(
+            ghostty_colorterm(Some("xterm-256color"), Some("truecolor")),
+            None
+        );
+        assert_eq!(ghostty_colorterm(Some("xterm-ghostty"), None), None);
+    }
+}

--- a/crates/et-bin/src/main.rs
+++ b/crates/et-bin/src/main.rs
@@ -79,6 +79,7 @@ fn role(name: &str, args: &[OsString]) -> Result<i32, clap::Error> {
 
 mod bootstrap;
 mod client;
+mod client_environment;
 mod client_terminal;
 mod client_terminal_loop;
 #[cfg(windows)]

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -85,6 +85,7 @@ exit "$ET_FAKE_EXIT"
     fn command(&self, config: &str, stdout: &str, exit: i32, stderr: &str) -> Command {
         let mut command = Command::new(env!("CARGO_BIN_EXE_et"));
         command
+            .env_clear()
             .env("PATH", &self.dir.0)
             .env("ET_FAKE_ARGV", &self.argv)
             .env("ET_FAKE_STDIN", &self.stdin)
@@ -125,10 +126,9 @@ fn stderr(output: &Output) -> String {
     String::from_utf8_lossy(&output.stderr).into_owned()
 }
 
-#[test]
-fn cli_proves_exact_ssh_bootstrap_v6_and_encrypted_initial_payload() {
+fn initial_payload_server() -> (u16, thread::JoinHandle<InitialPayload>) {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let address = listener.local_addr().unwrap();
+    let port = listener.local_addr().unwrap().port();
     let server = thread::spawn(move || {
         let (mut stream, _) = listener.accept().unwrap();
         bound(&stream);
@@ -141,21 +141,28 @@ fn cli_proves_exact_ssh_bootstrap_v6_and_encrypted_initial_payload() {
         let packet = connection.read_packet().unwrap();
         assert_eq!(packet.header(), EtPacketType::InitialPayload as u8);
         let payload = InitialPayload::decode(packet.payload()).unwrap();
-        assert_eq!(payload.jumphost, Some(false));
-        assert!(payload.reversetunnels.is_empty());
-        assert!(payload.environmentvariables.is_empty());
         connection
             .write_packet(
                 EtPacketType::InitialResponse as u8,
                 &InitialResponse { error: None }.encode_to_vec(),
             )
             .unwrap();
+        payload
     });
+    (port, server)
+}
+
+#[test]
+fn cli_proves_exact_ssh_bootstrap_v6_and_encrypted_initial_payload() {
+    let (port, server) = initial_payload_server();
 
     let fake = FakeSsh::new();
     let output = fake
         .command(RESOLVED_CONFIG, VALID_MARKER, 0, "")
-        .env("TERM", "xterm-test")
+        .env("TERM", "xterm-ghostty")
+        .env("COLORTERM", "truecolor")
+        .env("LANG", "C.UTF-8")
+        .env("LC_CTYPE", "C.UTF-8")
         .args([
             "-N",
             // Upstream takes an explicit verbosity level, not a repeat count.
@@ -167,14 +174,35 @@ fn cli_proves_exact_ssh_bootstrap_v6_and_encrypted_initial_payload() {
             "/tmp/server fifo",
             "--ssh-option",
             "StrictHostKeyChecking=no",
-            &format!("test-user@server-alias:{}", address.port()),
+            &format!("test-user@server-alias:{port}"),
         ])
         .output()
         .unwrap();
-    server.join().unwrap();
+    let payload = server.join().unwrap();
     assert!(output.status.success(), "{}", stderr(&output));
     assert!(output.stdout.is_empty() && output.stderr.is_empty());
     assert!(fs::read(&fake.stdin).unwrap().is_empty());
+    assert_eq!(payload.jumphost, Some(false));
+    assert!(payload.reversetunnels.is_empty());
+    assert_eq!(
+        payload.environmentvariables.get("LANG").map(String::as_str),
+        Some("C.UTF-8")
+    );
+    assert_eq!(
+        payload
+            .environmentvariables
+            .get("LC_CTYPE")
+            .map(String::as_str),
+        Some("C.UTF-8")
+    );
+    assert_eq!(
+        payload
+            .environmentvariables
+            .get("COLORTERM")
+            .map(String::as_str),
+        Some("truecolor")
+    );
+    assert_eq!(payload.environmentvariables.len(), 3);
 
     let invocations = fake.invocations();
     assert_eq!(invocations.len(), 3);
@@ -190,7 +218,7 @@ fn cli_proves_exact_ssh_bootstrap_v6_and_encrypted_initial_payload() {
     );
     let prefix = "printf '%s\\n' '";
     let value = argv[2].strip_prefix(prefix).unwrap();
-    let provisional = value.split_once("_xterm-test'").unwrap().0;
+    let provisional = value.split_once("_xterm-256color'").unwrap().0;
     let (id, key) = parse_id_passkey(provisional).unwrap();
     assert!(id.starts_with("XXX"));
     assert_eq!(id.len(), 16);
@@ -198,9 +226,59 @@ fn cli_proves_exact_ssh_bootstrap_v6_and_encrypted_initial_payload() {
     assert_eq!(
         argv[2],
         format!(
-            "printf '%s\\n' '{provisional}_xterm-test' | '/opt/et terminal' '--verbose=2' '--serverfifo=/tmp/server fifo'"
+            "printf '%s\\n' '{provisional}_xterm-256color' | '/opt/et terminal' '--verbose=2' '--serverfifo=/tmp/server fifo'"
         )
     );
+}
+
+#[test]
+fn posix_client_forwards_only_ssh_locale_environment() {
+    let (port, server) = initial_payload_server();
+    let fake = FakeSsh::new();
+    let output = fake
+        .command(RESOLVED_CONFIG, VALID_MARKER, 0, "")
+        .env("TERM", "xterm-test")
+        .env("LANG", "ko_KR.UTF-8")
+        .env("LC_TEST_SENTINEL", "C.UTF-8")
+        .env("LANGUAGE", "do-not-forward")
+        .env("ET_SECRET", "do-not-forward")
+        .args(["-N", &format!("server-alias:{port}")])
+        .output()
+        .unwrap();
+    let payload = server.join().unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert_eq!(
+        payload.environmentvariables.get("LANG").map(String::as_str),
+        Some("ko_KR.UTF-8")
+    );
+    assert_eq!(
+        payload
+            .environmentvariables
+            .get("LC_TEST_SENTINEL")
+            .map(String::as_str),
+        Some("C.UTF-8")
+    );
+    assert!(!payload.environmentvariables.contains_key("LANGUAGE"));
+    assert!(!payload.environmentvariables.contains_key("ET_SECRET"));
+    assert_eq!(payload.environmentvariables.len(), 2);
+
+    let (windows_port, windows_server) = initial_payload_server();
+    let windows_fake = FakeSsh::new();
+    let windows_output = windows_fake
+        .command(RESOLVED_CONFIG, VALID_MARKER, 0, "")
+        .env("TERM", "xterm256color")
+        .env("LANG", "ko_KR.UTF-8")
+        .env("LC_TEST_SENTINEL", "C.UTF-8")
+        .args(["-N", "--winserver", &format!("server-alias:{windows_port}")])
+        .output()
+        .unwrap();
+    let windows_payload = windows_server.join().unwrap();
+    assert!(
+        windows_output.status.success(),
+        "{}",
+        stderr(&windows_output)
+    );
+    assert!(windows_payload.environmentvariables.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- forward present Unicode `LANG` and `LC_*` values into POSIX sessions
- leave missing and non-Unicode locale values untouched so the server locale remains authoritative
- preserve Ghostty truecolor behavior and keep Windows Cmd/PowerShell payloads unchanged

## Root cause
The client populated protocol-v6 `InitialPayload.environmentvariables` only with the Ghostty `COLORTERM` hint. Existing server and PTY plumbing already forwards generic environment entries, so interactive programs saw no client locale even though the equivalent SSH session did.

## Compatibility
- no protocol, protobuf, fixture, or crypto-byte changes
- latest Eternal Terminal upstream was checked at `b74a12efc567dbc1360ac0846f889c945a2eba60`; it also uses the existing generic environment path, with caller-side variable selection
- POSIX only; native Windows session payload behavior is unchanged

## Verification
- failing-first encrypted bootstrap assertions for locale propagation and filtering
- Rust LSP clean; `cargo fmt --all --check`; workspace/all-target clippy with `-D warnings`
- full workspace tests serialized with `--test-threads=1`; exact Ghostty end-to-end regression
- real Ghostty-mode et session launched `btop` on jerry through PTY -> xterm.js -> headed Chrome; no UTF-8 error, live UI captured, clean exit and teardown
- missing-client-locale preserved jerry's UTF-8 locale
- Linux client -> Linux/macOS/Windows runtime matrix; macOS-built client -> Linux; native Windows build

## Release
- includes an `et: patch` Tegami note

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes locale detection in POSIX sessions by forwarding client `LANG` and `LC_*` values, matching SSH behavior. Previously only the Ghostty `COLORTERM` hint was sent, so locale-sensitive apps like btop couldn't detect UTF-8.

- Non-UTF-8 locale values are skipped so the server locale remains authoritative when the client locale is unusable.
- Windows Cmd/PowerShell session payloads are unchanged.
- Moves `normalize_terminal_type` and `ghostty_colorterm` into the new `client_environment` module.

<sup>Written for commit 76b364206832d70ca60c4e0188ba7796227b89ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

