### PR TITLE
feat(terminal): display message of the day

### DIFF
--- a/.tegami/feat-session-motd.md
+++ b/.tegami/feat-session-motd.md
@@ -1,0 +1,12 @@
+---
+packages:
+  et:
+    type: patch
+---
+
+## Show the login message of the day
+
+Terminal sessions now display the message of the day before the login shell
+starts, matching an interactive `ssh` login. The banner follows `pam_motd`'s
+default file and directory precedence, honors `.hushlogin`, and never reaches
+the shell as input. Reconnecting to the same session does not print it again.

--- a/crates/et-bin/src/main.rs
+++ b/crates/et-bin/src/main.rs
@@ -101,6 +101,10 @@ mod server_daemon;
 mod terminal;
 mod terminal_credentials;
 mod terminal_daemon;
+// The message of the day comes from `pam_motd`'s files, which exist only on
+// POSIX systems.
+#[cfg(unix)]
+mod terminal_motd;
 mod terminal_protocol;
 mod terminal_pty;
 

--- a/crates/et-bin/src/terminal_motd.rs
+++ b/crates/et-bin/src/terminal_motd.rs
@@ -1,0 +1,305 @@
+//! Session message-of-the-day output for new POSIX terminal sessions.
+//!
+//! `sshd` normally displays these files from its PAM session stack. Eternal
+//! Terminal starts its PTY outside that stack, so the authenticated
+//! `etterminal` process reads the same fixed files and sends them to the router
+//! as terminal output before the login shell starts.
+
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use et_core::packet::Packet;
+use et_core::proto::{TerminalBuffer, TerminalPacketType};
+use et_net::local::LocalStream;
+use et_net::local_packet::write_local_packet;
+use prost::Message;
+use rustix::fs::{Mode, OFlags};
+
+/// Largest output chunk per packet, matching the PTY output worker.
+const MAX_OUTPUT_CHUNK: usize = 16 * 1024;
+/// `pam_motd(8)` limits each message to 64 KiB.
+const MAX_MOTD_MESSAGE: usize = 64 * 1024;
+/// Bound aggregate startup output when many directory messages exist.
+const MAX_MOTD_TOTAL: usize = 256 * 1024;
+/// Bound directory enumeration as well as emitted bytes.
+const MAX_MOTD_ENTRIES: usize = 1024;
+/// Operator override naming one file to display instead of the defaults.
+const OVERRIDE_VARIABLE: &str = "ET_MOTD_PATH";
+/// `pam_motd(8)`'s default single files, highest priority first.
+const DEFAULT_FILES: [&str; 3] = ["/etc/motd", "/run/motd", "/usr/lib/motd"];
+/// `pam_motd(8)`'s default directories, highest priority first.
+const DEFAULT_DIRS: [&str; 3] = ["/etc/motd.d", "/run/motd.d", "/usr/lib/motd.d"];
+
+/// Emit the message of the day to the router, if there is one to show.
+///
+/// File-level failures are advisory and never fail the session. A router write
+/// failure follows the same error path as any other terminal output failure.
+pub fn emit(router: &mut LocalStream) -> Result<(), String> {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let override_path = std::env::var_os(OVERRIDE_VARIABLE)
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from);
+    let files: Vec<PathBuf> = DEFAULT_FILES.iter().map(PathBuf::from).collect();
+    let directories: Vec<PathBuf> = DEFAULT_DIRS.iter().map(PathBuf::from).collect();
+    let Some(text) = load_from(
+        &files,
+        &directories,
+        override_path.as_deref(),
+        home.as_deref(),
+    ) else {
+        return Ok(());
+    };
+    write_output(router, &text)
+}
+
+fn load_from(
+    files: &[PathBuf],
+    directories: &[PathBuf],
+    override_path: Option<&Path>,
+    home: Option<&Path>,
+) -> Option<Vec<u8>> {
+    if home.is_some_and(|home| home.join(".hushlogin").exists()) {
+        return None;
+    }
+
+    let mut output = Vec::new();
+    if let Some(path) = override_path {
+        let message = read_message(path)?;
+        append_terminal_bytes(&mut output, &message);
+    } else {
+        for path in files {
+            if let Some(message) = read_message(path) {
+                append_terminal_bytes(&mut output, &message);
+                break;
+            }
+        }
+        for path in directory_messages(directories) {
+            if output.len() >= MAX_MOTD_TOTAL {
+                break;
+            }
+            if let Some(message) = read_message(&path) {
+                append_terminal_bytes(&mut output, &message);
+            }
+        }
+    }
+    (!output.is_empty()).then_some(output)
+}
+
+/// Resolve directory overrides by basename, then return lexical display order.
+fn directory_messages(directories: &[PathBuf]) -> Vec<PathBuf> {
+    let mut messages: BTreeMap<OsString, PathBuf> = BTreeMap::new();
+    for directory in directories {
+        let Ok(entries) = std::fs::read_dir(directory) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            if messages.contains_key(&name) {
+                continue;
+            }
+            if messages.len() >= MAX_MOTD_ENTRIES {
+                break;
+            }
+            messages.insert(name, entry.path());
+        }
+    }
+    messages.into_values().collect()
+}
+
+/// Open without blocking on special files, then validate the opened object.
+fn read_message(path: &Path) -> Option<Vec<u8>> {
+    let descriptor = rustix::fs::open(
+        path,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NONBLOCK,
+        Mode::empty(),
+    )
+    .ok()?;
+    let file = File::from(descriptor);
+    if !file.metadata().ok()?.is_file() {
+        return None;
+    }
+    let mut bytes = Vec::with_capacity(MAX_MOTD_MESSAGE);
+    file.take(u64::try_from(MAX_MOTD_MESSAGE).ok()?.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .ok()?;
+    bytes.truncate(MAX_MOTD_MESSAGE);
+    Some(bytes)
+}
+
+/// Preserve existing CRLF and make lone LF render from column zero.
+fn append_terminal_bytes(output: &mut Vec<u8>, bytes: &[u8]) {
+    let mut previous = 0u8;
+    for byte in bytes {
+        if output.len() >= MAX_MOTD_TOTAL {
+            return;
+        }
+        if *byte == b'\n' && previous != b'\r' {
+            output.push(b'\r');
+            if output.len() >= MAX_MOTD_TOTAL {
+                return;
+            }
+        }
+        output.push(*byte);
+        previous = *byte;
+    }
+}
+
+fn output_packet(chunk: &[u8]) -> Packet {
+    let message = TerminalBuffer {
+        buffer: Some(chunk.to_vec()),
+    };
+    Packet::new(
+        TerminalPacketType::TerminalBuffer as u8,
+        message.encode_to_vec(),
+    )
+}
+
+fn write_output(router: &mut LocalStream, text: &[u8]) -> Result<(), String> {
+    for chunk in text.chunks(MAX_OUTPUT_CHUNK) {
+        write_local_packet(router, &output_packet(chunk))
+            .map_err(|error| format!("could not forward message of the day: {error}"))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    use nix::sys::stat::Mode as NixMode;
+    use nix::unistd::mkfifo;
+
+    use super::*;
+
+    struct Sandbox(PathBuf);
+
+    impl Sandbox {
+        fn new(label: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "et-rs-motd-{label}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            let _ = fs::remove_dir_all(&path);
+            fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+
+        fn file(&self, name: &str, contents: &[u8]) -> PathBuf {
+            let path = self.0.join(name);
+            fs::write(&path, contents).unwrap();
+            path
+        }
+
+        fn directory(&self, name: &str) -> PathBuf {
+            let path = self.0.join(name);
+            fs::create_dir(&path).unwrap();
+            path
+        }
+    }
+
+    impl Drop for Sandbox {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn load_suppresses_everything_when_home_has_hushlogin() {
+        let sandbox = Sandbox::new("hushlogin");
+        let motd = sandbox.file("motd", b"banner\n");
+        let home = Sandbox::new("hushlogin-home");
+        home.file(".hushlogin", b"");
+
+        assert_eq!(load_from(&[], &[], Some(&motd), Some(&home.0)), None);
+    }
+
+    #[test]
+    fn load_skips_missing_empty_and_nonregular_override_files() {
+        let sandbox = Sandbox::new("nonfatal");
+        let empty = sandbox.file("empty", b"");
+        let missing = sandbox.0.join("missing");
+        let directory = sandbox.directory("directory");
+        let fifo = sandbox.0.join("fifo");
+        mkfifo(&fifo, NixMode::S_IRUSR | NixMode::S_IWUSR).unwrap();
+
+        for source in [empty, missing, directory, fifo, PathBuf::from("/dev/null")] {
+            assert_eq!(load_from(&[], &[], Some(&source), None), None, "{source:?}");
+        }
+    }
+
+    #[test]
+    fn load_bounds_each_message_and_total_directory_output() {
+        let sandbox = Sandbox::new("bounded");
+        let directory = sandbox.directory("motd.d");
+        for index in 0..5 {
+            fs::write(
+                directory.join(format!("{index:02}-message")),
+                vec![b'x'; MAX_MOTD_MESSAGE * 3],
+            )
+            .unwrap();
+        }
+
+        let output = load_from(&[], std::slice::from_ref(&directory), None, None).unwrap();
+
+        assert_eq!(output.len(), MAX_MOTD_TOTAL);
+    }
+
+    #[test]
+    fn load_shows_only_the_first_readable_default_file() {
+        let sandbox = Sandbox::new("defaults");
+        let first = sandbox.file("first", b"first\n");
+        let second = sandbox.file("second", b"second\n");
+
+        assert_eq!(
+            load_from(&[first, second.clone()], &[], None, None).unwrap(),
+            b"first\r\n"
+        );
+        assert_eq!(
+            load_from(&[sandbox.0.join("absent"), second], &[], None, None).unwrap(),
+            b"second\r\n"
+        );
+    }
+
+    #[test]
+    fn load_orders_directory_union_and_honors_priority_overrides() {
+        let sandbox = Sandbox::new("directories");
+        let high = sandbox.directory("etc");
+        let middle = sandbox.directory("run");
+        let low = sandbox.directory("usr");
+        fs::write(high.join("10-first"), b"first\n").unwrap();
+        fs::write(high.join("20-shared"), b"high\n").unwrap();
+        fs::write(middle.join("20-shared"), b"middle\n").unwrap();
+        fs::write(low.join("20-shared"), b"low\n").unwrap();
+        fs::write(low.join("30-last"), b"last\n").unwrap();
+        fs::write(low.join("40-silenced"), b"must-not-appear\n").unwrap();
+        symlink("/dev/null", high.join("40-silenced")).unwrap();
+
+        assert_eq!(
+            load_from(&[], &[high, middle, low], None, None).unwrap(),
+            b"first\r\nhigh\r\nlast\r\n"
+        );
+    }
+
+    #[test]
+    fn load_preserves_raw_bytes_and_normalizes_only_lone_line_feeds() {
+        let sandbox = Sandbox::new("raw-bytes");
+        let motd = sandbox.file("motd", b"a\r\nb\n\x1b[31mc\x07\xff\xfe\n");
+
+        assert_eq!(
+            load_from(&[], &[], Some(&motd), None).unwrap(),
+            b"a\r\nb\r\n\x1b[31mc\x07\xff\xfe\r\n"
+        );
+    }
+
+    #[test]
+    fn maximum_output_packet_fits_the_local_frame_bound() {
+        let packet = output_packet(&vec![b'x'; MAX_OUTPUT_CHUNK]);
+
+        assert!(packet.wire_len() <= et_net::local_packet::MAX_LOCAL_PACKET_LEN);
+    }
+}

--- a/crates/et-bin/src/terminal_motd.rs
+++ b/crates/et-bin/src/terminal_motd.rs
@@ -170,9 +170,6 @@ mod tests {
     use std::fs;
     use std::os::unix::fs::symlink;
 
-    use nix::sys::stat::Mode as NixMode;
-    use nix::unistd::mkfifo;
-
     use super::*;
 
     struct Sandbox(PathBuf);
@@ -225,7 +222,11 @@ mod tests {
         let missing = sandbox.0.join("missing");
         let directory = sandbox.directory("directory");
         let fifo = sandbox.0.join("fifo");
-        mkfifo(&fifo, NixMode::S_IRUSR | NixMode::S_IWUSR).unwrap();
+        assert!(std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .unwrap()
+            .success());
 
         for source in [empty, missing, directory, fifo, PathBuf::from("/dev/null")] {
             assert_eq!(load_from(&[], &[], Some(&source), None), None, "{source:?}");

--- a/crates/et-bin/src/terminal_pty.rs
+++ b/crates/et-bin/src/terminal_pty.rs
@@ -28,6 +28,10 @@ enum WorkerEvent {
 
 pub fn run(mut router: LocalStream, term: &str) -> Result<i32, String> {
     let environment = read_initial_environment(&mut router)?;
+    // Upstream issue #257: show the login banner an interactive ssh would have
+    // printed, before the shell writes anything.
+    #[cfg(unix)]
+    crate::terminal_motd::emit(&mut router)?;
     let pair = native_pty_system()
         .openpty(PtySize {
             rows: 24,

--- a/crates/et-bin/tests/reconnect_end_to_end.rs
+++ b/crates/et-bin/tests/reconnect_end_to_end.rs
@@ -16,10 +16,13 @@ use reconnect_stack::{mkfifo, shell_quote, Stack};
 use reconnect_support::CutProxy;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
+const MOTD_MARKER: &[u8] = b"ET-MOTD-RECONNECT";
 
 #[test]
 fn real_client_recovers_same_shell_and_once_only_buffered_output() {
     let mut stack = Stack::start();
+    let motd = stack.directory.join("motd");
+    fs::write(&motd, b"ET-MOTD-RECONNECT\n").unwrap();
     let proxy = CutProxy::start(stack.port);
     let pair = native_pty_system()
         .openpty(PtySize {
@@ -52,6 +55,7 @@ fn real_client_recovers_same_shell_and_once_only_buffered_output() {
     );
     client.env("TERM", "xterm-256color");
     client.env("ET_SSH_COUNT", &stack.ssh_count);
+    client.env("ET_MOTD_PATH", &motd);
     let client_ready = stack.directory.join("client-ready");
     client.env("ET_SSH_READY", &client_ready);
     let mut child = pair.slave.spawn_command(client).unwrap();
@@ -159,6 +163,7 @@ fn real_client_recovers_same_shell_and_once_only_buffered_output() {
     assert!(output.windows(11).any(|window| window == b"SIZE:44 111"));
     assert_eq!(count(&output, b"BUFFERED-ONCE\r\n"), 1);
     assert_eq!(count(&output, b"BUFFERED-TWICE\r\n"), 1);
+    assert_eq!(count(&output, MOTD_MARKER), 1);
     assert!(text.contains("RECONNECT-TERMIOS:"), "output={text}");
     assert!(text.contains(":CODE:0:"), "output={text}");
     assert!(termios_restored(&text), "output={text}");

--- a/crates/et-bin/tests/terminal_runtime.rs
+++ b/crates/et-bin/tests/terminal_runtime.rs
@@ -23,6 +23,7 @@ const ID: &str = "abcdefghijklmnop";
 const KEY: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef";
 const TIMEOUT: Duration = Duration::from_secs(5);
 const LOGIN_TERM_COMPLETION: &[u8] = b"__ET_LOGIN_TERM_COMPLETE__\r\n";
+const MOTD_MARKER: &[u8] = b"ET-MOTD-MARKER";
 
 #[test]
 fn bootstrap_parent_reports_marker_and_leaves_registered_session_running() {
@@ -270,6 +271,125 @@ fn real_terminal_login_shell_preserves_term_without_colorterm() {
         "expected complete TERM/COLORTERM record; got {:?}",
         String::from_utf8_lossy(&output),
     );
+}
+
+#[test]
+fn real_terminal_emits_motd_before_login_shell_output() {
+    // Given: a server-side MOTD file the session is told to display.
+    let fixture = Fixture::new("motd-before-shell");
+    let motd = fixture.file("motd", b"ET-MOTD-MARKER\n");
+    let shell = fixture.login_probe_shell();
+    let mut child = fixture.spawn_session(
+        shell.to_str().unwrap(),
+        &[("ET_MOTD_PATH", motd.as_os_str())],
+    );
+    write_credentials(&mut child);
+    let (mut router, _) = fixture.listener.accept().unwrap();
+    router.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let _ = read_local_packet(&mut router).unwrap();
+    fixture.wait_ready();
+
+    // When: the session initializes and the login shell starts producing output.
+    send(
+        &mut router,
+        TerminalPacketType::TerminalInit,
+        &TermInit {
+            environmentnames: Vec::new(),
+            environmentvalues: Vec::new(),
+        },
+    );
+    send(
+        &mut router,
+        TerminalPacketType::TerminalBuffer,
+        &TerminalBuffer {
+            buffer: Some(b"exit\n".to_vec()),
+        },
+    );
+    let output = collect_until(&mut router, |output| contains(output, LOGIN_COLOR_MARKER));
+    let status = child.wait_timeout(TIMEOUT).unwrap().unwrap();
+    assert!(status.success());
+
+    // Then: the MOTD reached the client before any shell output.
+    let motd_at = find(&output, MOTD_MARKER);
+    let shell_at = find(&output, LOGIN_COLOR_MARKER);
+    assert!(
+        motd_at.is_some_and(|motd_at| shell_at.is_some_and(|shell_at| motd_at < shell_at)),
+        "expected MOTD before login shell output; got {:?}",
+        String::from_utf8_lossy(&output),
+    );
+    assert!(
+        contains(&output, b"ET-MOTD-MARKER\r\n"),
+        "expected MOTD lines terminated with CRLF; got {:?}",
+        String::from_utf8_lossy(&output),
+    );
+    assert_eq!(
+        count(&output, MOTD_MARKER),
+        1,
+        "expected MOTD exactly once; got {:?}",
+        String::from_utf8_lossy(&output),
+    );
+}
+
+#[test]
+fn real_terminal_suppresses_motd_when_home_has_hushlogin() {
+    // Given: a MOTD file plus a HOME containing .hushlogin.
+    let fixture = Fixture::new("motd-hushlogin");
+    let motd = fixture.file("motd", b"ET-MOTD-MARKER\n");
+    let home = fixture.file(".hushlogin", b"");
+    let home = home.parent().unwrap().to_owned();
+    let shell = fixture.login_probe_shell();
+    let mut child = fixture.spawn_session(
+        shell.to_str().unwrap(),
+        &[
+            ("ET_MOTD_PATH", motd.as_os_str()),
+            ("HOME", home.as_os_str()),
+        ],
+    );
+    write_credentials(&mut child);
+    let (mut router, _) = fixture.listener.accept().unwrap();
+    router.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let _ = read_local_packet(&mut router).unwrap();
+    fixture.wait_ready();
+
+    // When: the session runs to the point the login shell has produced output.
+    send(
+        &mut router,
+        TerminalPacketType::TerminalInit,
+        &TermInit {
+            environmentnames: Vec::new(),
+            environmentvalues: Vec::new(),
+        },
+    );
+    send(
+        &mut router,
+        TerminalPacketType::TerminalBuffer,
+        &TerminalBuffer {
+            buffer: Some(b"exit\n".to_vec()),
+        },
+    );
+    let output = collect_until(&mut router, |output| contains(output, LOGIN_COLOR_MARKER));
+    let status = child.wait_timeout(TIMEOUT).unwrap().unwrap();
+    assert!(status.success());
+
+    // Then: no MOTD was ever sent.
+    assert!(
+        !contains(&output, MOTD_MARKER),
+        "expected .hushlogin to suppress the MOTD; got {:?}",
+        String::from_utf8_lossy(&output),
+    );
+}
+
+fn find(output: &[u8], marker: &[u8]) -> Option<usize> {
+    output
+        .windows(marker.len())
+        .position(|window| window == marker)
+}
+
+fn count(output: &[u8], marker: &[u8]) -> usize {
+    output
+        .windows(marker.len())
+        .filter(|window| *window == marker)
+        .count()
 }
 
 fn send<M: Message>(router: &mut impl Write, kind: TerminalPacketType, message: &M) {

--- a/crates/et-bin/tests/terminal_runtime_support/mod.rs
+++ b/crates/et-bin/tests/terminal_runtime_support/mod.rs
@@ -50,7 +50,18 @@ impl Fixture {
     }
 
     pub fn spawn_with_shell(&self, shell: &str) -> std::process::Child {
-        Command::new(env!("CARGO_BIN_EXE_et"))
+        self.spawn_session(shell, &[])
+    }
+
+    /// Spawn the session child with extra environment entries applied before
+    /// exec, so a test can seed server-side state the session reads at startup.
+    pub fn spawn_session(
+        &self,
+        shell: &str,
+        environment: &[(&str, &std::ffi::OsStr)],
+    ) -> std::process::Child {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_et"));
+        command
             .args([
                 "terminal",
                 "--session-child",
@@ -60,12 +71,23 @@ impl Fixture {
             ])
             .arg(&self.socket)
             .env("SHELL", shell)
-            .env_remove("COLORTERM")
+            .env_remove("COLORTERM");
+        for (name, value) in environment {
+            command.env(name, value);
+        }
+        command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
             .unwrap()
+    }
+
+    /// Write a server-side file inside the fixture directory and return its path.
+    pub fn file(&self, name: &str, contents: &[u8]) -> std::path::PathBuf {
+        let path = self.directory.join(name);
+        fs::write(&path, contents).unwrap();
+        path
     }
 
     /// Wrapper that emits an ANSI palette color marker only when argv[1] is `-l`.


### PR DESCRIPTION
## Summary
- display PAM-style MOTD files before each new POSIX login shell
- honor `.hushlogin`, bounded file/directory reads, and safe terminal framing
- keep MOTD output once-only across reconnects and leave protocol v6 unchanged

Implements the behavior requested in MisterTea/EternalTerminal#257 and discussed in MisterTea/EternalTerminal#191 and MisterTea/EternalTerminal#445.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- real client/server PTY rendered through xterm.js, including CJK MOTD text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Displays the system message of the day before a new POSIX login shell starts, matching interactive `ssh` behavior. This addresses MisterTea/EternalTerminal#257 and the discussion in #191 and #445.

**New Features**
- Reads PAM-style MOTD files from the default locations, with `.hushlogin` and an `ET_MOTD_PATH` override respected.
- Bounds message and total output sizes, avoids blocking on special files, and frames output through the existing protocol, so protocol v6 is unchanged.
- Shows the banner only once per session; reconnecting to the same session does not print it again.

<sup>Written for commit 3315cd7f4c79aae23e6cad0dae1a22b715cc12b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

