### PR TITLE
fix(client): bound forwarded locale environment

### DIFF
--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -12,7 +12,7 @@ use crate::bootstrap::{
     validate_ssh_destination, BootstrapRequest, Credentials, JumpBootstrapRequest, RemoteShell,
 };
 use crate::client_environment::{
-    ghostty_colorterm, normalize_terminal_type, ssh_locale_environment,
+    ghostty_colorterm, locale_environment_capacity, normalize_terminal_type, ssh_locale_environment,
 };
 use crate::deadline::Deadline;
 use crate::error::ClientError;
@@ -205,9 +205,19 @@ fn run_client(
         initial_payload.jumphost = Some(true);
     }
     if remote_mode.terminal_shell == RemoteShellKind::Posix {
+        let forward_environment = initial_payload
+            .reversetunnels
+            .iter()
+            .filter(|request| request.environmentvariable.is_some())
+            .count();
+        let locale_capacity = locale_environment_capacity(
+            initial_payload.environmentvariables.len(),
+            colorterm.is_some(),
+            forward_environment,
+        );
         initial_payload
             .environmentvariables
-            .extend(ssh_locale_environment());
+            .extend(ssh_locale_environment().take(locale_capacity));
         if let Some(value) = colorterm {
             initial_payload
                 .environmentvariables

--- a/crates/et-bin/src/client_environment.rs
+++ b/crates/et-bin/src/client_environment.rs
@@ -1,3 +1,5 @@
+use crate::terminal_protocol::{valid_environment_name, MAX_ENVIRONMENT, MAX_ENV_VALUE};
+
 pub(crate) fn normalize_terminal_type(term: Option<&str>) -> String {
     match term {
         None | Some("xterm-ghostty") => "xterm-256color".to_owned(),
@@ -17,18 +19,42 @@ pub(crate) fn ghostty_colorterm<'a>(
 
 /// Collect locale variables matched by OpenSSH's `SendEnv LANG LC_*`.
 pub(crate) fn ssh_locale_environment() -> impl Iterator<Item = (String, String)> {
-    std::env::vars_os().filter_map(|(name, value)| {
-        let name = name.into_string().ok()?;
-        if name != "LANG" && !name.starts_with("LC_") {
-            return None;
-        }
-        Some((name, value.into_string().ok()?))
-    })
+    let mut environment: Vec<_> = std::env::vars_os()
+        .filter_map(|(name, value)| {
+            let name = name.into_string().ok()?;
+            if (name != "LANG" && !name.starts_with("LC_")) || !valid_environment_name(&name) {
+                return None;
+            }
+            let value = value.into_string().ok()?;
+            (value.len() <= MAX_ENV_VALUE).then_some((name, value))
+        })
+        .collect();
+    environment.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+    environment.into_iter()
+}
+
+pub(crate) fn locale_environment_capacity(
+    existing: usize,
+    has_colorterm: bool,
+    forward_environment: usize,
+) -> usize {
+    let reserved = existing
+        .saturating_add(usize::from(has_colorterm))
+        .saturating_add(forward_environment);
+    MAX_ENVIRONMENT.saturating_sub(reserved)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ghostty_colorterm, normalize_terminal_type};
+    use super::{ghostty_colorterm, locale_environment_capacity, normalize_terminal_type};
+
+    #[test]
+    fn locale_capacity_reserves_terminal_environment_entries() {
+        assert_eq!(locale_environment_capacity(0, false, 0), 128);
+        assert_eq!(locale_environment_capacity(0, true, 1), 126);
+        assert_eq!(locale_environment_capacity(127, false, 1), 0);
+        assert_eq!(locale_environment_capacity(usize::MAX, true, usize::MAX), 0);
+    }
 
     #[test]
     fn ghostty_term_uses_compatible_remote_fallback() {

--- a/crates/et-bin/src/terminal_protocol.rs
+++ b/crates/et-bin/src/terminal_protocol.rs
@@ -7,8 +7,8 @@ use et_net::local_packet::{read_local_packet, LocalPacketDecoder};
 use portable_pty::{MasterPty, PtySize};
 use prost::Message;
 
-const MAX_ENVIRONMENT: usize = 128;
-const MAX_ENV_VALUE: usize = 4096;
+pub(crate) const MAX_ENVIRONMENT: usize = 128;
+pub(crate) const MAX_ENV_VALUE: usize = 4096;
 const READ_BUFFER: usize = 16 * 1024;
 
 pub fn read_initial_environment(router: &mut LocalStream) -> Result<Vec<(String, String)>, String> {
@@ -92,7 +92,7 @@ pub fn handle_packet(
     }
 }
 
-fn valid_environment_name(name: &str) -> bool {
+pub(crate) fn valid_environment_name(name: &str) -> bool {
     let mut bytes = name.bytes();
     matches!(bytes.next(), Some(b'A'..=b'Z' | b'a'..=b'z' | b'_'))
         && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -282,6 +282,57 @@ fn posix_client_forwards_only_ssh_locale_environment() {
 }
 
 #[test]
+fn posix_client_filters_locale_to_terminal_environment_limits() {
+    let (port, server) = initial_payload_server();
+    let fake = FakeSsh::new();
+    let mut command = fake.command(RESOLVED_CONFIG, VALID_MARKER, 0, "");
+    command
+        .env("TERM", "xterm-ghostty")
+        .env("COLORTERM", "truecolor")
+        .env("LANG", "ko_KR.UTF-8")
+        .env("LC_ALL", "C")
+        .env("LC_\u{1f4a5}", "C.UTF-8")
+        .env("LC_OVERSIZED", "x".repeat(4097));
+    for index in 0..130 {
+        command.env(format!("LC_BOUNDARY_{index:03}"), "C.UTF-8");
+    }
+    let output = command
+        .args(["-N", &format!("server-alias:{port}")])
+        .output()
+        .unwrap();
+    let payload = server.join().unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+
+    assert_eq!(
+        payload.environmentvariables.get("LANG").map(String::as_str),
+        Some("ko_KR.UTF-8")
+    );
+    assert_eq!(
+        payload
+            .environmentvariables
+            .get("LC_ALL")
+            .map(String::as_str),
+        Some("C")
+    );
+    assert_eq!(
+        payload
+            .environmentvariables
+            .get("COLORTERM")
+            .map(String::as_str),
+        Some("truecolor")
+    );
+    assert!(!payload.environmentvariables.contains_key("LC_\u{1f4a5}"));
+    assert!(!payload.environmentvariables.contains_key("LC_OVERSIZED"));
+    assert_eq!(payload.environmentvariables.len(), 128);
+    assert!(payload.environmentvariables.iter().all(|(name, value)| {
+        let mut bytes = name.bytes();
+        matches!(bytes.next(), Some(b'A'..=b'Z' | b'a'..=b'z' | b'_'))
+            && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+            && value.len() <= 4096
+    }));
+}
+
+#[test]
 fn bare_windows_login_shell_is_detected_before_bootstrap() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let address = listener.local_addr().unwrap();


### PR DESCRIPTION
## Summary

- filter OpenSSH-style LANG/LC_* forwarding to the terminal environment name and 4096-byte value contract
- deterministically cap forwarded locale entries at the 128-entry terminal limit
- reserve slots for Ghostty COLORTERM and named-pipe reverse-tunnel variables added by the server
- preserve LANG and LC_ALL values verbatim, including LC_ALL=C

This resolves the producer/consumer boundary issue identified after #51 and in https://github.com/minpeter/et.rs/pull/51#discussion_r3879143714.

No second Tegami changeset is included: #51's existing unreleased et: patch note already describes this same locale-forwarding behavior; this commit corrects that unreleased implementation.

## Verification

- RED: malformed Unicode LC_* names were serialized before the fix
- GREEN: exact client_bootstrap boundary regression passes with invalid Unicode name, 4097-byte value, 130 valid locale variables, LANG, LC_ALL=C, and COLORTERM
- GREEN: locale capacity unit regression reserves COLORTERM and named-pipe reverse-tunnel slots with saturating arithmetic
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1
- cargo build -p et
- git diff --check
- zero LSP diagnostics in all four changed files

## Real surfaces

- hostile 130-entry locale environment reaches Linux jerry and preserves LANG=C.UTF-8 plus LC_ALL=C
- same hostile environment plus --reversetunnel ET_PIPE:remote-name starts successfully, exposes a live socket, exits 0, and removes the socket
- Linux jerry and macOS swing report UTF-8; native Windows Cmd prints FOLLOWUP-WINDOWS-OK
- final btop run through a real 120x36 PTY, xterm.js 5.5.0, and headed Chromium exits 0 with no UTF-8 error; independent visual and functional reviewers pass


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes locale forwarding so hostile environments can't break the terminal protocol. Locale variables are now filtered to valid names and values under 4096 bytes, and the set is capped at the 128-entry terminal limit while reserving slots for Ghostty's `COLORTERM` and reverse-tunnel environment variables. `LANG` and `LC_ALL` are preserved verbatim, including `LC_ALL=C`; entries are now sorted for deterministic output.

<sup>Written for commit eaf1886d909e3f05827b291a54df7f872fe53cb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

