### PR TITLE
fix(client): omit unsent jumphost colorterm

### DIFF
--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -98,7 +98,12 @@ fn run_client(
     let local_term = std::env::var("TERM").ok();
     let local_colorterm = std::env::var("COLORTERM").ok();
     let term = normalize_terminal_type(local_term.as_deref());
-    let colorterm = ghostty_colorterm(local_term.as_deref(), local_colorterm.as_deref());
+    // Explicit non-POSIX modes never transmit locale or COLORTERM. A bare
+    // destination remains potentially POSIX until the credential-free probe.
+    let may_send_posix_environment = !args.remote_is_windows();
+    let colorterm = may_send_posix_environment
+        .then(|| ghostty_colorterm(local_term.as_deref(), local_colorterm.as_deref()))
+        .flatten();
     let reserved_environment = reserved_environment_value_lengths(
         initial_payload
             .environmentvariables

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -757,6 +757,39 @@ fn colorterm_counts_toward_the_tunnel_environment_limit() {
 }
 
 #[test]
+fn non_posix_colorterm_does_not_reserve_an_unsent_environment_name() {
+    let no_ssh = TestDir::new("honest");
+    let mut arguments = vec![
+        "-N".to_owned(),
+        "--winserver".to_owned(),
+        "--jumphost".to_owned(),
+        "jump-alias".to_owned(),
+    ];
+    for index in 0..128 {
+        arguments.extend([
+            "-r".to_owned(),
+            format!("ET_PIPE_{index:03}:remote-{index}"),
+        ]);
+    }
+    arguments.push("example.test".to_owned());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_et"))
+        .env("PATH", &no_ssh.0)
+        .env("TERM", "xterm-ghostty")
+        .env("COLORTERM", "truecolor")
+        .args(arguments)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", stderr(&output));
+    assert!(
+        stderr(&output).contains("could not start system ssh"),
+        "{}",
+        stderr(&output)
+    );
+}
+
+#[test]
 fn oversized_tunnel_environment_name_exceeds_local_packet_limit() {
     let no_ssh = TestDir::new("honest");
     let environment_name = format!("E{}", "T".repeat(MAX_LOCAL_PACKET_LEN));
@@ -801,6 +834,39 @@ fn oversized_jumphost_initialization_fails_before_ssh_bootstrap() {
     assert_eq!(output.status.code(), Some(2));
     assert!(
         stderr(&output).contains("jumphost initialization packet needs at least"),
+        "{}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn non_posix_jumphost_ignores_unsent_colorterm_in_packet_budget() {
+    let no_ssh = TestDir::new("honest");
+    let mut arguments = vec![
+        "-N".to_owned(),
+        "--winserver".to_owned(),
+        "--jumphost".to_owned(),
+        "jump-alias".to_owned(),
+    ];
+    let destination = format!("remote-{}", "x".repeat(486));
+    for _ in 0..127 {
+        arguments.extend(["-r".to_owned(), format!("ET_PIPE:{destination}")]);
+    }
+    let boundary_destination = format!("remote-{}", "x".repeat(587));
+    arguments.extend(["-r".to_owned(), format!("ET_PIPE:{boundary_destination}")]);
+    arguments.push("example.test".to_owned());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_et"))
+        .env("PATH", &no_ssh.0)
+        .env("TERM", "xterm-ghostty")
+        .env("COLORTERM", "truecolor")
+        .args(arguments)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", stderr(&output));
+    assert!(
+        stderr(&output).contains("could not start system ssh"),
         "{}",
         stderr(&output)
     );


### PR DESCRIPTION
## Summary

- omit Ghostty COLORTERM from terminal-name reservation and JUMPHOST_INIT frame modeling when explicit Windows, Cmd, or PowerShell modes will not transmit it
- keep bare auto-detected destinations conservatively POSIX-capable before their credential-free probe
- add exact failing-first regressions for the 65,537-byte false rejection and 129-name false reservation

Resolves https://github.com/minpeter/et.rs/pull/55#discussion_r3880033256.

No additional Tegami note is included because the existing unreleased locale-forwarding changeset covers this correction to the same unshipped behavior.

## RED / GREEN

- base non-POSIX near-limit frame with COLORTERM: false exit 2 at 65,537 bytes
- corrected same frame: reaches SSH spawn boundary, exit 1 under empty PATH
- base 128 distinct non-POSIX reverse names plus COLORTERM: false exit 2 at 129 names
- corrected same reservation: reaches SSH spawn boundary
- explicit POSIX control still rejects 65,537 bytes
- genuine non-POSIX base overflow still rejects 65,540 bytes

## Verification

- client_bootstrap: 21 passed
- client_environment: 6 passed
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1
- cargo build -p et
- git diff --check
- changed-file diagnostics: no errors or warnings
- native Windows Cmd runtime: exit 0
- POSIX jerry locale charmap: UTF-8, exit 0
- independent Oracle: PASS, confidence 0.99, no findings

## Scope

Protocol v6, protobuf/schema, wire fixtures, crypto, manifests, lockfile, dependencies, and telemetry are unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the client's environment budget so Ghostty COLORTERM is no longer reserved when explicit Windows, Cmd, or PowerShell modes mean it won't be transmitted. Previously, unsent COLORTERM could cause false rejections at the 65,537-byte and 129-name limits; now those cases reach the SSH spawn boundary.

Adds regression tests for both false-positive cases.

<sup>Written for commit 9a12ed475d20b7c92a2c0231c75cd056a8d9cc10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

