### PR TITLE
ci: verify published Linux arm64 releases

### DIFF
--- a/.github/workflows/qa-published-release.yml
+++ b/.github/workflows/qa-published-release.yml
@@ -1,0 +1,106 @@
+name: QA Published Release
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/qa-published-release.yml
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Published et release tag to verify
+        required: true
+        default: et@0.0.17
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: qa-published-release-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native-linux-arm64:
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+    env:
+      RELEASE_TAG: ${{ inputs.tag || 'et@0.0.17' }}
+    steps:
+      - name: Verify published archive
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$RELEASE_TAG" =~ ^et@[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release tag: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          version="${RELEASE_TAG#et@}"
+          archive="et-${version}-${{ matrix.target }}.tar.gz"
+          release_url="https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}"
+          work_dir="$(mktemp -d "${RUNNER_TEMP}/qa-published-release.XXXXXX")"
+          start_dir="$PWD"
+
+          cleanup() {
+            cd "$start_dir"
+            rm -rf -- "$work_dir"
+          }
+          trap cleanup EXIT
+
+          cd "$work_dir"
+          curl --fail --location --silent --show-error --remote-name \
+            "${release_url}/${archive}"
+          curl --fail --location --silent --show-error --remote-name \
+            "${release_url}/${archive}.sha256"
+          sha256sum --check "${archive}.sha256"
+          tar --extract --gzip --file "$archive"
+
+          binary_dir="${work_dir}/${archive%.tar.gz}"
+          file_output="$(file "${binary_dir}/et")"
+          echo "$file_output"
+          echo "runner architecture: $(uname -m)"
+          [[ "$(uname -m)" == aarch64 ]]
+          grep --fixed-strings --quiet 'ARM aarch64' <<<"$file_output"
+
+          assert_version() {
+            local binary="$1"
+            local role="$2"
+            local expected_version="$3"
+            local output
+
+            output="$($binary --version)"
+            echo "$output"
+            [[ "${output%%$'\n'*}" == "${role} version ${expected_version} (et.rs)" ]]
+          }
+
+          control_version=0.0.18
+          if [[ "$version" == "$control_version" ]]; then
+            control_version=0.0.17
+          fi
+          if assert_version "${binary_dir}/et" et "$control_version"; then
+            echo "CONTROL_RED failed: wrong version ${control_version} was accepted" >&2
+            exit 1
+          else
+            echo "CONTROL_RED passed: wrong version ${control_version} was rejected"
+          fi
+
+          for role in et etserver etterminal htm htmd; do
+            assert_version "${binary_dir}/${role}" "$role" "$version"
+          done
+
+          cd "$start_dir"
+          cleanup
+          trap - EXIT
+          if [[ -e "$work_dir" ]]; then
+            echo "Runtime cleanup failed: $work_dir still exists" >&2
+            exit 1
+          fi
+          echo "RUNTIME_CLEANUP_PASS: removed $work_dir"


### PR DESCRIPTION
## Summary
- add a path-triggered and manually dispatchable smoke workflow for published releases
- verify GNU and musl arm64 release archives, checksums, architecture, and all busybox-style roles on native ARM runners
- include a non-fatal wrong-version control before the expected-version assertions

## Verification
- `git diff --check origin/main...HEAD`
- workflow runs on this pull request for both arm64 matrix targets

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a smoke-test workflow that verifies published Linux arm64 release archives (GNU and musl) on native ARM runners. The workflow triggers on PRs touching the workflow file and via manual dispatch with a release tag, checking checksums, architecture, and all busybox-style roles.

<sup>Written for commit 93d95c9ebb1c88210c2d8db0a227ad6dda85dbde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

