### PR TITLE
fix(server): drain terminal output before disconnect

### DIFF
--- a/.tegami/fix-terminal-hup-drain.md
+++ b/.tegami/fix-terminal-hup-drain.md
@@ -1,0 +1,11 @@
+---
+packages:
+  et:
+    type: patch
+---
+
+## Drain terminal output before disconnect
+
+Terminal sessions now drain final terminal output safely when the terminal
+exits or disconnects, preserving buffered output for the connected client
+before the session closes.

--- a/crates/et-server/src/runtime_handler.rs
+++ b/crates/et-server/src/runtime_handler.rs
@@ -278,7 +278,7 @@ fn handle_new(
     crate::diag::info(format!("id={id}: terminal bridge running for {peer}"));
     let _ = crate::terminal_bridge::run(active.clone(), terminal, forwarder);
     crate::diag::info(format!("id={id}: terminal bridge ended for {peer}"));
-    let _ = active.shutdown();
+    let _ = active.finish_terminal();
 }
 
 /// Upstream `TerminalServer::runJumpHost`: answer the initial response, hand
@@ -349,7 +349,7 @@ fn run_jumphost(
         crate::terminal_bridge::BridgeMode::Jumphost,
     );
     crate::diag::info(format!("id={id}: jumphost bridge ended for {peer}"));
-    let _ = active.shutdown();
+    let _ = active.finish_terminal();
 }
 
 fn send_initial_error(connection: &mut Connection, message: &str) {

--- a/crates/et-server/src/runtime_lifecycle.rs
+++ b/crates/et-server/src/runtime_lifecycle.rs
@@ -23,28 +23,20 @@ pub(crate) fn run(
                     "terminal disconnected for registration id={}",
                     identity.id()
                 ));
