### PR TITLE
ci: upload native macOS source artifacts

### DIFF
--- a/.github/workflows/qa-published-release.yml
+++ b/.github/workflows/qa-published-release.yml
@@ -20,6 +20,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  native-macos-source:
+    name: x86_64-apple-darwin source artifact
+    runs-on: macos-15-intel
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ github.token }}
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build native source artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(uname -m)" == x86_64 ]]
+          cargo build --release --locked -p et
+          file target/release/et | tee target/release/et.file
+          shasum -a 256 target/release/et > target/release/et.sha256
+          target/release/et --version
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: et-source-${{ github.sha }}-x86_64-apple-darwin
+          path: |
+            target/release/et
+            target/release/et.file
+            target/release/et.sha256
+          if-no-files-found: error
+
   native-linux-arm64:
     name: ${{ matrix.target }}
     runs-on: ubuntu-24.04-arm


### PR DESCRIPTION
## Summary
- build the current source tree on the native `macos-15-intel` runner
- upload the x86_64 Darwin `et` binary, file identity, and SHA-256
- reuse the artifact for native Tahoe release-candidate QA without installing a host toolchain

## Scope
CI-only. No product source, version, changelog, or Tegami changeset changes.

## Verification
- one workflow file changed
- Bun YAML parse passed
- PR workflow must build and upload the exact-head artifact before merge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI job that builds and uploads the macOS x86_64 source artifact so native Tahoe QA can reuse it without a host toolchain. The job runs on `macos-15-intel`, builds `et` with `cargo build --release --locked`, and uploads the binary, file identity, and SHA-256 as `et-source-${{ github.sha }}-x86_64-apple-darwin`.

- CI-only change; no product, version, or changelog changes.

<sup>Written for commit a6a5d3eaff2afad7c090d4242084271df937a991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

