### PR TITLE
fix(client): make SSH config expansion noninteractive

### DIFF
--- a/.tegami/fix-windows-ssh-config-resolution.md
+++ b/.tegami/fix-windows-ssh-config-resolution.md
@@ -1,0 +1,10 @@
+---
+packages:
+  et:
+    type: patch
+---
+
+## Fix Windows SSH configuration resolution
+
+SSH configuration expansion now disables PTY allocation, preventing Windows
+OpenSSH from stalling before the client bootstrap.

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -17,7 +17,10 @@ pub fn resolve_ssh_config(
     deadline: Deadline,
 ) -> Result<ResolvedSshConfig, ClientError> {
     validate_ssh_destination(host_alias, requested_user)?;
-    let mut args = vec!["-G".to_string()];
+    // Config expansion never opens a remote session. Disable PTY allocation
+    // so Windows OpenSSH completes reliably when stdout is a pipe, preserving
+    // the bounded SystemSsh capture path.
+    let mut args = vec!["-G".to_string(), "-T".to_string()];
     args.extend(ssh_options.iter().map(|option| format!("-o{option}")));
     let destination = match requested_user {
         Some(user) => format!("{user}@{host_alias}"),
@@ -75,7 +78,7 @@ mod tests {
         fn run(&self, invocation: &SshInvocation, _: Deadline) -> Result<SshOutput, ClientError> {
             assert_eq!(
                 invocation.args,
-                ["-G", "-oPort=2222", "requested@server-alias"]
+                ["-G", "-T", "-oPort=2222", "requested@server-alias"]
             );
             Ok(SshOutput {
                 status: Some(success_status()),

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -221,7 +221,12 @@ fn cli_proves_exact_ssh_bootstrap_v6_and_encrypted_initial_payload() {
     assert_eq!(invocations.len(), 3);
     assert_eq!(
         invocations[0],
-        ["-G", "-oStrictHostKeyChecking=no", "test-user@server-alias"]
+        [
+            "-G",
+            "-T",
+            "-oStrictHostKeyChecking=no",
+            "test-user@server-alias"
+        ]
     );
     assert!(invocations[1].last().unwrap().contains("__ET_COMSPEC__"));
     let argv = &invocations[2];
@@ -539,7 +544,7 @@ fn explicit_posix_shell_skips_probe_and_uses_exact_posix_bootstrap() {
 
     let invocations = fake.invocations();
     assert_eq!(invocations.len(), 2, "{invocations:?}");
-    assert_eq!(invocations[0], ["-G", "127.0.0.1"]);
+    assert_eq!(invocations[0], ["-G", "-T", "127.0.0.1"]);
     let bootstrap = &invocations[1];
     assert_eq!(bootstrap[0], "config-user@127.0.0.1");
     let input = bootstrap[1]
@@ -926,7 +931,7 @@ fn jumphost_starts_a_jump_terminal_and_connects_to_the_jumphost() {
     // -G dst, login-shell probe, dst bootstrap through -J, -G jumphost,
     // jump bootstrap.
     assert_eq!(invocations.len(), 5, "{invocations:?}");
-    assert_eq!(invocations[0], ["-G", "test-user@server-alias"]);
+    assert_eq!(invocations[0], ["-G", "-T", "test-user@server-alias"]);
     assert!(invocations[1].last().unwrap().contains("__ET_COMSPEC__"));
     let destination = &invocations[2];
     assert_eq!(destination[0], "-J");
@@ -948,7 +953,7 @@ fn jumphost_starts_a_jump_terminal_and_connects_to_the_jumphost() {
         "{:?}",
         destination[3]
     );
-    assert_eq!(invocations[3], ["-G", "jump.example"]);
+    assert_eq!(invocations[3], ["-G", "-T", "jump.example"]);
     let jump = &invocations[4];
     assert_eq!(jump[0], "jump.example");
     // The jumphost remains POSIX even when the destination probe selects Cmd.


### PR DESCRIPTION
## Summary
- pass `-T` to OpenSSH configuration expansion
- prevent Windows `ssh -G` from stalling when stdout is captured through a pipe
- cover direct and jumphost invocation arguments

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy -p et --all-targets -- -D warnings`
- `cargo test -p et --bins -- --test-threads=1` (69 passed)
- `cargo test -p et --test client_bootstrap -- --test-threads=1` (21 passed)
- `cargo build -p et`
- `cargo check --locked -p et --target x86_64-pc-windows-gnu`
- native Windows MSVC `cargo build -p et`
- Windows piped `ssh -G` control: no flag hangs, `-n` hangs, `-T` exits 0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes `-T` to SSH config expansion so Windows OpenSSH no longer stalls when stdout is captured through a pipe during client bootstrap.

- Adds `-T` to all `ssh -G` invocations, including jumphost resolution.
- Updates unit and integration tests to expect the new argument order.

<sup>Written for commit 37d5eaa9f355a56707ec8e86b264f1d22bdf7c73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

