### PR TITLE
fix(client): validate complete terminal environment

### DIFF
--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -12,7 +12,8 @@ use crate::bootstrap::{
     validate_ssh_destination, BootstrapRequest, Credentials, JumpBootstrapRequest, RemoteShell,
 };
 use crate::client_environment::{
-    ghostty_colorterm, locale_environment_capacity, normalize_terminal_type, ssh_locale_environment,
+    bounded_locale_environment, ghostty_colorterm, normalize_terminal_type,
+    reserved_environment_value_lengths, ssh_locale_environment,
 };
 use crate::deadline::Deadline;
 use crate::error::ClientError;
@@ -93,6 +94,33 @@ fn run_client(
     // Bind local sources only after the encrypted session exists so accepted
     // tunnels can be multiplexed immediately (avoids pre-handshake accept races).
     let local_sources = forward_config.local_sources;
+    let mut initial_payload = forward_config.initial_payload;
+    let local_term = std::env::var("TERM").ok();
+    let local_colorterm = std::env::var("COLORTERM").ok();
+    let term = normalize_terminal_type(local_term.as_deref());
+    let colorterm = ghostty_colorterm(local_term.as_deref(), local_colorterm.as_deref());
+    let reserved_environment = reserved_environment_value_lengths(
+        initial_payload
+            .environmentvariables
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.len())),
+        colorterm,
+        initial_payload
+            .reversetunnels
+            .iter()
+            .filter_map(|request| request.environmentvariable.as_deref()),
+    );
+    if reserved_environment.len() > crate::terminal_protocol::MAX_ENVIRONMENT {
+        return Err(
+            crate::forward_config::ForwardConfigError::TooManyEnvironmentNames(
+                reserved_environment.len(),
+            )
+            .into(),
+        );
+    }
+    let locale_environment =
+        bounded_locale_environment(ssh_locale_environment(), &reserved_environment)
+            .map_err(crate::forward_config::ForwardConfigError::EnvironmentPacketTooLarge)?;
 
     let requested_user = command_user(destination.user, args.username.clone());
     validate_ssh_destination(&destination.host, requested_user.as_deref())?;
@@ -105,10 +133,6 @@ fn run_client(
     )?;
     let user = requested_user.or(resolved.user);
     validate_ssh_destination(&destination.host, user.as_deref())?;
