### PR TITLE
fix(client): bound jumphost environment payload

### DIFF
--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -12,8 +12,8 @@ use crate::bootstrap::{
     validate_ssh_destination, BootstrapRequest, Credentials, JumpBootstrapRequest, RemoteShell,
 };
 use crate::client_environment::{
-    bounded_locale_environment, ghostty_colorterm, normalize_terminal_type,
-    reserved_environment_value_lengths, ssh_locale_environment,
+    bound_jumphost_locale_environment, bounded_locale_environment, ghostty_colorterm,
+    normalize_terminal_type, reserved_environment_value_lengths, ssh_locale_environment,
 };
 use crate::deadline::Deadline;
 use crate::error::ClientError;
@@ -118,9 +118,13 @@ fn run_client(
             .into(),
         );
     }
-    let locale_environment =
+    let mut locale_environment =
         bounded_locale_environment(ssh_locale_environment(), &reserved_environment)
             .map_err(crate::forward_config::ForwardConfigError::EnvironmentPacketTooLarge)?;
+    if args.jumphost.is_some() {
+        bound_jumphost_locale_environment(&initial_payload, &mut locale_environment, colorterm)
+            .map_err(crate::forward_config::ForwardConfigError::JumphostPacketTooLarge)?;
+    }
 
     let requested_user = command_user(destination.user, args.username.clone());
     validate_ssh_destination(&destination.host, requested_user.as_deref())?;

--- a/crates/et-bin/src/client_environment.rs
+++ b/crates/et-bin/src/client_environment.rs
@@ -1,8 +1,10 @@
 use std::collections::BTreeMap;
 
 use et_cli::tunnel::MAX_UNIX_SOCKET_PATH;
-use et_core::packet::HEADER_LEN;
+use et_core::packet::{Packet, HEADER_LEN};
+use et_core::proto::{InitialPayload, TerminalPacketType};
 use et_net::local_packet::MAX_LOCAL_PACKET_LEN;
+use prost::Message;
 
 use crate::terminal_protocol::{valid_environment_name, MAX_ENVIRONMENT, MAX_ENV_VALUE};
 
@@ -47,9 +49,9 @@ pub(crate) fn ssh_locale_environment() -> impl Iterator<Item = (String, String)>
 
 fn locale_priority(name: &str) -> u8 {
     match name {
-        "LANG" => 0,
-        "LC_ALL" => 1,
-        "LC_CTYPE" => 2,
+        "LC_ALL" => 0,
+        "LC_CTYPE" => 1,
+        "LANG" => 2,
         _ => 3,
     }
 }
@@ -107,6 +109,36 @@ pub(crate) fn bounded_locale_environment(
     Ok(selected)
 }
 