-                let shutdown_raw_sockets = match core.sessions.active(identity.id()) {
-                    Ok(Some(_)) => false,
-                    Ok(None) => true,
-                    Err(error) => {
-                        crate::diag::info(format!(
-                            "id={}: session table error checking active session: {error}",
-                            identity.id()
-                        ));
-                        first_error.get_or_insert(RuntimeError::SessionTable(error));
-                        true
-                    }
-                };
-                if shutdown_raw_sockets {
-                    if let Err(error) = core.raw_sockets.shutdown_registration(&identity) {
-                        crate::diag::info(format!(
-                            "id={}: error shutting down raw sockets: {error}",
-                            identity.id()
-                        ));
-                        first_error.get_or_insert(error);
-                    }
-                }
-                match core.sessions.remove_registration(&identity) {
+                let removed = core
+                    .sessions
+                    .remove_registration_with(&identity, |shutdown_raw| {
+                        if shutdown_raw {
+                            if let Err(error) = core.raw_sockets.shutdown_registration(&identity) {
+                                crate::diag::info(format!(
+                                    "id={}: error shutting down raw sockets: {error}",
+                                    identity.id()
+                                ));
+                                first_error.get_or_insert(error);
+                            }
+                        }
+                    });
+                match removed {
                     Ok(Some(removed)) => {
                         crate::diag::info(format!(
                             "id={}: removed session after terminal disconnect",

--- a/crates/et-server/src/runtime_lifecycle.rs
+++ b/crates/et-server/src/runtime_lifecycle.rs
@@ -23,6 +23,27 @@ pub(crate) fn run(
                     "terminal disconnected for registration id={}",
                     identity.id()
                 ));
+                let shutdown_raw_sockets = match core.sessions.active(identity.id()) {
+                    Ok(Some(_)) => false,
+                    Ok(None) => true,
+                    Err(error) => {
+                        crate::diag::info(format!(
+                            "id={}: session table error checking active session: {error}",
+                            identity.id()
+                        ));
+                        first_error.get_or_insert(RuntimeError::SessionTable(error));
+                        true
+                    }
+                };
+                if shutdown_raw_sockets {
+                    if let Err(error) = core.raw_sockets.shutdown_registration(&identity) {
+                        crate::diag::info(format!(
+                            "id={}: error shutting down raw sockets: {error}",
+                            identity.id()
+                        ));
+                        first_error.get_or_insert(error);
+                    }
+                }
                 match core.sessions.remove_registration(&identity) {
                     Ok(Some(removed)) => {
                         crate::diag::info(format!(
@@ -30,13 +51,6 @@ pub(crate) fn run(
                             identity.id()
                         ));
                         if let Some(SessionConnection::Starting(stream)) = removed.connection {
-                            if let Err(error) = core.raw_sockets.shutdown_registration(&identity) {
-                                crate::diag::info(format!(
-                                    "id={}: error shutting down raw sockets: {error}",
-                                    identity.id()
-                                ));
-                                first_error.get_or_insert(error);
-                            }
                             if let Err(error) = stream.shutdown(std::net::Shutdown::Both) {
                                 crate::diag::info(format!(
                                     "id={}: error shutting down session connection: {error}",

--- a/crates/et-server/src/runtime_lifecycle.rs
+++ b/crates/et-server/src/runtime_lifecycle.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use crate::registry::RegistrationIdentity;
 use crate::runtime_error::RuntimeError;
 use crate::runtime_state::RuntimeCore;
+use crate::session::SessionConnection;
 
 pub(crate) enum LifecycleEvent {
     TerminalDisconnected(RegistrationIdentity),
@@ -22,26 +23,28 @@ pub(crate) fn run(
                     "terminal disconnected for registration id={}",
                     identity.id()
                 ));
-                if let Err(error) = core.raw_sockets.shutdown_registration(&identity) {
-                    crate::diag::info(format!(
-                        "id={}: error shutting down raw sockets: {error}",
-                        identity.id()
-                    ));
-                    first_error.get_or_insert(error);
-                }
                 match core.sessions.remove_registration(&identity) {
                     Ok(Some(removed)) => {
                         crate::diag::info(format!(
                             "id={}: removed session after terminal disconnect",
                             identity.id()
                         ));
-                        if let Some(connection) = removed.connection {
-                            if let Err(error) = connection.shutdown() {
+                        if let Some(SessionConnection::Starting(stream)) = removed.connection {
+                            if let Err(error) = core.raw_sockets.shutdown_registration(&identity) {
+                                crate::diag::info(format!(
+                                    "id={}: error shutting down raw sockets: {error}",
+                                    identity.id()
+                                ));
+                                first_error.get_or_insert(error);
+                            }
+                            if let Err(error) = stream.shutdown(std::net::Shutdown::Both) {
                                 crate::diag::info(format!(
                                     "id={}: error shutting down session connection: {error}",
                                     identity.id()
                                 ));
-                                first_error.get_or_insert(RuntimeError::Session(error));
+                                first_error.get_or_insert(RuntimeError::Session(
+                                    crate::session::SessionError::Io(error),
+                                ));
                             }
                         }
                     }

--- a/crates/et-server/src/runtime_lifecycle.rs
+++ b/crates/et-server/src/runtime_lifecycle.rs
@@ -43,14 +43,18 @@ pub(crate) fn run(
                             identity.id()
                         ));
                         if let Some(SessionConnection::Starting(stream)) = removed.connection {
-                            if let Err(error) = stream.shutdown(std::net::Shutdown::Both) {
-                                crate::diag::info(format!(
-                                    "id={}: error shutting down session connection: {error}",
-                                    identity.id()
-                                ));
-                                first_error.get_or_insert(RuntimeError::Session(
-                                    crate::session::SessionError::Io(error),
-                                ));
+                            match stream.shutdown(std::net::Shutdown::Both) {
+                                Ok(()) => {}
+                                Err(error) if error.kind() == std::io::ErrorKind::NotConnected => {}
+                                Err(error) => {
+                                    crate::diag::info(format!(
+                                        "id={}: error shutting down session connection: {error}",
+                                        identity.id()
+                                    ));
+                                    first_error.get_or_insert(RuntimeError::Session(
+                                        crate::session::SessionError::Io(error),
+                                    ));
+                                }
                             }
                         }
                     }

--- a/crates/et-server/src/session.rs
+++ b/crates/et-server/src/session.rs
@@ -245,6 +245,23 @@ impl ActiveSession {
         }
     }
 
+    pub(crate) fn finish_terminal(&self) -> Result<(), SessionError> {
+        self.shutdown.store(true, Ordering::Release);
+        let _ = self.signal();
+        let terminal = self
+            .terminal_control
+            .lock()
+            .map_err(|_| SessionError::Unavailable)?;
+        let _ = terminal.shutdown(Shutdown::Both);
+        drop(terminal);
+        let control = self.control.lock().map_err(|_| SessionError::Unavailable)?;
+        match control.shutdown(Shutdown::Write) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotConnected => Ok(()),
+            Err(error) => Err(SessionError::Io(error)),
+        }
+    }
+
     pub(crate) fn shutdown(&self) -> Result<(), SessionError> {
         self.shutdown.store(true, Ordering::Release);
         let _ = self.signal();

--- a/crates/et-server/src/session_table.rs
+++ b/crates/et-server/src/session_table.rs
@@ -185,18 +185,23 @@ impl SessionTable {
         })
     }
 
-    pub(crate) fn remove_registration(
+    pub(crate) fn remove_registration_with<F>(
         &self,
         identity: &RegistrationIdentity,
-    ) -> Result<Option<RemovedRegistration>, SessionTableError> {
+        before_notify: F,
+    ) -> Result<Option<RemovedRegistration>, SessionTableError>
+    where
+        F: FnOnce(bool),
+    {
         let mut state = self.lock()?;
-        let matches = state
-            .slots
-            .get(identity.id())
-            .is_some_and(|slot| identity.matches(slot.registration()));
-        if !matches {
+        let Some(slot) = state.slots.get(identity.id()) else {
+            return Ok(None);
+        };
+        if !identity.matches(slot.registration()) {
             return Ok(None);
         }
+        let shutdown_raw = !matches!(slot, Slot::Active { .. });
+        before_notify(shutdown_raw);
         let connection = state
             .slots
             .remove(identity.id())

--- a/crates/et-server/src/terminal_bridge.rs
+++ b/crates/et-server/src/terminal_bridge.rs
@@ -127,28 +127,44 @@ fn run_mode_poll(
             }
             (connected, connection_generation) = session.connection_state()?;
         }
-        if terminal_events.intersects(PollFlags::HUP | PollFlags::ERR) {
-            return Err(SessionError::Io(io::ErrorKind::UnexpectedEof.into()));
-        }
-        if terminal_events.contains(PollFlags::IN) {
-            if let Some(packet) = read_terminal_packet(&mut terminal, &mut decoder)? {
-                let packet = if mode == BridgeMode::Terminal {
-                    validate_terminal_output(&packet)?;
-                    packet
-                } else {
-                    jumphost_terminal_packet(&session, packet)?
-                };
-                decoder = LocalPacketDecoder::new();
-                if let Err(error) = session.send_packet(packet.header(), packet.payload()) {
-                    if !client_transport_error(
-                        &error,
-                        &session,
-                        &mut connected,
-                        &mut connection_generation,
-                    )? {
-                        return Err(error);
+        let terminal_closed = terminal_events.intersects(PollFlags::HUP | PollFlags::ERR);
+        if terminal_closed || terminal_events.contains(PollFlags::IN) {
+            loop {
+                match read_terminal_packet(&mut terminal, &mut decoder) {
+                    Ok(Some(packet)) => {
+                        let packet = if mode == BridgeMode::Terminal {
+                            validate_terminal_output(&packet)?;
+                            packet
+                        } else {
+                            jumphost_terminal_packet(&session, packet)?
+                        };
+                        decoder = LocalPacketDecoder::new();
+                        if let Err(error) = session.send_packet(packet.header(), packet.payload()) {
+                            if !client_transport_error(
+                                &error,
+                                &session,
+                                &mut connected,
+                                &mut connection_generation,
+                            )? {
+                                return Err(error);
+                            }
+                        }
                     }
+                    Ok(None) if terminal_closed => continue,
+                    Ok(None) => break,
+                    Err(SessionError::Io(error))
+                        if terminal_closed && error.kind() == io::ErrorKind::UnexpectedEof =>
+                    {
+                        break;
+                    }
+                    Err(error) => return Err(error),
                 }
+                if !terminal_closed {
+                    break;
+                }
+            }
+            if terminal_closed {
+                return Ok(());
             }
         }
         // Recovery authentication may read more than its proof packet into

--- a/crates/et-server/tests/terminal_bridge.rs
+++ b/crates/et-server/tests/terminal_bridge.rs
@@ -104,6 +104,60 @@ fn encrypted_client_and_registered_terminal_exchange_packets() {
 }
 
 #[test]
+fn terminal_hup_still_delivers_buffered_final_packet() {
+    use std::net::Shutdown;
+
+    let mut server = TestRuntime::start();
+    let mut terminal = server.register(ID_A, KEY_A);
+    terminal.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let (stream, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    let key = passkey_to_key(KEY_A).unwrap();
+    let (mut client, initial) = initialize(stream, &key, default_payload());
+    assert_eq!(initial.error, None);
+
+    let init = read_local_packet(&mut terminal).unwrap();
+    assert_eq!(init.header(), TerminalPacketType::TerminalInit as u8);
+
+    client
+        .write_packet(TerminalPacketType::TerminalInfo as u8, b"bridge-ready")
+        .unwrap();
+    let readiness = read_local_packet(&mut terminal).unwrap();
+    assert_eq!(readiness.payload(), b"bridge-ready");
+
+    let final_packets = [
+        TerminalBuffer {
+            buffer: Some(b"final-terminal-packet-one".to_vec()),
+        },
+        TerminalBuffer {
+            buffer: Some(b"final-terminal-packet-two".to_vec()),
+        },
+    ];
+    for packet in &final_packets {
+        write_local_packet(
+            &mut terminal,
+            &Packet::new(
+                TerminalPacketType::TerminalBuffer as u8,
+                packet.encode_to_vec(),
+            ),
+        )
+        .unwrap();
+    }
+    terminal.shutdown(Shutdown::Both).unwrap();
+
+    for expected in &final_packets {
+        let received = client.read_packet().unwrap();
+        assert_eq!(received.header(), TerminalPacketType::TerminalBuffer as u8);
+        assert_eq!(
+            TerminalBuffer::decode(received.payload()).unwrap(),
+            *expected
+        );
+    }
+
+    server.runtime.shutdown().unwrap();
+}
+
+#[test]
 fn terminal_environment_is_forwarded_without_interpolation() {
     let mut server = TestRuntime::start();
     let mut terminal = server.register(ID_A, KEY_A);


### PR DESCRIPTION
## Summary
- drain complete terminal packets reported with Unix HUP/ERR before closing the bridge
- defer Active raw-socket and connection shutdown to the bridge handler
- gracefully close only the TCP write half after terminal output is flushed
- add a two-packet regression test and patch changeset

## Verification
- focused terminal HUP test: passed
- `cargo test -p et-server --test terminal_bridge -- --test-threads=1`: passed
- `cargo test -p et-server -- --test-threads=1`: passed
- `cargo clippy --workspace --all-targets -- -D warnings`: passed
- `cargo fmt --all -- --check`: passed
- mutation proof: base production failed with `UnexpectedEof`; restored production passed

Evidence was captured outside the commit under `.omo/evidence/ulw/et-platform-matrix-0.0.17-20260828/debug/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal sessions dropping buffered final output on HUP/ERR: all pending terminal packets are now drained before the bridge closes, and the TCP write side is half-closed instead of fully disconnected so the client receives the flushed data.

**Bug Fixes**

- On terminal disconnect, raw-socket shutdown runs only when the removed session is not `Active`; closing stale `Starting` connections tolerates sockets that are already closed.
- Adds `finish_terminal()` which marks shutdown and half-closes the TCP write side instead of fully disconnecting.
- Adds a regression test verifying two buffered packets are delivered on terminal hangup.

<sup>Written for commit bb43f0d42508f92db0826a3a5a1b25fabf2ade76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