-    let local_term = std::env::var("TERM").ok();
-    let local_colorterm = std::env::var("COLORTERM").ok();
-    let term = normalize_terminal_type(local_term.as_deref());
-    let colorterm = ghostty_colorterm(local_term.as_deref(), local_colorterm.as_deref());
     let probe_request = BootstrapRequest {
         user: user.clone(),
         host_alias: destination.host.clone(),
@@ -172,7 +196,6 @@ fn run_client(
         host: resolved.hostname,
         port: destination.port,
     };
-    let mut initial_payload = forward_config.initial_payload;
     if let Some(jumphost) = args.jumphost.as_deref() {
         let parsed_jump = et_cli::host::parse_host_string(jumphost);
         let jump_host = parsed_jump
@@ -205,19 +228,9 @@ fn run_client(
         initial_payload.jumphost = Some(true);
     }
     if remote_mode.terminal_shell == RemoteShellKind::Posix {
-        let forward_environment = initial_payload
-            .reversetunnels
-            .iter()
-            .filter(|request| request.environmentvariable.is_some())
-            .count();
-        let locale_capacity = locale_environment_capacity(
-            initial_payload.environmentvariables.len(),
-            colorterm.is_some(),
-            forward_environment,
-        );
         initial_payload
             .environmentvariables
-            .extend(ssh_locale_environment().take(locale_capacity));
+            .extend(locale_environment);
         if let Some(value) = colorterm {
             initial_payload
                 .environmentvariables

--- a/crates/et-bin/src/client_environment.rs
+++ b/crates/et-bin/src/client_environment.rs
@@ -1,4 +1,12 @@
+use std::collections::BTreeMap;
+
+use et_cli::tunnel::MAX_UNIX_SOCKET_PATH;
+use et_core::packet::HEADER_LEN;
+use et_net::local_packet::MAX_LOCAL_PACKET_LEN;
+
 use crate::terminal_protocol::{valid_environment_name, MAX_ENVIRONMENT, MAX_ENV_VALUE};
+
+const MAX_LOSSY_FORWARD_ENV_VALUE: usize = MAX_UNIX_SOCKET_PATH * 3;
 
 pub(crate) fn normalize_terminal_type(term: Option<&str>) -> String {
     match term {
@@ -29,31 +37,132 @@ pub(crate) fn ssh_locale_environment() -> impl Iterator<Item = (String, String)>
             (value.len() <= MAX_ENV_VALUE).then_some((name, value))
         })
         .collect();
-    environment.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+    environment.sort_unstable_by(|(left, _), (right, _)| {
+        locale_priority(left)
+            .cmp(&locale_priority(right))
+            .then_with(|| left.cmp(right))
+    });
     environment.into_iter()
 }
 
-pub(crate) fn locale_environment_capacity(
-    existing: usize,
-    has_colorterm: bool,
-    forward_environment: usize,
-) -> usize {
-    let reserved = existing
-        .saturating_add(usize::from(has_colorterm))
-        .saturating_add(forward_environment);
+fn locale_priority(name: &str) -> u8 {
+    match name {
+        "LANG" => 0,
+        "LC_ALL" => 1,
+        "LC_CTYPE" => 2,
+        _ => 3,
+    }
+}
+
+pub(crate) fn reserved_environment_value_lengths<'a>(
+    existing: impl IntoIterator<Item = (&'a str, usize)>,
+    colorterm: Option<&str>,
+    forward_environment: impl IntoIterator<Item = &'a str>,
+) -> BTreeMap<String, usize> {
+    let mut reserved: BTreeMap<_, _> = existing
+        .into_iter()
+        .map(|(name, value_len)| (name.to_owned(), value_len))
+        .collect();
+    if let Some(value) = colorterm {
+        reserved.insert("COLORTERM".to_owned(), value.len());
+    }
+    for name in forward_environment {
+        // A successfully bound Unix socket path is at most 107 raw bytes, but
+        // `to_string_lossy()` can expand each non-UTF-8 byte to U+FFFD.
+        reserved.insert(name.to_owned(), MAX_LOSSY_FORWARD_ENV_VALUE);
+    }
+    reserved
+}
+
+pub(crate) fn locale_environment_capacity(reserved: usize) -> usize {
     MAX_ENVIRONMENT.saturating_sub(reserved)
+}
+
+pub(crate) fn bounded_locale_environment(
+    candidates: impl IntoIterator<Item = (String, String)>,
+    reserved: &BTreeMap<String, usize>,
+) -> Result<Vec<(String, String)>, usize> {
+    let mut packet_len = HEADER_LEN;
+    for (name, value_len) in reserved {
+        packet_len = packet_len
+            .saturating_add(encoded_string_field_len(name.len()))
+            .saturating_add(encoded_string_field_len(*value_len));
+    }
+    if packet_len > MAX_LOCAL_PACKET_LEN {
+        return Err(packet_len);
+    }
+
+    let capacity = locale_environment_capacity(reserved.len());
+    let mut selected = Vec::with_capacity(capacity);
+    for (name, value) in candidates {
+        if reserved.contains_key(&name) || selected.len() == capacity {
+            continue;
+        }
+        let addition = encoded_string_field_len(name.len()) + encoded_string_field_len(value.len());
+        if packet_len.saturating_add(addition) <= MAX_LOCAL_PACKET_LEN {
+            packet_len += addition;
+            selected.push((name, value));
+        }
+    }
+    Ok(selected)
+}
+
+fn encoded_string_field_len(value_len: usize) -> usize {
+    1usize
+        .saturating_add(varint_len(value_len))
+        .saturating_add(value_len)
+}
+
+fn varint_len(mut value: usize) -> usize {
+    let mut len = 1;
+    while value >= 0x80 {
+        value >>= 7;
+        len += 1;
+    }
+    len
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ghostty_colorterm, locale_environment_capacity, normalize_terminal_type};
+    use super::{
+        ghostty_colorterm, locale_environment_capacity, locale_priority, normalize_terminal_type,
+        reserved_environment_value_lengths, MAX_LOSSY_FORWARD_ENV_VALUE,
+    };
+
+    #[test]
+    fn effective_locale_controls_precede_other_categories() {
+        for name in ["LANG", "LC_ALL", "LC_CTYPE"] {
+            assert!(locale_priority(name) < locale_priority("LC_000"));
+        }
+    }
 
     #[test]
     fn locale_capacity_reserves_terminal_environment_entries() {
-        assert_eq!(locale_environment_capacity(0, false, 0), 128);
-        assert_eq!(locale_environment_capacity(0, true, 1), 126);
-        assert_eq!(locale_environment_capacity(127, false, 1), 0);
-        assert_eq!(locale_environment_capacity(usize::MAX, true, usize::MAX), 0);
+        assert_eq!(locale_environment_capacity(0), 128);
+        assert_eq!(locale_environment_capacity(2), 126);
+        assert_eq!(locale_environment_capacity(128), 0);
+        assert_eq!(locale_environment_capacity(usize::MAX), 0);
+    }
+
+    #[test]
+    fn locale_capacity_counts_distinct_reserved_names() {
+        let reserved = reserved_environment_value_lengths(
+            [("COLORTERM", 4), ("LC_COLLISION", 1)],
+            Some("truecolor"),
+            ["ET_PIPE", "ET_PIPE", "LC_COLLISION"],
+        );
+        assert_eq!(
+            reserved.into_keys().collect::<Vec<_>>(),
+            ["COLORTERM", "ET_PIPE", "LC_COLLISION"],
+        );
+        let reserved = reserved_environment_value_lengths(
+            [("COLORTERM", 4), ("LC_COLLISION", 1)],
+            Some("truecolor"),
+            ["ET_PIPE", "ET_PIPE", "LC_COLLISION"],
+        );
+        assert_eq!(reserved["COLORTERM"], "truecolor".len());
+        assert_eq!(reserved["ET_PIPE"], MAX_LOSSY_FORWARD_ENV_VALUE);
+        assert_eq!(reserved["LC_COLLISION"], MAX_LOSSY_FORWARD_ENV_VALUE);
     }
 
     #[test]

--- a/crates/et-bin/src/forward_config.rs
+++ b/crates/et-bin/src/forward_config.rs
@@ -1,11 +1,18 @@
+use std::collections::BTreeSet;
+
 use et_cli::client::ClientArgs;
 use et_cli::tunnel::parse_tunnels;
 use et_core::proto::{InitialPayload, PortForwardSourceRequest, SocketEndpoint};
+
+use crate::terminal_protocol::{valid_environment_name, MAX_ENVIRONMENT};
 
 #[derive(Debug)]
 pub enum ForwardConfigError {
     MissingAgentSocket,
     Tunnel(et_cli::tunnel::TunnelError),
+    InvalidEnvironmentName(String),
+    TooManyEnvironmentNames(usize),
+    EnvironmentPacketTooLarge(usize),
 }
 
 impl std::fmt::Display for ForwardConfigError {
@@ -16,6 +23,21 @@ impl std::fmt::Display for ForwardConfigError {
                 "Missing environment variable SSH_AUTH_SOCK.  Are you sure you ran ssh-agent first?"
             ),
             Self::Tunnel(error) => error.fmt(formatter),
+            Self::InvalidEnvironmentName(name) => {
+                write!(
+                    formatter,
+                    "invalid reverse-tunnel environment variable name: {name}"
+                )
+            }
+            Self::TooManyEnvironmentNames(count) => write!(
+                formatter,
+                "terminal environment has {count} reserved names; maximum is {MAX_ENVIRONMENT}"
+            ),
+            Self::EnvironmentPacketTooLarge(length) => write!(
+                formatter,
+                "terminal environment packet needs at least {length} bytes; maximum is {}",
+                et_net::local_packet::MAX_LOCAL_PACKET_LEN
+            ),
         }
     }
 }
@@ -24,7 +46,10 @@ impl std::error::Error for ForwardConfigError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Tunnel(error) => Some(error),
-            Self::MissingAgentSocket => None,
+            Self::MissingAgentSocket
+            | Self::InvalidEnvironmentName(_)
+            | Self::TooManyEnvironmentNames(_)
+            | Self::EnvironmentPacketTooLarge(_) => None,
         }
     }
 }