+pub(crate) fn bound_jumphost_locale_environment(
+    payload: &InitialPayload,
+    locale: &mut Vec<(String, String)>,
+    colorterm: Option<&str>,
+) -> Result<(), usize> {
+    let mut modeled = payload.clone();
+    modeled.jumphost = Some(true);
+    modeled.environmentvariables.extend(locale.iter().cloned());
+    if let Some(value) = colorterm {
+        modeled
+            .environmentvariables
+            .insert("COLORTERM".to_owned(), value.to_owned());
+    }
+
+    loop {
+        let packet_len = Packet::new(
+            TerminalPacketType::JumphostInit as u8,
+            modeled.encode_to_vec(),
+        )
+        .wire_len();
+        if packet_len <= MAX_LOCAL_PACKET_LEN {
+            return Ok(());
+        }
+        let Some((name, _)) = locale.pop() else {
+            return Err(packet_len);
+        };
+        modeled.environmentvariables.remove(&name);
+    }
+}
+
 fn encoded_string_field_len(value_len: usize) -> usize {
     1usize
         .saturating_add(varint_len(value_len))
@@ -125,15 +157,71 @@ fn varint_len(mut value: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::{
-        ghostty_colorterm, locale_environment_capacity, locale_priority, normalize_terminal_type,
-        reserved_environment_value_lengths, MAX_LOSSY_FORWARD_ENV_VALUE,
+        bound_jumphost_locale_environment, ghostty_colorterm, locale_environment_capacity,
+        locale_priority, normalize_terminal_type, reserved_environment_value_lengths,
+        MAX_LOSSY_FORWARD_ENV_VALUE,
     };
+    use et_core::packet::Packet;
+    use et_core::proto::{
+        InitialPayload, PortForwardSourceRequest, SocketEndpoint, TerminalPacketType,
+    };
+    use et_net::local_packet::MAX_LOCAL_PACKET_LEN;
+    use prost::Message;
 
     #[test]
     fn effective_locale_controls_precede_other_categories() {
-        for name in ["LANG", "LC_ALL", "LC_CTYPE"] {
-            assert!(locale_priority(name) < locale_priority("LC_000"));
+        assert!(locale_priority("LC_ALL") < locale_priority("LC_CTYPE"));
+        assert!(locale_priority("LC_CTYPE") < locale_priority("LANG"));
+        assert!(locale_priority("LANG") < locale_priority("LC_000"));
+    }
+
+    #[test]
+    fn jumphost_packet_budget_preserves_effective_locale_controls() {
+        let request = PortForwardSourceRequest {
+            source: None,
+            destination: Some(SocketEndpoint {
+                name: Some("remote-name-padding".to_owned()),
+                port: None,
+            }),
+            environmentvariable: Some("ET_PIPE".to_owned()),
+        };
+        let payload = InitialPayload {
+            jumphost: Some(false),
+            reversetunnels: vec![request; 128],
+            environmentvariables: Default::default(),
+        };
+        let mut locale = vec![
+            ("LC_ALL".to_owned(), "C".to_owned()),
+            ("LC_CTYPE".to_owned(), "C.UTF-8".to_owned()),
+            ("LANG".to_owned(), "ko_KR.UTF-8".to_owned()),
+        ];
+        locale.extend((0..15).map(|index| (format!("LC_000_{index:03}"), "x".repeat(4096))));
+        assert!(jumphost_packet_len(&payload, &locale, Some("truecolor")) > MAX_LOCAL_PACKET_LEN);
+        bound_jumphost_locale_environment(&payload, &mut locale, Some("truecolor")).unwrap();
+        assert!(jumphost_packet_len(&payload, &locale, Some("truecolor")) <= MAX_LOCAL_PACKET_LEN);
+        for name in ["LC_ALL", "LC_CTYPE", "LANG"] {
+            assert!(locale.iter().any(|(candidate, _)| candidate == name));
         }
+    }
+
+    fn jumphost_packet_len(
+        payload: &InitialPayload,
+        locale: &[(String, String)],
+        colorterm: Option<&str>,
+    ) -> usize {
+        let mut modeled = payload.clone();
+        modeled.jumphost = Some(true);
+        modeled.environmentvariables.extend(locale.iter().cloned());
+        if let Some(value) = colorterm {
+            modeled
+                .environmentvariables
+                .insert("COLORTERM".to_owned(), value.to_owned());
+        }
+        Packet::new(
+            TerminalPacketType::JumphostInit as u8,
+            modeled.encode_to_vec(),
+        )
+        .wire_len()
     }
 
     #[test]

--- a/crates/et-bin/src/forward_config.rs
+++ b/crates/et-bin/src/forward_config.rs
@@ -13,6 +13,7 @@ pub enum ForwardConfigError {
     InvalidEnvironmentName(String),
     TooManyEnvironmentNames(usize),
     EnvironmentPacketTooLarge(usize),
+    JumphostPacketTooLarge(usize),
 }
 
 impl std::fmt::Display for ForwardConfigError {
@@ -38,6 +39,11 @@ impl std::fmt::Display for ForwardConfigError {
                 "terminal environment packet needs at least {length} bytes; maximum is {}",
                 et_net::local_packet::MAX_LOCAL_PACKET_LEN
             ),
+            Self::JumphostPacketTooLarge(length) => write!(
+                formatter,
+                "jumphost initialization packet needs at least {length} bytes; maximum is {}",
+                et_net::local_packet::MAX_LOCAL_PACKET_LEN
+            ),
         }
     }
 }
@@ -49,7 +55,8 @@ impl std::error::Error for ForwardConfigError {
             Self::MissingAgentSocket
             | Self::InvalidEnvironmentName(_)
             | Self::TooManyEnvironmentNames(_)
-            | Self::EnvironmentPacketTooLarge(_) => None,
+            | Self::EnvironmentPacketTooLarge(_)
+            | Self::JumphostPacketTooLarge(_) => None,
         }
     }
 }

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -780,6 +780,33 @@ fn oversized_tunnel_environment_name_exceeds_local_packet_limit() {
 }
 
 #[test]
