### PR TITLE
test(terminal): guard command exit banner

### DIFF
--- a/crates/et-bin/tests/terminal_tty_qa.rs
+++ b/crates/et-bin/tests/terminal_tty_qa.rs
@@ -67,6 +67,10 @@ fn real_tty_restores_termios_and_propagates_resize() {
     assert!(output.contains("TERMIOS-RESTORED:"), "{output:?}");
     assert!(output.contains(":CODE:0:"), "{output:?}");
     assert!(termios_restored(&output), "{output:?}");
+    assert!(
+        !output.contains("Connection to 127.0.0.1 closed."),
+        "command sessions must not print an interactive close banner: {output:?}"
+    );
 }
 
 fn termios_restored(output: &str) -> bool {


### PR DESCRIPTION
## Summary
- add a real-PTY assertion that `et -c` command sessions do not print the interactive `Connection to … closed.` banner
- close the only coverage gap identified by the final PR #50 code reviewer

## Mutation proof
- GREEN on merged source: `real_tty_restores_termios_and_propagates_resize` passes
- RED after temporarily widening the product guard from `raw_mode.enabled && command.is_none()` to `raw_mode.enabled`: exit 101 after observing `Connection to 127.0.0.1 closed.`
- restored the guard and the same test returned GREEN

## Verification
- rust-analyzer diagnostics clean
- `cargo fmt --all --check`
- full `terminal_tty_qa`: 3 passed
- `cargo clippy -p et --test terminal_tty_qa -- -D warnings`
- worktree diff is test-only; product source unchanged
- test fixture cleanup verified

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a real-PTY assertion that `et -c` command sessions do not print the interactive `Connection to … closed.` banner, closing the last coverage gap from the prior review. The change is test-only; product source is untouched.

<sup>Written for commit 5c2425b5c546a924756e03d7c5df86a78f126387. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