@@ -65,6 +90,7 @@ pub fn build(
             environmentvariable: Some("SSH_AUTH_SOCK".to_owned()),
         });
     }
+    validate_environment_names(&reverse_tunnels)?;
     Ok(ForwardConfig {
         local_sources,
         initial_payload: InitialPayload {
@@ -73,6 +99,25 @@ pub fn build(
             environmentvariables: std::collections::HashMap::new(),
         },
     })
+}
+
+fn validate_environment_names(
+    reverse_tunnels: &[PortForwardSourceRequest],
+) -> Result<(), ForwardConfigError> {
+    let mut names = BTreeSet::new();
+    for name in reverse_tunnels
+        .iter()
+        .filter_map(|request| request.environmentvariable.as_deref())
+    {
+        if !valid_environment_name(name) {
+            return Err(ForwardConfigError::InvalidEnvironmentName(name.to_owned()));
+        }
+        names.insert(name);
+    }
+    if names.len() > MAX_ENVIRONMENT {
+        return Err(ForwardConfigError::TooManyEnvironmentNames(names.len()));
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -11,9 +11,13 @@ use std::thread;
 use std::time::Duration;
 
 use et_core::keys::{parse_id_passkey, passkey_to_key};
-use et_core::proto::{ConnectStatus, EtPacketType, InitialPayload, InitialResponse};
+use et_core::packet::Packet;
+use et_core::proto::{
+    ConnectStatus, EtPacketType, InitialPayload, InitialResponse, TermInit, TerminalPacketType,
+};
 use et_net::connection::Connection;
 use et_net::handshake::{read_request, response_status, write_response};
+use et_net::local_packet::MAX_LOCAL_PACKET_LEN;
 use prost::Message;
 
 const SERVER_ID: &str = "abcdefghijklmnop";
@@ -127,6 +131,12 @@ fn stderr(output: &Output) -> String {
 }
 
 fn initial_payload_server() -> (u16, thread::JoinHandle<InitialPayload>) {
+    initial_payload_server_with_error(None)
+}
+
+fn initial_payload_server_with_error(
+    error: Option<&'static str>,
+) -> (u16, thread::JoinHandle<InitialPayload>) {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let port = listener.local_addr().unwrap().port();
     let server = thread::spawn(move || {
@@ -144,7 +154,10 @@ fn initial_payload_server() -> (u16, thread::JoinHandle<InitialPayload>) {
         connection
             .write_packet(
                 EtPacketType::InitialResponse as u8,
-                &InitialResponse { error: None }.encode_to_vec(),
+                &InitialResponse {
+                    error: error.map(str::to_owned),
+                }
+                .encode_to_vec(),
             )
             .unwrap();
         payload
@@ -330,6 +343,112 @@ fn posix_client_filters_locale_to_terminal_environment_limits() {
             && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
             && value.len() <= 4096
     }));
+}
+
+#[test]
+fn posix_client_counts_duplicate_tunnel_environment_names_once() {
+    let (port, server) = initial_payload_server_with_error(Some("stop after payload"));
+    let fake = FakeSsh::new();
+    let mut command = fake.command(RESOLVED_CONFIG, VALID_MARKER, 0, "");
+    command
+        .env("TERM", "xterm-ghostty")
+        .env("COLORTERM", "truecolor")
+        .env("LANG", "ko_KR.UTF-8")
+        .env("LC_ALL", "C");
+    for index in 0..130 {
+        command.env(format!("LC_BOUNDARY_{index:03}"), "C.UTF-8");
+    }
+    let mut arguments = vec!["-N".to_owned()];
+    for index in 0..128 {
+        arguments.extend([
+            "--reversetunnel".to_owned(),
+            format!("ET_PIPE:remote-{index}"),
+        ]);
+    }
+    arguments.push(format!("server-alias:{port}"));
+
+    let output = command.args(arguments).output().unwrap();
+    let payload = server.join().unwrap();
+    assert!(!output.status.success());
+    assert!(stderr(&output).contains("stop after payload"));
+    assert_eq!(payload.reversetunnels.len(), 128);
+    assert!(payload
+        .reversetunnels
+        .iter()
+        .all(|request| { request.environmentvariable.as_deref() == Some("ET_PIPE") }));
+    assert_eq!(
+        payload.environmentvariables.get("LANG").map(String::as_str),
+        Some("ko_KR.UTF-8")
+    );
+    assert_eq!(
+        payload
+            .environmentvariables
+            .get("LC_ALL")
+            .map(String::as_str),
+        Some("C")
+    );
+    assert_eq!(
+        payload
+            .environmentvariables
+            .get("COLORTERM")
+            .map(String::as_str),
+        Some("truecolor")
+    );
+    assert_eq!(payload.environmentvariables.len(), 127);
+}
+
+#[test]
+fn posix_client_bounds_locale_to_local_terminal_packet() {
+    let (port, server) = initial_payload_server();
+    let fake = FakeSsh::new();
+    let mut command = fake.command(RESOLVED_CONFIG, VALID_MARKER, 0, "");
+    command
+        .env("TERM", "xterm-256color")
+        .env("LANG", "ko_KR.UTF-8")
+        .env("LC_ALL", "C")
+        .env("LC_CTYPE", "C.UTF-8");
+    for index in 0..20 {
+        command.env(format!("LC_000_{index:03}"), "x".repeat(4096));
+    }
+    let output = command
+        .args(["-N", &format!("server-alias:{port}")])
+        .output()
+        .unwrap();
+    let payload = server.join().unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert_eq!(
+        payload.environmentvariables.get("LANG").map(String::as_str),
+        Some("ko_KR.UTF-8")
+    );
+    assert_eq!(
+        payload
+            .environmentvariables
+            .get("LC_ALL")
+            .map(String::as_str),
+        Some("C")
+    );
+    assert_eq!(
+        payload
+            .environmentvariables
+            .get("LC_CTYPE")
+            .map(String::as_str),
+        Some("C.UTF-8")
+    );
+    let environment: std::collections::BTreeMap<_, _> =
+        payload.environmentvariables.into_iter().collect();
+    let term_init = TermInit {
+        environmentnames: environment.keys().cloned().collect(),
+        environmentvalues: environment.values().cloned().collect(),
+    };
+    let packet = Packet::new(
+        TerminalPacketType::TerminalInit as u8,
+        term_init.encode_to_vec(),
+    );
+    assert!(
+        packet.wire_len() <= MAX_LOCAL_PACKET_LEN,
+        "{} > {MAX_LOCAL_PACKET_LEN}",
+        packet.wire_len()
+    );
 }
 
 #[test]
@@ -563,9 +682,19 @@ fn leading_hyphen_destination_components_are_rejected_before_spawn() {
 #[test]
 fn invalid_client_modes_fail_before_ssh_bootstrap() {
     let no_ssh = TestDir::new("honest");
-    for args in [
-        vec!["-N", "-t", "0:80", "example.test"],
-        vec!["--no-exit", "example.test"],
+    for (args, message) in [
+        (
+            vec!["-N", "-t", "0:80", "example.test"],
+            "invalid tunnel endpoint",
+        ),
+        (
+            vec!["--no-exit", "example.test"],
+            "--no-exit requires --command",
+        ),
+        (
+            vec!["-N", "-r", "BAD-NAME:remote", "example.test"],
+            "invalid reverse-tunnel environment variable name",
+        ),
     ] {
         let output = Command::new(env!("CARGO_BIN_EXE_et"))
             .env("PATH", &no_ssh.0)
@@ -573,11 +702,81 @@ fn invalid_client_modes_fail_before_ssh_bootstrap() {
             .output()
             .unwrap();
         assert_eq!(output.status.code(), Some(2));
-        assert!(
-            stderr(&output).contains("invalid tunnel endpoint")
-                || stderr(&output).contains("--no-exit requires --command")
-        );
+        assert!(stderr(&output).contains(message), "{}", stderr(&output));
     }
+}
+
+#[test]
+fn excessive_unique_tunnel_environment_names_fail_before_ssh_bootstrap() {
+    let no_ssh = TestDir::new("honest");
+    let mut arguments = vec!["-N".to_owned()];
+    for index in 0..129 {
+        arguments.extend([
+            "-r".to_owned(),
+            format!("ET_PIPE_{index:03}:remote-{index}"),
+        ]);
+    }
+    arguments.push("example.test".to_owned());
+    let output = Command::new(env!("CARGO_BIN_EXE_et"))
+        .env("PATH", &no_ssh.0)
+        .args(arguments)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        stderr(&output).contains("terminal environment has 129 reserved names; maximum is 128"),
+        "{}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn colorterm_counts_toward_the_tunnel_environment_limit() {
+    let no_ssh = TestDir::new("honest");
+    let mut arguments = vec!["-N".to_owned()];
+    for index in 0..128 {
+        arguments.extend([
+            "-r".to_owned(),
+            format!("ET_PIPE_{index:03}:remote-{index}"),
+        ]);
+    }
+    arguments.push("server-alias:1".to_owned());
+    let output = Command::new(env!("CARGO_BIN_EXE_et"))
+        .env("PATH", &no_ssh.0)
+        .env("TERM", "xterm-ghostty")
+        .env("COLORTERM", "truecolor")
+        .args(arguments)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        stderr(&output).contains("terminal environment has 129 reserved names; maximum is 128"),
+        "{}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn oversized_tunnel_environment_name_exceeds_local_packet_limit() {
+    let no_ssh = TestDir::new("honest");
+    let environment_name = format!("E{}", "T".repeat(MAX_LOCAL_PACKET_LEN));
+    let output = Command::new(env!("CARGO_BIN_EXE_et"))
+        .env("PATH", &no_ssh.0)
+        .env("TERM", "xterm-256color")
+        .args([
+            "-N",
+            "-r",
+            &format!("{environment_name}:remote"),
+            "server-alias:1",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        stderr(&output).contains("terminal environment packet needs at least"),
+        "{}",
+        stderr(&output)
+    );
 }
 
 #[test]

--- a/crates/et-cli/src/tunnel.rs
+++ b/crates/et-cli/src/tunnel.rs
@@ -17,7 +17,7 @@
 use et_core::proto::{PortForwardSourceRequest, SocketEndpoint};
 
 pub const MAX_TUNNEL_REQUESTS: usize = 65_535;
-const MAX_UNIX_SOCKET_PATH: usize = 107;
+pub const MAX_UNIX_SOCKET_PATH: usize = 107;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TunnelError {


### PR DESCRIPTION
## Summary

- deduplicate reverse-tunnel environment reservations by final map key and account for collisions with existing entries, COLORTERM, and locale variables
- validate reverse-tunnel environment names against the terminal grammar and reject more than 128 complete reserved names
- bound the complete TermInit packet to the 64 KiB local frame using exact protobuf/string and packet-header sizing
- preserve LANG, LC_ALL, and LC_CTYPE under packet pressure and reserve worst-case lossy UTF-8 expansion for generated Unix socket paths
- run the complete environment preflight before SSH config resolution, shell probing, credentials, or remote bootstrap so rejected inputs cannot strand etterminal

This resolves https://github.com/minpeter/et.rs/pull/52#discussion_r3879428548 and every blocker in the merged PR #52 goal/code/context reviews.

No additional Tegami changeset is included: the existing unreleased locale-forwarding patch note from #51 already covers this correction to the same behavior.

## Failing-first evidence

- duplicate tunnel requests: count-only reservation API failed before distinct-key implementation
- invalid BAD-NAME, 129 unique names, and 128 names plus COLORTERM: three independent RED tests
- aggregate packet: valid inputs reconstructed an 82,292-byte TermInit against 65,536 bytes
- LC_CTYPE priority: effective-locale-control unit RED
- pre-bootstrap order: empty-PATH COLORTERM/huge-name tests returned SSH failure before the move
- lossy path expansion: 107-byte reservation failed a required 321-byte assertion

Local evidence ledger: .omo/evidence/locale-utf8/followup/C005-*-red.txt and C005-oracle-blockers-red-green.txt.

## Verification

- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1
- cargo build -p et
- git diff --check
- all five changed files have zero LSP diagnostics
- client_bootstrap: 18/18 PASS
- environment units: 5/5 PASS
- independent Oracle pre-commit review: PASS, confidence 0.99

## Real surfaces

- 128 duplicate ET_PIPE reverse tunnels plus 130 locale variables reached the real Linux server/terminal path; LANG and LC_CTYPE remained C.UTF-8, charmap was UTF-8, the socket was live, client exited 0, and every remote socket directory was removed
- twenty valid 4096-byte locale values reached Linux with UTF-8 charmap and exit 0 while the reconstructed terminal packet remained within 64 KiB
- BAD-NAME and 129 unique names reject locally with exit 2 and exact messages
- prior merged matrix still covers Linux, macOS, native Windows build/Cmd, Ghostty btop through headed xterm.js, missing locale, LC_ALL=C, and server combinations

## Scope

Protocol v6 protobufs, wire fixtures, crypto, manifests, lockfile, and dependencies are unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates the complete terminal environment preflight so reverse-tunnel names are deduplicated, validated against the terminal grammar, and the TermInit packet stays within the 64 KiB local frame.

**Key changes**
- Duplicate tunnel names and collisions with `COLORTERM` or locale variables count once per unique name.
- The preflight now runs before SSH config resolution, shell probing, and credentials so invalid inputs fail fast with exit 2.
- `LANG`, `LC_ALL`, and `LC_CTYPE` are preserved under packet pressure; lossy UTF-8 expansion of Unix socket paths is reserved.
- The existing unreleased locale-forwarding changelog from #51 covers this correction, so no new changeset is needed.

<sup>Written for commit 4f50a8b0a5f3104299324af46d2b49143c87ed1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