+fn oversized_jumphost_initialization_fails_before_ssh_bootstrap() {
+    let no_ssh = TestDir::new("honest");
+    let mut arguments = vec![
+        "-N".to_owned(),
+        "--jumphost".to_owned(),
+        "jump-alias".to_owned(),
+    ];
+    let destination = format!("remote-{}", "x".repeat(500));
+    for _ in 0..128 {
+        arguments.extend(["-r".to_owned(), format!("ET_PIPE:{destination}")]);
+    }
+    arguments.push("example.test".to_owned());
+    let output = Command::new(env!("CARGO_BIN_EXE_et"))
+        .env("PATH", &no_ssh.0)
+        .env("TERM", "xterm-256color")
+        .args(arguments)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        stderr(&output).contains("jumphost initialization packet needs at least"),
+        "{}",
+        stderr(&output)
+    );
+}
+
+#[test]
 fn jumphost_starts_a_jump_terminal_and_connects_to_the_jumphost() {
     // Upstream `--jumphost` is an ET-native relay: the destination terminal is
     // started through `ssh -J`, a second `etterminal --jump` is started on the


### PR DESCRIPTION
## Summary

- preflight the exact serialized InitialPayload wrapped as JUMPHOST_INIT, including repeated reverse requests, protobuf map wrappers, COLORTERM, and the two-byte Packet header
- trim lower-priority locale entries until a salvageable jumphost payload fits 64 KiB; reject unsalvageable payloads with exit 2 before any SSH/bootstrap side effect
- preserve effective POSIX locale precedence under byte pressure: LC_ALL, then LC_CTYPE, then fallback LANG, then other LC_* values

Resolves:
- https://github.com/minpeter/et.rs/pull/54#discussion_r3879805002
- https://github.com/minpeter/et.rs/pull/54#discussion_r3879805008

No additional Tegami note is included because the existing unreleased locale-forwarding changeset covers this correction to the same unshipped behavior.

## Failing-first evidence

- missing jumphost packet helper: compile RED
- oversized supported jumphost payload reached SSH under empty PATH: process RED
- prior locale priority ordered LANG before LC_ALL/LC_CTYPE: precedence RED

## Verification

- client_bootstrap: 19 passed
- client_environment: 6 passed
- exact salvageable JUMPHOST_INIT unit: PASS
- exact unsalvageable empty-PATH preflight: exit 2 PASS
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1
- cargo build -p et
- git diff --check
- changed-file diagnostics: no active diagnostics
- real jumphost rejection: 67,204 > 65,536, exit 2 before SSH
- direct aggregate UTF-8 session: exit 0
- independent Oracle review: PASS, confidence 0.985

## Scope

Protocol v6, protobuf/schema, wire fixtures, crypto, manifests, lockfile, dependencies, and telemetry are unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the jumphost locale environment so initialization packets never exceed the 64 KiB limit. Previously oversized payloads reached SSH and failed at runtime; now the client trims lower-priority locale entries until the payload fits, or exits with code 2 before any SSH side effect when it can't.

**Bug Fixes**
- Preserves locale precedence under byte pressure: LC_ALL, then LC_CTYPE, then LANG, then other LC_* entries.
- Reports the measured packet size in the new jumphost packet too large error.

<sup>Written for commit 684063b9bc6838f2644fc72ee8ac3b790d792276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

