### PR TITLE
fix(terminal): tolerate startup under load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,12 @@ jobs:
       - if: runner.os == 'Linux'
         run: cargo test --workspace -- --test-threads=1
 
+      # Library unit tests exercise the real SCM_RIGHTS helper. Unlike the
+      # Linux workspace test command, `--lib --bins` does not produce Cargo's
+      # un-hashed executable, so build the shipped helper explicitly.
+      - if: runner.os == 'macOS'
+        run: cargo build -p et-net --bin et-user-socket-helper
+
       - if: runner.os == 'macOS'
         run: cargo test --workspace --lib --bins -- --test-threads=1
 

--- a/.tegami/fix-terminal-startup-under-load.md
+++ b/.tegami/fix-terminal-startup-under-load.md
@@ -6,6 +6,7 @@ packages:
 
 ## Keep terminal startup reliable under heavy load
 
-Terminal startup now allows heavily loaded servers more time to create and
-register a session process, while still reporting child startup failures
-immediately instead of hiding them behind a generic timeout.
+Terminal startup now uses authenticated, bounded registration and structured
+startup acknowledgements before reporting readiness. Initialization remains
+responsive under load while forged identities, stalled peers, premature
+success, leaked children, and unbounded admission are rejected or cleaned up.

--- a/.tegami/fix-terminal-startup-under-load.md
+++ b/.tegami/fix-terminal-startup-under-load.md
@@ -1,0 +1,11 @@
+---
+packages:
+  et:
+    type: patch
+---
+
+## Keep terminal startup reliable under heavy load
+
+Terminal startup now allows heavily loaded servers more time to create and
+register a session process, while still reporting child startup failures
+immediately instead of hiding them behind a generic timeout.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,7 @@ dependencies = [
  "signal-hook",
  "sysinfo",
  "wait-timeout",
+ "windows-spawn",
 ]
 
 [[package]]
@@ -1470,6 +1471,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-spawn"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2de3bd5b666ddb82bdd91c438afbe6a413fc21725d10e3e0b8d1d1c4afdd91c6"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/crates/et-bin/Cargo.toml
+++ b/crates/et-bin/Cargo.toml
@@ -38,6 +38,8 @@ signal-hook = "0.3.18"
 [target.'cfg(windows)'.dependencies]
 # Ctrl+C / console shutdown signalling, the Windows analogue of SIGINT/SIGTERM.
 ctrlc = "3.5"
+# Safe CreateProcessW wrapper with an explicit inherited-handle allowlist.
+windows-spawn = "0.1.0"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 nix = { version = "0.31.3", default-features = false, features = ["fs", "poll"] }

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -280,8 +280,12 @@ fn run_client(
     if args.no_terminal && !has_forwarding {
         return Ok(());
     }
-    let (forwarder, skipped) = et_net::forward::Forwarder::start_with_origins(local_sources)
-        .map_err(|error| ClientError::Terminal(error.to_string()))?;
+    let (forwarder, skipped) = et_net::forward::Forwarder::start_with_origins_deadline(
+        local_sources,
+        deadline.expires_at(),
+        std::sync::Arc::new(et_net::forward::SystemForwardResolver),
+    )
+    .map_err(|error| ClientError::Terminal(error.to_string()))?;
     for skipped in skipped {
         let source = skipped.request.source.unwrap_or_default();
         let label = match (source.name.as_deref(), source.port) {

--- a/crates/et-bin/src/client_terminal_loop.rs
+++ b/crates/et-bin/src/client_terminal_loop.rs
@@ -1,5 +1,5 @@
 #[cfg(unix)]
-use std::io::{self, Read};
+use std::io::{self, Read, Write};
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
 #[cfg(unix)]
@@ -31,6 +31,45 @@ use crate::initial_connect::ReconnectOutcome;
 const INPUT_CHUNK: usize = 16 * 1024;
 #[cfg(unix)]
 const MISSED_KEEPALIVES: u32 = 3;
+
+#[cfg(unix)]
+struct PumpProbe {
+    stream: UnixStream,
+}
+
+#[cfg(unix)]
+impl PumpProbe {
+    fn connect() -> Result<Option<Self>, ClientError> {
+        let Some(path) = std::env::var_os("ET_PUMP_PROBE") else {
+            return Ok(None);
+        };
+        let mut stream = UnixStream::connect(path)
+            .map_err(|error| terminal_io("connecting terminal pump probe", error))?;
+        stream
+            .write_all(b"R")
+            .map_err(|error| terminal_io("reporting terminal pump readiness", error))?;
+        let mut gate = [0_u8; 1];
+        stream
+            .read_exact(&mut gate)
+            .map_err(|error| terminal_io("waiting for terminal pump probe gate", error))?;
+        if gate != *b"G" {
+            return Err(terminal_text("terminal pump probe sent an invalid gate"));
+        }
+        Ok(Some(Self { stream }))
+    }
+
+    fn arm(&mut self) -> Result<(), ClientError> {
+        self.stream
+            .write_all(b"A")
+            .map_err(|error| terminal_io("arming terminal pump probe", error))
+    }
+
+    fn progressed(&mut self) -> Result<(), ClientError> {
+        self.stream
+            .write_all(b"P")
+            .map_err(|error| terminal_io("reporting terminal pump progress", error))
+    }
+}
 
 /// Loop configuration resolved by [`crate::client_terminal::run`].
 pub(crate) struct PumpOptions<'a> {
@@ -77,7 +116,11 @@ where
     if let Ok(path) = std::env::var("ET_SSH_READY") {
         let _ = std::fs::write(path, b"ready");
     }
+    let mut pump_probe = PumpProbe::connect()?;
     loop {
+        if let Some(probe) = pump_probe.as_mut() {
+            probe.arm()?;
+        }
         // Retry a held forwarding packet first: draining the forwarder's
         // outbound queue below is what frees worker capacity, so this makes
         // progress every iteration instead of deadlocking on a blocking send.
@@ -142,6 +185,9 @@ where
                     .unwrap_or(PollFlags::empty()),
             )
         };
+        if let Some(probe) = pump_probe.as_mut() {
+            probe.progressed()?;
+        }
         let mut reconnect_needed = network.intersects(PollFlags::HUP | PollFlags::ERR);
         if resize.intersects(PollFlags::IN | PollFlags::HUP) {
             drain(wake)?;

--- a/crates/et-bin/src/detach.rs
+++ b/crates/et-bin/src/detach.rs
@@ -10,16 +10,41 @@
 //! `et` server and terminal usable on Windows without WSL. Some jobs forbid
 //! breakaway, so the flag is dropped on retry.
 
+use std::ffi::OsStr;
 use std::io;
 use std::process::{Child, Command};
 
-/// Configure `command` to survive the current shell/session.
-pub fn configure(command: &mut Command) {
+/// Construct a re-exec command that closes every descriptor above stderr
+/// before entering the long-lived child. The shell is only a descriptor-hygiene
+/// trampoline; all executable paths and arguments remain positional values.
+pub fn command(executable: &OsStr) -> Command {
     #[cfg(unix)]
     {
-        use std::os::unix::process::CommandExt;
-        command.process_group(0);
+        const CLOSE_AND_EXEC: &str = r#"
+for path in /proc/self/fd/[3-9] /proc/self/fd/[1-9][0-9]* /dev/fd/[3-9] /dev/fd/[1-9][0-9]*; do
+    [ -e "$path" ] || continue
+    fd=${path##*/}
+    eval "exec ${fd}>&-" 2>/dev/null || :
+done
+exec "$@"
+"#;
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", CLOSE_AND_EXEC, "et-detached-child"]);
+        command.arg(executable);
+        command
     }
+    #[cfg(windows)]
+    {
+        Command::new(executable)
+    }
+}
+
+/// Configure `command` to survive the current shell/session. On Unix the
+/// re-executed child calls `setsid()` itself; making it a process-group leader
+/// here would make that operation fail with `EPERM`.
+pub fn configure(command: &mut Command) {
+    #[cfg(unix)]
+    let _ = command;
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
@@ -27,20 +52,11 @@ pub fn configure(command: &mut Command) {
     }
 }
 
-/// Spawn `command` detached, retrying without job breakaway if the job object
-/// does not allow it.
+/// Spawn `command` detached. Windows must fail closed when the enclosing job
+/// forbids breakaway: retrying without breakaway would report readiness for a
+/// child that OpenSSH kills as soon as bootstrap exits.
 pub fn spawn(command: &mut Command) -> io::Result<Child> {
-    match command.spawn() {
-        Ok(child) => Ok(child),
-        #[cfg(windows)]
-        Err(error) => {
-            use std::os::windows::process::CommandExt;
-            command.creation_flags(windows_flags(false));
-            command.spawn().map_err(|_| error)
-        }
-        #[cfg(unix)]
-        Err(error) => Err(error),
-    }
+    command.spawn()
 }
 
 #[cfg(windows)]
@@ -83,9 +99,7 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn breakaway_is_requested_first_and_optional() {
-        assert_ne!(windows_flags(true), windows_flags(false));
+    fn breakaway_is_mandatory() {
         assert_eq!(windows_flags(true) & 0x0100_0000, 0x0100_0000);
-        assert_eq!(windows_flags(false) & 0x0100_0000, 0);
     }
 }

--- a/crates/et-bin/src/detach.rs
+++ b/crates/et-bin/src/detach.rs
@@ -16,6 +16,8 @@ pub type Child = std::process::Child;
 pub type Stdio = std::process::Stdio;
 #[cfg(unix)]
 pub type ChildStdout = std::process::ChildStdout;
+#[cfg(unix)]
+pub type ChildStderr = std::process::ChildStderr;
 #[cfg(windows)]
 pub type Command = windows_spawn::Command;
 #[cfg(windows)]
@@ -24,6 +26,8 @@ pub type Child = windows_spawn::Child;
 pub type Stdio = windows_spawn::Stdio;
 #[cfg(windows)]
 pub type ChildStdout = windows_spawn::ChildStdout;
+#[cfg(windows)]
+pub type ChildStderr = windows_spawn::ChildStderr;
 
 /// Construct a re-exec command with inherited-resource hygiene.
 pub fn command(executable: &OsStr) -> Command {
@@ -46,6 +50,30 @@ exec "$@"
     {
         Command::new(executable)
     }
+}
+
+/// Construct a direct re-exec command. Unix children must close inherited
+/// descriptors before creating threads.
+pub fn direct_command(executable: &OsStr) -> Command {
+    Command::new(executable)
+}
+
+/// Close every inherited non-stdio descriptor after direct re-exec.
+#[cfg(unix)]
+pub fn close_inherited_descriptors() -> io::Result<()> {
+    let entries = std::fs::read_dir("/proc/self/fd")
+        .or_else(|_| std::fs::read_dir("/dev/fd"))?
+        .collect::<Result<Vec<_>, _>>()?;
+    let descriptors = entries
+        .iter()
+        .filter_map(|entry| entry.file_name().to_str()?.parse::<i32>().ok())
+        .filter(|descriptor| *descriptor >= 3)
+        .collect::<Vec<_>>();
+    drop(entries);
+    for descriptor in descriptors {
+        let _ = nix::unistd::close(descriptor);
+    }
+    Ok(())
 }
 
 /// Configure `command` to survive the current shell/session.

--- a/crates/et-bin/src/detach.rs
+++ b/crates/et-bin/src/detach.rs
@@ -1,6 +1,6 @@
 //! Spawning processes that outlive the launching shell.
 //!
-//! Unix children re-exec through a descriptor-closing trampoline and call
+//! Unix children re-exec directly, close inherited descriptors, and call
 //! `setsid` in the child. Windows uses `windows-spawn`, whose STARTUPINFOEX
 //! handle list includes only configured stdio, together with mandatory job
 //! breakaway flags. Failure to obtain either property fails before readiness.
@@ -28,29 +28,6 @@ pub type Stdio = windows_spawn::Stdio;
 pub type ChildStdout = windows_spawn::ChildStdout;
 #[cfg(windows)]
 pub type ChildStderr = windows_spawn::ChildStderr;
-
-/// Construct a re-exec command with inherited-resource hygiene.
-pub fn command(executable: &OsStr) -> Command {
-    #[cfg(unix)]
-    {
-        const CLOSE_AND_EXEC: &str = r#"
-for path in /proc/self/fd/[3-9] /proc/self/fd/[1-9][0-9]* /dev/fd/[3-9] /dev/fd/[1-9][0-9]*; do
-    [ -e "$path" ] || continue
-    fd=${path##*/}
-    eval "exec ${fd}>&-" 2>/dev/null || :
-done
-exec "$@"
-"#;
-        let mut command = Command::new("/bin/sh");
-        command.args(["-c", CLOSE_AND_EXEC, "et-detached-child"]);
-        command.arg(executable);
-        command
-    }
-    #[cfg(windows)]
-    {
-        Command::new(executable)
-    }
-}
 
 /// Construct a direct re-exec command. Unix children must close inherited
 /// descriptors before creating threads.
@@ -135,7 +112,7 @@ mod tests {
         // handle arguments to STARTUPINFOEX. This type assertion prevents a
         // regression back to std::process::Command's inherit-all default.
         fn requires_allowlisted_command(_: &windows_spawn::Command) {}
-        let command = command(OsStr::new("cmd.exe"));
+        let command = direct_command(OsStr::new("cmd.exe"));
         requires_allowlisted_command(&command);
     }
 }

--- a/crates/et-bin/src/detach.rs
+++ b/crates/et-bin/src/detach.rs
@@ -1,22 +1,31 @@
 //! Spawning processes that outlive the launching shell.
 //!
-//! Unix only needs a new process group; the child keeps running once the
-//! bootstrap `ssh` exits.
-//!
-//! Windows needs more care. OpenSSH puts each session in a job object and
-//! terminates the job when the session ends, so a plain `DETACHED_PROCESS`
-//! child of an ssh-launched command dies with the connection. Sessions must
-//! therefore break away from that job as well, which is the piece that makes an
-//! `et` server and terminal usable on Windows without WSL. Some jobs forbid
-//! breakaway, so the flag is dropped on retry.
+//! Unix children re-exec through a descriptor-closing trampoline and call
+//! `setsid` in the child. Windows uses `windows-spawn`, whose STARTUPINFOEX
+//! handle list includes only configured stdio, together with mandatory job
+//! breakaway flags. Failure to obtain either property fails before readiness.
 
 use std::ffi::OsStr;
 use std::io;
-use std::process::{Child, Command};
 
-/// Construct a re-exec command that closes every descriptor above stderr
-/// before entering the long-lived child. The shell is only a descriptor-hygiene
-/// trampoline; all executable paths and arguments remain positional values.
+#[cfg(unix)]
+pub type Command = std::process::Command;
+#[cfg(unix)]
+pub type Child = std::process::Child;
+#[cfg(unix)]
+pub type Stdio = std::process::Stdio;
+#[cfg(unix)]
+pub type ChildStdout = std::process::ChildStdout;
+#[cfg(windows)]
+pub type Command = windows_spawn::Command;
+#[cfg(windows)]
+pub type Child = windows_spawn::Child;
+#[cfg(windows)]
+pub type Stdio = windows_spawn::Stdio;
+#[cfg(windows)]
+pub type ChildStdout = windows_spawn::ChildStdout;
+
+/// Construct a re-exec command with inherited-resource hygiene.
 pub fn command(executable: &OsStr) -> Command {
     #[cfg(unix)]
     {
@@ -39,39 +48,33 @@ exec "$@"
     }
 }
 
-/// Configure `command` to survive the current shell/session. On Unix the
-/// re-executed child calls `setsid()` itself; making it a process-group leader
-/// here would make that operation fail with `EPERM`.
+/// Configure `command` to survive the current shell/session.
 pub fn configure(command: &mut Command) {
-    #[cfg(unix)]
+    // All platform policy is applied either by the Unix child (`setsid`) or by
+    // the Windows spawn transaction below.
     let _ = command;
+}
+
+/// Spawn detached and fail closed if mandatory Windows breakaway or explicit
+/// handle inheritance cannot be established.
+pub fn spawn(command: &mut Command) -> io::Result<Child> {
+    #[cfg(unix)]
+    {
+        command.spawn()
+    }
     #[cfg(windows)]
     {
-        use std::os::windows::process::CommandExt;
-        command.creation_flags(windows_flags(true));
+        use windows_spawn::{CreationFlags, DropPolicy, SpawnOptions};
+        command.spawn_with(
+            SpawnOptions::new()
+                .creation_flags(
+                    CreationFlags::DETACHED_PROCESS
+                        | CreationFlags::NEW_PROCESS_GROUP
+                        | CreationFlags::BREAKAWAY_FROM_JOB,
+                )
+                .drop_policy(DropPolicy::Detach),
+        )
     }
-}
-
-/// Spawn `command` detached. Windows must fail closed when the enclosing job
-/// forbids breakaway: retrying without breakaway would report readiness for a
-/// child that OpenSSH kills as soon as bootstrap exits.
-pub fn spawn(command: &mut Command) -> io::Result<Child> {
-    command.spawn()
-}
-
-#[cfg(windows)]
-fn windows_flags(breakaway: bool) -> u32 {
-    /// No inherited console.
-    const DETACHED_PROCESS: u32 = 0x0000_0008;
-    /// Ctrl+C in the parent console does not reach the child.
-    const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
-    /// Leave the launching job object (e.g. the OpenSSH session job).
-    const CREATE_BREAKAWAY_FROM_JOB: u32 = 0x0100_0000;
-    let mut flags = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP;
-    if breakaway {
-        flags |= CREATE_BREAKAWAY_FROM_JOB;
-    }
-    flags
 }
 
 #[cfg(test)]
@@ -89,9 +92,9 @@ mod tests {
             command
         };
         command
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null());
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
         configure(&mut command);
         let mut child = spawn(&mut command).unwrap();
         assert!(child.wait().unwrap().success());
@@ -99,7 +102,12 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn breakaway_is_mandatory() {
-        assert_eq!(windows_flags(true) & 0x0100_0000, 0x0100_0000);
+    fn windows_spawn_uses_explicit_handle_allowlist_and_breakaway() {
+        // `windows_spawn::Command` exposes only configured stdio and explicit
+        // handle arguments to STARTUPINFOEX. This type assertion prevents a
+        // regression back to std::process::Command's inherit-all default.
+        fn requires_allowlisted_command(_: &windows_spawn::Command) {}
+        let command = command(OsStr::new("cmd.exe"));
+        requires_allowlisted_command(&command);
     }
 }

--- a/crates/et-bin/src/initial_connect.rs
+++ b/crates/et-bin/src/initial_connect.rs
@@ -19,6 +19,9 @@ use crate::resolver::EndpointResolver;
 const MAX_ENDPOINT_ADDRESSES: usize = 16;
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 const IO_TIMEOUT: Duration = Duration::from_secs(10);
+/// Server owns an eight-second absolute initialization budget. Do not admit a
+/// connection unless the outer budget leaves an additional propagation margin.
+const MIN_INITIALIZATION_BUDGET: Duration = Duration::from_secs(9);
 
 #[path = "reconnect.rs"]
 mod reconnect_impl;
@@ -56,8 +59,9 @@ pub fn connect_initial(
     resolver: &dyn EndpointResolver,
     deadline: Deadline,
 ) -> Result<Connection, ClientError> {
+    let admission_deadline = initialization_admission_deadline(deadline)?;
     let key = passkey_to_key(&credentials.passkey).ok_or(ClientError::InvalidPasskey)?;
-    let mut stream = connect_endpoint(endpoint, resolver, deadline)?;
+    let mut stream = connect_endpoint(endpoint, resolver, admission_deadline)?;
     set_stream_timeout(&stream, deadline)?;
 
     ensure_deadline(deadline, "sending ConnectRequest")?;
@@ -137,6 +141,17 @@ fn set_stream_timeout(stream: &TcpStream, deadline: Deadline) -> Result<(), Clie
             operation: "setting the write timeout",
             source,
         })
+}
+
+fn initialization_admission_deadline(deadline: Deadline) -> Result<Deadline, ClientError> {
+    match deadline.remaining() {
+        Some(remaining) if remaining > MIN_INITIALIZATION_BUDGET => {
+            Ok(Deadline::after(remaining - MIN_INITIALIZATION_BUDGET))
+        }
+        _ => Err(ClientError::BootstrapTimeout(
+            "reserving the ET initialization budget",
+        )),
+    }
 }
 
 fn ensure_deadline(deadline: Deadline, operation: &'static str) -> Result<(), ClientError> {

--- a/crates/et-bin/src/initial_connect.rs
+++ b/crates/et-bin/src/initial_connect.rs
@@ -7,6 +7,7 @@ use et_core::proto::{
     ConnectResponse, ConnectStatus, EtPacketType, InitialPayload, InitialResponse,
 };
 use et_net::connection::Connection;
+use et_net::forward::ForwardOrigin;
 use et_net::framing_io::{read_proto_limited, write_proto};
 use et_net::handshake::{client_request, MAX_HANDSHAKE_PROTO_LEN};
 use prost::Message;
@@ -56,6 +57,7 @@ pub fn connect_initial(
     endpoint: &Endpoint,
     credentials: &Credentials,
     initial_payload: &InitialPayload,
+    remote_origins: &[ForwardOrigin],
     resolver: &dyn EndpointResolver,
     deadline: Deadline,
 ) -> Result<Connection, ClientError> {
@@ -77,7 +79,7 @@ pub fn connect_initial(
     ensure_deadline(deadline, "sending INITIAL_PAYLOAD")?;
     let mut connection = Connection::new_client(stream, &key);
     connection
-        .write_packet_live(
+        .write_packet_strict(
             EtPacketType::InitialPayload as u8,
             &initial_payload.encode_to_vec(),
         )
@@ -91,7 +93,13 @@ pub fn connect_initial(
     }
     let response =
         InitialResponse::decode(packet.payload()).map_err(ClientError::MalformedInitialResponse)?;
-    accept_initial_response(response)?;
+    if accept_initial_response(response, remote_origins)? {
+        connection
+            .write_packet_strict(EtPacketType::Heartbeat as u8, &[])
+            .map_err(|error| {
+                transport_error(deadline, "acknowledging reverse forwarding skips", error)
+            })?;
+    }
     connection
         .set_io_timeout(None)
         .map_err(ClientError::Transport)?;
@@ -145,6 +153,14 @@ fn set_stream_timeout(stream: &TcpStream, deadline: Deadline) -> Result<(), Clie
         })
 }
 
+fn classify_initial_response_error(message: String) -> ClientError {
+    if et_net::forward::decode_forward_timeout(&message).is_some() {
+        ClientError::BootstrapTimeout("setting up forwarding")
+    } else {
+        ClientError::InitialResponseRejected(message)
+    }
+}
+
 fn ensure_initialization_budget(deadline: Deadline) -> Result<(), ClientError> {
     match deadline.remaining() {
         Some(remaining) if remaining >= MIN_INITIALIZATION_BUDGET => Ok(()),
@@ -190,12 +206,41 @@ fn transport_error(
     }
 }
 
-fn accept_initial_response(response: InitialResponse) -> Result<(), ClientError> {
-    if let Some(message) = response.error {
-        Err(ClientError::InitialResponseRejected(message))
-    } else {
-        Ok(())
+fn accept_initial_response(
+    response: InitialResponse,
+    remote_origins: &[ForwardOrigin],
+) -> Result<bool, ClientError> {
+    let Some(message) = response.error else {
+        return Ok(false);
+    };
+    let rows = match et_net::reverse_report::decode_skipped_rows(&message, remote_origins.len()) {
+        Ok(Some(rows)) => rows,
+        Ok(None) => return Err(classify_initial_response_error(message)),
+        Err(_) => {
+            return Err(ClientError::InitialResponseRejected(
+                "malformed reverse forwarding skip report".to_owned(),
+            ));
+        }
+    };
+    for row in &rows {
+        match remote_origins[row.index] {
+            ForwardOrigin::SshConfig { strict: false } => {}
+            ForwardOrigin::Explicit
+            | ForwardOrigin::SshConfig { strict: true }
+            | ForwardOrigin::Reported(_) => {
+                return Err(ClientError::InitialResponseRejected(
+                    "required reverse forwarding row could not bind".to_owned(),
+                ));
+            }
+        }
     }
+    for row in rows {
+        et_cli::logging::warn(format!(
+            "SSH remoteforward row {} could not bind; skipping forwarding row",
+            row.index
+        ));
+    }
+    Ok(true)
 }
 
 fn accept_response(response: ConnectResponse) -> Result<(), ClientError> {

--- a/crates/et-bin/src/initial_connect.rs
+++ b/crates/et-bin/src/initial_connect.rs
@@ -64,7 +64,9 @@ pub fn connect_initial(
     let mut stream = connect_endpoint(endpoint, resolver, admission_deadline)?;
     set_stream_timeout(&stream, deadline)?;
 
-    ensure_deadline(deadline, "sending ConnectRequest")?;
+    // Resolution/connect may consume their entire admission slice. Revalidate
+    // the reserved server-response margin at the actual admission boundary.
+    ensure_initialization_budget(deadline)?;
     write_proto(&mut stream, &client_request(&credentials.id))
         .map_err(|source| connect_error(deadline, "sending ConnectRequest", source))?;
     set_stream_timeout(&stream, deadline)?;
@@ -141,6 +143,15 @@ fn set_stream_timeout(stream: &TcpStream, deadline: Deadline) -> Result<(), Clie
             operation: "setting the write timeout",
             source,
         })
+}
+
+fn ensure_initialization_budget(deadline: Deadline) -> Result<(), ClientError> {
+    match deadline.remaining() {
+        Some(remaining) if remaining >= MIN_INITIALIZATION_BUDGET => Ok(()),
+        _ => Err(ClientError::BootstrapTimeout(
+            "reserving the ET initialization budget",
+        )),
+    }
 }
 
 fn initialization_admission_deadline(deadline: Deadline) -> Result<Deadline, ClientError> {

--- a/crates/et-bin/src/initial_connect.rs
+++ b/crates/et-bin/src/initial_connect.rs
@@ -7,7 +7,6 @@ use et_core::proto::{
     ConnectResponse, ConnectStatus, EtPacketType, InitialPayload, InitialResponse,
 };
 use et_net::connection::Connection;
-use et_net::forward::ForwardOrigin;
 use et_net::framing_io::{read_proto_limited, write_proto};
 use et_net::handshake::{client_request, MAX_HANDSHAKE_PROTO_LEN};
 use prost::Message;
@@ -57,7 +56,6 @@ pub fn connect_initial(
     endpoint: &Endpoint,
     credentials: &Credentials,
     initial_payload: &InitialPayload,
-    remote_origins: &[ForwardOrigin],
     resolver: &dyn EndpointResolver,
     deadline: Deadline,
 ) -> Result<Connection, ClientError> {
@@ -79,7 +77,7 @@ pub fn connect_initial(
     ensure_deadline(deadline, "sending INITIAL_PAYLOAD")?;
     let mut connection = Connection::new_client(stream, &key);
     connection
-        .write_packet_strict(
+        .write_packet_live(
             EtPacketType::InitialPayload as u8,
             &initial_payload.encode_to_vec(),
         )
@@ -93,13 +91,7 @@ pub fn connect_initial(
     }
     let response =
         InitialResponse::decode(packet.payload()).map_err(ClientError::MalformedInitialResponse)?;
-    if accept_initial_response(response, remote_origins)? {
-        connection
-            .write_packet_strict(EtPacketType::Heartbeat as u8, &[])
-            .map_err(|error| {
-                transport_error(deadline, "acknowledging reverse forwarding skips", error)
-            })?;
-    }
+    accept_initial_response(response)?;
     connection
         .set_io_timeout(None)
         .map_err(ClientError::Transport)?;
@@ -206,41 +198,12 @@ fn transport_error(
     }
 }
 
-fn accept_initial_response(
-    response: InitialResponse,
-    remote_origins: &[ForwardOrigin],
-) -> Result<bool, ClientError> {
-    let Some(message) = response.error else {
-        return Ok(false);
-    };
-    let rows = match et_net::reverse_report::decode_skipped_rows(&message, remote_origins.len()) {
-        Ok(Some(rows)) => rows,
-        Ok(None) => return Err(classify_initial_response_error(message)),
-        Err(_) => {
-            return Err(ClientError::InitialResponseRejected(
-                "malformed reverse forwarding skip report".to_owned(),
-            ));
-        }
-    };
-    for row in &rows {
-        match remote_origins[row.index] {
-            ForwardOrigin::SshConfig { strict: false } => {}
-            ForwardOrigin::Explicit
-            | ForwardOrigin::SshConfig { strict: true }
-            | ForwardOrigin::Reported(_) => {
-                return Err(ClientError::InitialResponseRejected(
-                    "required reverse forwarding row could not bind".to_owned(),
-                ));
-            }
-        }
+fn accept_initial_response(response: InitialResponse) -> Result<(), ClientError> {
+    if let Some(message) = response.error {
+        Err(classify_initial_response_error(message))
+    } else {
+        Ok(())
     }
-    for row in rows {
-        et_cli::logging::warn(format!(
-            "SSH remoteforward row {} could not bind; skipping forwarding row",
-            row.index
-        ));
-    }
-    Ok(true)
 }
 
 fn accept_response(response: ConnectResponse) -> Result<(), ClientError> {

--- a/crates/et-bin/src/initial_connect_tests.rs
+++ b/crates/et-bin/src/initial_connect_tests.rs
@@ -1,15 +1,13 @@
+use std::time::Duration;
+
 use et_core::proto::{ConnectResponse, ConnectStatus, InitialResponse};
-use et_net::forward::ForwardOrigin;
-use et_net::reverse_report::{encode_skipped_rows, SkipReason, SkippedRow};
 
 use super::{
     accept_initial_response, accept_reconnect_response, accept_response,
-    classify_initial_response_error, ensure_initialization_budget,
     initialization_admission_deadline, ReconnectStatus,
 };
 use crate::deadline::Deadline;
 use crate::error::ClientError;
-use std::time::Duration;
 
 #[test]
 fn short_outer_budget_is_rejected_before_connection_admission() {
@@ -22,24 +20,37 @@ fn short_outer_budget_is_rejected_before_connection_admission() {
     let outer = Deadline::after(Duration::from_secs(10));
     let admission = initialization_admission_deadline(outer).unwrap();
     assert!(admission.expires_at() < outer.expires_at());
-    assert!(matches!(
-        ensure_initialization_budget(Deadline::after(Duration::from_secs(9))),
-        Err(ClientError::BootstrapTimeout(
-            "reserving the ET initialization budget"
-        ))
-    ));
 }
 
 #[test]
-fn forwarding_timeout_sentinel_maps_to_bootstrap_timeout_variant() {
-    let encoded = et_net::forward::encode_forward_timeout("legacy-readable detail");
-    assert_eq!(
-        et_net::forward::decode_forward_timeout(&encoded),
-        Some("legacy-readable detail")
-    );
+fn initial_response_without_error_is_accepted() {
+    assert!(accept_initial_response(InitialResponse { error: None }).is_ok());
+}
+
+#[test]
+fn every_non_timeout_initial_response_error_is_fatal() {
+    for message in [
+        "reverse forwarding failed",
+        "ETRS-RF-SKIP/1 0 13",
+        "anything else",
+    ] {
+        assert!(matches!(
+            accept_initial_response(InitialResponse {
+                error: Some(message.to_owned()),
+            }),
+            Err(ClientError::InitialResponseRejected(error)) if error == message
+        ));
+    }
+}
+
+#[test]
+fn forwarding_timeout_uses_bootstrap_timeout_classification() {
+    let message = et_net::forward::encode_forward_timeout("deadline elapsed");
     assert!(matches!(
-        classify_initial_response_error(encoded),
-        ClientError::BootstrapTimeout("setting up forwarding")
+        accept_initial_response(InitialResponse {
+            error: Some(message),
+        }),
+        Err(ClientError::BootstrapTimeout("setting up forwarding"))
     ));
 }
 
@@ -52,62 +63,6 @@ fn fresh_bootstrap_rejects_returning_status() {
     assert!(matches!(
         accept_response(response),
         Err(ClientError::ReturningSessionRequiresRecovery)
-    ));
-}
-
-#[test]
-fn config_only_skip_report_continues_but_explicit_report_is_fatal() {
-    let report = encode_skipped_rows(&[SkippedRow {
-        index: 0,
-        reason: SkipReason::Bind,
-    }])
-    .unwrap();
-
-    assert!(accept_initial_response(
-        InitialResponse {
-            error: Some(report.clone()),
-        },
-        &[ForwardOrigin::SshConfig { strict: false }],
-    )
-    .is_ok());
-    for origin in [
-        ForwardOrigin::Explicit,
-        ForwardOrigin::SshConfig { strict: true },
-        ForwardOrigin::Reported(0),
-    ] {
-        assert!(matches!(
-            accept_initial_response(
-                InitialResponse {
-                    error: Some(report.clone()),
-                },
-                &[origin],
-            ),
-            Err(ClientError::InitialResponseRejected(message))
-                if message == "required reverse forwarding row could not bind"
-        ));
-    }
-}
-
-#[test]
-fn old_server_error_and_malformed_reserved_report_fail_closed() {
-    assert!(matches!(
-        accept_initial_response(
-            InitialResponse {
-                error: Some("port forwarding I/O: address in use".to_owned()),
-            },
-            &[ForwardOrigin::SshConfig { strict: false }],
-        ),
-        Err(ClientError::InitialResponseRejected(_))
-    ));
-    assert!(matches!(
-        accept_initial_response(
-            InitialResponse {
-                error: Some("ETRS-RF-SKIP/2;0:B".to_owned()),
-            },
-            &[ForwardOrigin::SshConfig { strict: false }],
-        ),
-        Err(ClientError::InitialResponseRejected(message))
-            if message == "malformed reverse forwarding skip report"
     ));
 }
 

--- a/crates/et-bin/src/initial_connect_tests.rs
+++ b/crates/et-bin/src/initial_connect_tests.rs
@@ -1,13 +1,15 @@
-use std::time::Duration;
-
 use et_core::proto::{ConnectResponse, ConnectStatus, InitialResponse};
+use et_net::forward::ForwardOrigin;
+use et_net::reverse_report::{encode_skipped_rows, SkipReason, SkippedRow};
 
 use super::{
     accept_initial_response, accept_reconnect_response, accept_response,
-    ensure_initialization_budget, initialization_admission_deadline, ReconnectStatus,
+    classify_initial_response_error, ensure_initialization_budget,
+    initialization_admission_deadline, ReconnectStatus,
 };
 use crate::deadline::Deadline;
 use crate::error::ClientError;
+use std::time::Duration;
 
 #[test]
 fn short_outer_budget_is_rejected_before_connection_admission() {
@@ -29,24 +31,16 @@ fn short_outer_budget_is_rejected_before_connection_admission() {
 }
 
 #[test]
-fn initial_response_without_error_is_accepted() {
-    assert!(accept_initial_response(InitialResponse { error: None }).is_ok());
-}
-
-#[test]
-fn every_initial_response_error_is_fatal() {
-    for message in [
-        "reverse forwarding failed",
-        "ETRS-RF-SKIP/1 0 13",
-        "anything else",
-    ] {
-        assert!(matches!(
-            accept_initial_response(InitialResponse {
-                error: Some(message.to_owned()),
-            }),
-            Err(ClientError::InitialResponseRejected(error)) if error == message
-        ));
-    }
+fn forwarding_timeout_sentinel_maps_to_bootstrap_timeout_variant() {
+    let encoded = et_net::forward::encode_forward_timeout("legacy-readable detail");
+    assert_eq!(
+        et_net::forward::decode_forward_timeout(&encoded),
+        Some("legacy-readable detail")
+    );
+    assert!(matches!(
+        classify_initial_response_error(encoded),
+        ClientError::BootstrapTimeout("setting up forwarding")
+    ));
 }
 
 #[test]
@@ -58,6 +52,62 @@ fn fresh_bootstrap_rejects_returning_status() {
     assert!(matches!(
         accept_response(response),
         Err(ClientError::ReturningSessionRequiresRecovery)
+    ));
+}
+
+#[test]
+fn config_only_skip_report_continues_but_explicit_report_is_fatal() {
+    let report = encode_skipped_rows(&[SkippedRow {
+        index: 0,
+        reason: SkipReason::Bind,
+    }])
+    .unwrap();
+
+    assert!(accept_initial_response(
+        InitialResponse {
+            error: Some(report.clone()),
+        },
+        &[ForwardOrigin::SshConfig { strict: false }],
+    )
+    .is_ok());
+    for origin in [
+        ForwardOrigin::Explicit,
+        ForwardOrigin::SshConfig { strict: true },
+        ForwardOrigin::Reported(0),
+    ] {
+        assert!(matches!(
+            accept_initial_response(
+                InitialResponse {
+                    error: Some(report.clone()),
+                },
+                &[origin],
+            ),
+            Err(ClientError::InitialResponseRejected(message))
+                if message == "required reverse forwarding row could not bind"
+        ));
+    }
+}
+
+#[test]
+fn old_server_error_and_malformed_reserved_report_fail_closed() {
+    assert!(matches!(
+        accept_initial_response(
+            InitialResponse {
+                error: Some("port forwarding I/O: address in use".to_owned()),
+            },
+            &[ForwardOrigin::SshConfig { strict: false }],
+        ),
+        Err(ClientError::InitialResponseRejected(_))
+    ));
+    assert!(matches!(
+        accept_initial_response(
+            InitialResponse {
+                error: Some("ETRS-RF-SKIP/2;0:B".to_owned()),
+            },
+            &[ForwardOrigin::SshConfig { strict: false }],
+        ),
+        Err(ClientError::InitialResponseRejected(message))
+            if message == "malformed reverse forwarding skip report"
     ));
 }
 

--- a/crates/et-bin/src/initial_connect_tests.rs
+++ b/crates/et-bin/src/initial_connect_tests.rs
@@ -1,6 +1,26 @@
-use super::{accept_initial_response, accept_reconnect_response, accept_response, ReconnectStatus};
-use crate::error::ClientError;
+use std::time::Duration;
+
 use et_core::proto::{ConnectResponse, ConnectStatus, InitialResponse};
+
+use super::{
+    accept_initial_response, accept_reconnect_response, accept_response,
+    initialization_admission_deadline, ReconnectStatus,
+};
+use crate::deadline::Deadline;
+use crate::error::ClientError;
+
+#[test]
+fn short_outer_budget_is_rejected_before_connection_admission() {
+    assert!(matches!(
+        initialization_admission_deadline(Deadline::after(Duration::from_secs(3))),
+        Err(ClientError::BootstrapTimeout(
+            "reserving the ET initialization budget"
+        ))
+    ));
+    let outer = Deadline::after(Duration::from_secs(10));
+    let admission = initialization_admission_deadline(outer).unwrap();
+    assert!(admission.expires_at() < outer.expires_at());
+}
 
 #[test]
 fn initial_response_without_error_is_accepted() {

--- a/crates/et-bin/src/initial_connect_tests.rs
+++ b/crates/et-bin/src/initial_connect_tests.rs
@@ -4,7 +4,7 @@ use et_core::proto::{ConnectResponse, ConnectStatus, InitialResponse};
 
 use super::{
     accept_initial_response, accept_reconnect_response, accept_response,
-    initialization_admission_deadline, ReconnectStatus,
+    ensure_initialization_budget, initialization_admission_deadline, ReconnectStatus,
 };
 use crate::deadline::Deadline;
 use crate::error::ClientError;
@@ -20,6 +20,12 @@ fn short_outer_budget_is_rejected_before_connection_admission() {
     let outer = Deadline::after(Duration::from_secs(10));
     let admission = initialization_admission_deadline(outer).unwrap();
     assert!(admission.expires_at() < outer.expires_at());
+    assert!(matches!(
+        ensure_initialization_budget(Deadline::after(Duration::from_secs(9))),
+        Err(ClientError::BootstrapTimeout(
+            "reserving the ET initialization budget"
+        ))
+    ));
 }
 
 #[test]

--- a/crates/et-bin/src/main.rs
+++ b/crates/et-bin/src/main.rs
@@ -33,7 +33,10 @@ fn main() {
 
     match dispatch(prog, &argv[1..]) {
         Ok(code) => std::process::exit(code),
-        Err(error) => error.exit(),
+        Err(error) => {
+            crate::server_daemon::fail_startup(&error.to_string());
+            error.exit();
+        }
     }
 }
 

--- a/crates/et-bin/src/server.rs
+++ b/crates/et-bin/src/server.rs
@@ -65,6 +65,10 @@ pub fn run(args: &[OsString]) -> Result<i32, clap::Error> {
         .map_err(|error| clap_io("could not select terminal router path", error))?;
     let mut runtime = Runtime::start(config.bind_ip, config.port, router_path)
         .map_err(|error| clap_io("could not start ET server", error))?;
+    if parsed.daemon_child {
+        crate::server_daemon::signal_runtime_started()
+            .map_err(|error| clap::Error::raw(ErrorKind::Io, error))?;
+    }
     et_cli::logging::info(format!(
         "etserver listening on {:?} router {}",
         runtime.tcp_addresses(),
@@ -84,6 +88,10 @@ pub fn run(args: &[OsString]) -> Result<i32, clap::Error> {
     runtime
         .shutdown()
         .map_err(|error| clap_io("could not shut down ET server", error))?;
+    if parsed.daemon_child {
+        crate::server_daemon::signal_shutdown_complete()
+            .map_err(|error| clap::Error::raw(ErrorKind::Io, error))?;
+    }
     Ok(0)
 }
 

--- a/crates/et-bin/src/server.rs
+++ b/crates/et-bin/src/server.rs
@@ -66,7 +66,8 @@ pub fn run(args: &[OsString]) -> Result<i32, clap::Error> {
     let mut runtime = Runtime::start(config.bind_ip, config.port, router_path)
         .map_err(|error| clap_io("could not start ET server", error))?;
     if parsed.daemon_child {
-        crate::server_daemon::signal_runtime_started()
+        crate::server_daemon::signal_startup_complete()
+            .and_then(|()| crate::server_daemon::signal_runtime_started())
             .map_err(|error| clap::Error::raw(ErrorKind::Io, error))?;
     }
     et_cli::logging::info(format!(

--- a/crates/et-bin/src/server_daemon.rs
+++ b/crates/et-bin/src/server_daemon.rs
@@ -6,10 +6,10 @@
 //! detached child: the parent returns immediately (exit 0), and the child
 //! becomes a session leader before serving.
 
+use crate::detach::Stdio;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
 
 #[cfg(unix)]
 pub const DEFAULT_PID_FILE: &str = "/var/run/etserver.pid";

--- a/crates/et-bin/src/server_daemon.rs
+++ b/crates/et-bin/src/server_daemon.rs
@@ -9,7 +9,7 @@
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 #[cfg(unix)]
 pub const DEFAULT_PID_FILE: &str = "/var/run/etserver.pid";
@@ -30,7 +30,7 @@ pub fn spawn_detached(args: &[std::ffi::OsString]) -> Result<(), String> {
         .map_err(|error| format!("could not locate etserver executable: {error}"))?
         .canonicalize()
         .map_err(|error| format!("could not resolve etserver executable: {error}"))?;
-    let mut child = Command::new(executable);
+    let mut child = crate::detach::command(executable.as_os_str());
     child.arg("server");
     for argument in args {
         if argument == std::ffi::OsStr::new("--daemon") {
@@ -57,12 +57,8 @@ pub fn detach_child(pidfile: Option<&Path>) -> Result<(), String> {
     {
         // A fresh child of the original shell is not a process-group leader, so
         // this succeeds and drops the controlling terminal.
-        if let Err(error) = rustix::process::setsid() {
-            // Already a session leader is not an error for our purposes.
-            if error != rustix::io::Errno::PERM {
-                return Err(format!("could not create a new session: {error}"));
-            }
-        }
+        rustix::process::setsid()
+            .map_err(|error| format!("could not create a new session: {error}"))?;
     }
     // The working directory is already `/`: the parent sets it on the child
     // via `Command::current_dir`, matching upstream's `chdir("/")`.

--- a/crates/et-bin/src/server_daemon.rs
+++ b/crates/et-bin/src/server_daemon.rs
@@ -6,7 +6,7 @@
 //! detached child: the parent returns after runtime-startup acknowledgement,
 //! and the child becomes a session leader before serving.
 
-use crate::detach::{ChildStdout, Stdio};
+use crate::detach::{ChildStderr, Stdio};
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -47,7 +47,7 @@ pub fn spawn_detached(args: &[std::ffi::OsString]) -> Result<(), String> {
         .map_err(|error| format!("could not locate etserver executable: {error}"))?
         .canonicalize()
         .map_err(|error| format!("could not resolve etserver executable: {error}"))?;
-    let mut child = crate::detach::command(executable.as_os_str());
+    let mut child = crate::detach::direct_command(executable.as_os_str());
     child.arg("server");
     for argument in args {
         if argument == std::ffi::OsStr::new("--daemon") {
@@ -58,19 +58,19 @@ pub fn spawn_detached(args: &[std::ffi::OsString]) -> Result<(), String> {
     }
     child
         .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
         .env(STATUS_ENV, STATUS_TOKEN)
         .current_dir(root_directory());
     crate::detach::configure(&mut child);
     let mut child = crate::detach::spawn(&mut child)
         .map_err(|error| format!("could not start background etserver: {error}"))?;
-    let stdout = child
-        .stdout
+    let stderr = child
+        .stderr
         .take()
         .ok_or_else(|| "background etserver status pipe was not created".to_owned())?;
     let (sender, receiver) = mpsc::sync_channel(1);
-    let worker = match spawn_status_worker(stdout, sender) {
+    let worker = match spawn_status_worker(stderr, sender) {
         Ok(worker) => worker,
         Err(error) => {
             let _ = child.kill();
@@ -84,12 +84,24 @@ pub fn spawn_detached(args: &[std::ffi::OsString]) -> Result<(), String> {
         }
         Err(_) => Err("timed out waiting for background etserver to detach".to_owned()),
     };
-    if result.is_err() {
-        let _ = child.kill();
-        let _ = child.wait();
-    }
     let _ = worker.join();
-    result
+    match result {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let status = match child.try_wait() {
+                Ok(Some(status)) => format!("child exited with {status}"),
+                Ok(None) => {
+                    let _ = child.kill();
+                    match child.wait() {
+                        Ok(status) => format!("child was still running and was killed: {status}"),
+                        Err(wait_error) => format!("child kill/wait failed: {wait_error}"),
+                    }
+                }
+                Err(wait_error) => format!("could not inspect child exit status: {wait_error}"),
+            };
+            Err(format!("{error}; {status}"))
+        }
+    }
 }
 
 /// Finish detaching inside the re-executed child: become a session leader,
@@ -97,6 +109,8 @@ pub fn spawn_detached(args: &[std::ffi::OsString]) -> Result<(), String> {
 pub fn detach_child(pidfile: Option<&Path>) -> Result<(), String> {
     #[cfg(unix)]
     {
+        crate::detach::close_inherited_descriptors()
+            .map_err(|error| format!("could not close inherited descriptors: {error}"))?;
         // A fresh child of the original shell is not a process-group leader, so
         // this succeeds and drops the controlling terminal.
         rustix::process::setsid()
@@ -125,8 +139,8 @@ fn write_startup_status(code: u8, message: &str) -> Result<(), String> {
     let bytes = message.as_bytes();
     let bytes = &bytes[..bytes.len().min(MAX_STATUS_MESSAGE)];
     let length = u16::try_from(bytes.len()).expect("daemon status bound fits u16");
-    let stdout = std::io::stdout();
-    let mut output = stdout.lock();
+    let stderr = std::io::stderr();
+    let mut output = stderr.lock();
     output
         .write_all(STATUS_MAGIC)
         .and_then(|()| output.write_all(&[code]))
@@ -137,31 +151,50 @@ fn write_startup_status(code: u8, message: &str) -> Result<(), String> {
 }
 
 fn spawn_status_worker(
-    stdout: ChildStdout,
+    stderr: ChildStderr,
     sender: mpsc::SyncSender<Result<(), String>>,
 ) -> Result<std::thread::JoinHandle<()>, String> {
     std::thread::Builder::new()
         .name("et-server-daemon-status".to_owned())
         .spawn(move || {
-            let _ = sender.send(read_status(stdout));
+            let _ = sender.send(read_status(stderr));
         })
         .map_err(|error| format!("could not start daemon status worker: {error}"))
 }
 
-fn read_status(mut stdout: impl Read) -> Result<(), String> {
+fn read_status(mut status: impl Read) -> Result<(), String> {
     let mut header = [0u8; 7];
-    stdout
-        .read_exact(&mut header)
-        .map_err(|error| format!("daemon status channel closed: {error}"))?;
+    let mut filled = 0;
+    while filled < header.len() {
+        match status.read(&mut header[filled..]) {
+            Ok(0) => {
+                return Err(format!(
+                    "daemon status channel closed after {filled} header bytes: {}",
+                    escaped_status_bytes(&header[..filled])
+                ));
+            }
+            Ok(read) => filled += read,
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(error) => {
+                return Err(format!(
+                    "daemon status channel failed after {filled} header bytes: {error}; bytes={}",
+                    escaped_status_bytes(&header[..filled])
+                ));
+            }
+        }
+    }
     if &header[..4] != STATUS_MAGIC {
-        return Err("malformed daemon startup status".to_owned());
+        return Err(format!(
+            "malformed daemon startup status: {}",
+            escaped_status_bytes(&header)
+        ));
     }
     let length = usize::from(u16::from_be_bytes([header[5], header[6]]));
     if length > MAX_STATUS_MESSAGE {
         return Err("oversized daemon startup status".to_owned());
     }
     let mut message = vec![0u8; length];
-    stdout
+    status
         .read_exact(&mut message)
         .map_err(|error| format!("truncated daemon startup status: {error}"))?;
     match header[4] {
@@ -169,6 +202,14 @@ fn read_status(mut stdout: impl Read) -> Result<(), String> {
         STATUS_FAILED => Err(String::from_utf8_lossy(&message).into_owned()),
         _ => Err("malformed daemon startup status".to_owned()),
     }
+}
+
+fn escaped_status_bytes(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .flat_map(|byte| std::ascii::escape_default(*byte))
+        .map(char::from)
+        .collect()
 }
 
 /// Signal an opt-in test observer after signal handling and runtime startup.

--- a/crates/et-bin/src/server_daemon.rs
+++ b/crates/et-bin/src/server_daemon.rs
@@ -69,39 +69,7 @@ pub fn spawn_detached(args: &[std::ffi::OsString]) -> Result<(), String> {
         .stderr
         .take()
         .ok_or_else(|| "background etserver status pipe was not created".to_owned())?;
-    let (sender, receiver) = mpsc::sync_channel(1);
-    let worker = match spawn_status_worker(stderr, sender) {
-        Ok(worker) => worker,
-        Err(error) => {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(error);
-        }
-    };
-    let result = match receiver.recv_timeout(READY_TIMEOUT) {
-        Ok(result) => {
-            result.map_err(|error| format!("background etserver did not detach: {error}"))
-        }
-        Err(_) => Err("timed out waiting for background etserver to detach".to_owned()),
-    };
-    let _ = worker.join();
-    match result {
-        Ok(()) => Ok(()),
-        Err(error) => {
-            let status = match child.try_wait() {
-                Ok(Some(status)) => format!("child exited with {status}"),
-                Ok(None) => {
-                    let _ = child.kill();
-                    match child.wait() {
-                        Ok(status) => format!("child was still running and was killed: {status}"),
-                        Err(wait_error) => format!("child kill/wait failed: {wait_error}"),
-                    }
-                }
-                Err(wait_error) => format!("could not inspect child exit status: {wait_error}"),
-            };
-            Err(format!("{error}; {status}"))
-        }
-    }
+    await_startup(child, stderr, READY_TIMEOUT)
 }
 
 /// Finish detaching inside the re-executed child: become a session leader,
@@ -148,6 +116,51 @@ fn write_startup_status(code: u8, message: &str) -> Result<(), String> {
         .and_then(|()| output.write_all(bytes))
         .and_then(|()| output.flush())
         .map_err(|error| format!("could not write daemon startup status: {error}"))
+}
+
+fn await_startup(
+    mut child: crate::detach::Child,
+    stderr: ChildStderr,
+    timeout: Duration,
+) -> Result<(), String> {
+    let (sender, receiver) = mpsc::sync_channel(1);
+    let worker = match spawn_status_worker(stderr, sender) {
+        Ok(worker) => worker,
+        Err(error) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(error);
+        }
+    };
+    let result = match receiver.recv_timeout(timeout) {
+        Ok(result) => {
+            result.map_err(|error| format!("background etserver did not detach: {error}"))
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            Err("timed out waiting for background etserver to detach".to_owned())
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            Err("background etserver status reader terminated".to_owned())
+        }
+    };
+    if result.is_ok() {
+        let _ = worker.join();
+        return Ok(());
+    }
+
+    let status = match child.try_wait() {
+        Ok(Some(status)) => format!("child exited with {status}"),
+        Ok(None) => {
+            let _ = child.kill();
+            match child.wait() {
+                Ok(status) => format!("child was still running and was killed: {status}"),
+                Err(wait_error) => format!("child kill/wait failed: {wait_error}"),
+            }
+        }
+        Err(wait_error) => format!("could not inspect child exit status: {wait_error}"),
+    };
+    let _ = worker.join();
+    Err(format!("{}; {status}", result.unwrap_err()))
 }
 
 fn spawn_status_worker(
@@ -309,5 +322,28 @@ mod tests {
     fn pid_file_errors_are_reported_with_the_path() {
         let error = write_pid_file(Path::new("/nonexistent-dir/etserver.pid")).unwrap_err();
         assert!(error.contains("/nonexistent-dir/etserver.pid"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn partial_status_timeout_kills_reaps_then_joins_reader() {
+        let mut child = std::process::Command::new("/bin/sh")
+            .args(["-c", "printf ET >&2; printf R >&1; exec sleep 30"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let pid = i32::try_from(child.id()).unwrap();
+        let mut ready = [0u8; 1];
+        child.stdout.take().unwrap().read_exact(&mut ready).unwrap();
+        assert_eq!(ready, *b"R");
+        let stderr = child.stderr.take().unwrap();
+
+        let error = await_startup(child, stderr, Duration::from_millis(50)).unwrap_err();
+
+        assert!(error.contains("timed out waiting for background etserver"));
+        assert!(error.contains("was killed"));
+        assert!(nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_err());
     }
 }

--- a/crates/et-bin/src/server_daemon.rs
+++ b/crates/et-bin/src/server_daemon.rs
@@ -3,8 +3,8 @@
 //! Upstream double-forks, calls `setsid`, writes the pid file, `chdir("/")`,
 //! and redirects stdio to `/dev/null`. Forking is not expressible in safe
 //! Rust, so the same end state is reached by re-executing this binary as a
-//! detached child: the parent returns after pid-file acknowledgement, and the
-//! child becomes a session leader before serving.
+//! detached child: the parent returns after runtime-startup acknowledgement,
+//! and the child becomes a session leader before serving.
 
 use crate::detach::{ChildStdout, Stdio};
 use std::fs;
@@ -21,7 +21,10 @@ pub const DEFAULT_PID_FILE: &str = "etserver.pid";
 
 const STATUS_ENV: &str = "ET_SERVER_DAEMON_STATUS";
 const STATUS_TOKEN: &str = "ready-v1";
-const STATUS_FRAME: &[u8; 4] = b"ETD1";
+const STATUS_MAGIC: &[u8; 4] = b"ETD1";
+const STATUS_READY: u8 = 1;
+const STATUS_FAILED: u8 = 2;
+const MAX_STATUS_MESSAGE: usize = 8 * 1024;
 #[cfg(unix)]
 const SHUTDOWN_STATUS_ENV: &str = "ET_RS_TEST_SERVER_SHUTDOWN_SOCKET";
 #[cfg(unix)]
@@ -31,7 +34,7 @@ const SHUTDOWN_STATUS_FRAME: &[u8; 4] = b"ETD2";
 const READY_TIMEOUT: Duration = Duration::from_secs(45);
 
 /// Re-exec this binary as a detached background server and return after the
-/// child acknowledges its pid file.
+/// child acknowledges runtime startup.
 ///
 /// The child receives the original arguments with `--daemon` replaced by the
 /// internal `--daemon-child` marker so it knows to finish detaching.
@@ -102,16 +105,35 @@ pub fn detach_child(pidfile: Option<&Path>) -> Result<(), String> {
     // The working directory is already `/`: the parent sets it on the child
     // via `Command::current_dir`, matching upstream's `chdir("/")`.
     let path = pidfile.unwrap_or_else(|| Path::new(DEFAULT_PID_FILE));
-    write_pid_file(path)?;
-    if std::env::var(STATUS_ENV).as_deref() == Ok(STATUS_TOKEN) {
-        let stdout = std::io::stdout();
-        let mut output = stdout.lock();
-        output
-            .write_all(STATUS_FRAME)
-            .and_then(|()| output.flush())
-            .map_err(|error| format!("could not signal daemon readiness: {error}"))?;
+    write_pid_file(path)
+}
+
+/// Acknowledge that signal handling and the server runtime are both ready.
+pub fn signal_startup_complete() -> Result<(), String> {
+    write_startup_status(STATUS_READY, "")
+}
+
+/// Report a bounded daemon startup failure to the spawning parent.
+pub fn fail_startup(message: &str) {
+    let _ = write_startup_status(STATUS_FAILED, message);
+}
+
+fn write_startup_status(code: u8, message: &str) -> Result<(), String> {
+    if std::env::var(STATUS_ENV).as_deref() != Ok(STATUS_TOKEN) {
+        return Ok(());
     }
-    Ok(())
+    let bytes = message.as_bytes();
+    let bytes = &bytes[..bytes.len().min(MAX_STATUS_MESSAGE)];
+    let length = u16::try_from(bytes.len()).expect("daemon status bound fits u16");
+    let stdout = std::io::stdout();
+    let mut output = stdout.lock();
+    output
+        .write_all(STATUS_MAGIC)
+        .and_then(|()| output.write_all(&[code]))
+        .and_then(|()| output.write_all(&length.to_be_bytes()))
+        .and_then(|()| output.write_all(bytes))
+        .and_then(|()| output.flush())
+        .map_err(|error| format!("could not write daemon startup status: {error}"))
 }
 
 fn spawn_status_worker(
@@ -127,14 +149,26 @@ fn spawn_status_worker(
 }
 
 fn read_status(mut stdout: impl Read) -> Result<(), String> {
-    let mut frame = [0u8; STATUS_FRAME.len()];
+    let mut header = [0u8; 7];
     stdout
-        .read_exact(&mut frame)
+        .read_exact(&mut header)
         .map_err(|error| format!("daemon status channel closed: {error}"))?;
-    if &frame != STATUS_FRAME {
+    if &header[..4] != STATUS_MAGIC {
         return Err("malformed daemon startup status".to_owned());
     }
-    Ok(())
+    let length = usize::from(u16::from_be_bytes([header[5], header[6]]));
+    if length > MAX_STATUS_MESSAGE {
+        return Err("oversized daemon startup status".to_owned());
+    }
+    let mut message = vec![0u8; length];
+    stdout
+        .read_exact(&mut message)
+        .map_err(|error| format!("truncated daemon startup status: {error}"))?;
+    match header[4] {
+        STATUS_READY if message.is_empty() => Ok(()),
+        STATUS_FAILED => Err(String::from_utf8_lossy(&message).into_owned()),
+        _ => Err("malformed daemon startup status".to_owned()),
+    }
 }
 
 /// Signal an opt-in test observer after signal handling and runtime startup.

--- a/crates/et-bin/src/server_daemon.rs
+++ b/crates/et-bin/src/server_daemon.rs
@@ -3,13 +3,15 @@
 //! Upstream double-forks, calls `setsid`, writes the pid file, `chdir("/")`,
 //! and redirects stdio to `/dev/null`. Forking is not expressible in safe
 //! Rust, so the same end state is reached by re-executing this binary as a
-//! detached child: the parent returns immediately (exit 0), and the child
-//! becomes a session leader before serving.
+//! detached child: the parent returns after pid-file acknowledgement, and the
+//! child becomes a session leader before serving.
 
-use crate::detach::Stdio;
+use crate::detach::{ChildStdout, Stdio};
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::time::Duration;
 
 #[cfg(unix)]
 pub const DEFAULT_PID_FILE: &str = "/var/run/etserver.pid";
@@ -17,7 +19,13 @@ pub const DEFAULT_PID_FILE: &str = "/var/run/etserver.pid";
 #[cfg(windows)]
 pub const DEFAULT_PID_FILE: &str = "etserver.pid";
 
-/// Re-exec this binary as a detached background server and return.
+const STATUS_ENV: &str = "ET_SERVER_DAEMON_STATUS";
+const STATUS_TOKEN: &str = "ready-v1";
+const STATUS_FRAME: &[u8; 4] = b"ETD1";
+const READY_TIMEOUT: Duration = Duration::from_secs(45);
+
+/// Re-exec this binary as a detached background server and return after the
+/// child acknowledges its pid file.
 ///
 /// The child receives the original arguments with `--daemon` replaced by the
 /// internal `--daemon-child` marker so it knows to finish detaching.
@@ -41,13 +49,38 @@ pub fn spawn_detached(args: &[std::ffi::OsString]) -> Result<(), String> {
     }
     child
         .stdin(Stdio::null())
-        .stdout(Stdio::null())
+        .stdout(Stdio::piped())
         .stderr(Stdio::null())
+        .env(STATUS_ENV, STATUS_TOKEN)
         .current_dir(root_directory());
     crate::detach::configure(&mut child);
-    crate::detach::spawn(&mut child)
-        .map(|_| ())
-        .map_err(|error| format!("could not start background etserver: {error}"))
+    let mut child = crate::detach::spawn(&mut child)
+        .map_err(|error| format!("could not start background etserver: {error}"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "background etserver status pipe was not created".to_owned())?;
+    let (sender, receiver) = mpsc::sync_channel(1);
+    let worker = match spawn_status_worker(stdout, sender) {
+        Ok(worker) => worker,
+        Err(error) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(error);
+        }
+    };
+    let result = match receiver.recv_timeout(READY_TIMEOUT) {
+        Ok(result) => {
+            result.map_err(|error| format!("background etserver did not detach: {error}"))
+        }
+        Err(_) => Err("timed out waiting for background etserver to detach".to_owned()),
+    };
+    if result.is_err() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    let _ = worker.join();
+    result
 }
 
 /// Finish detaching inside the re-executed child: become a session leader,
@@ -63,7 +96,39 @@ pub fn detach_child(pidfile: Option<&Path>) -> Result<(), String> {
     // The working directory is already `/`: the parent sets it on the child
     // via `Command::current_dir`, matching upstream's `chdir("/")`.
     let path = pidfile.unwrap_or_else(|| Path::new(DEFAULT_PID_FILE));
-    write_pid_file(path)
+    write_pid_file(path)?;
+    if std::env::var(STATUS_ENV).as_deref() == Ok(STATUS_TOKEN) {
+        let stdout = std::io::stdout();
+        let mut output = stdout.lock();
+        output
+            .write_all(STATUS_FRAME)
+            .and_then(|()| output.flush())
+            .map_err(|error| format!("could not signal daemon readiness: {error}"))?;
+    }
+    Ok(())
+}
+
+fn spawn_status_worker(
+    stdout: ChildStdout,
+    sender: mpsc::SyncSender<Result<(), String>>,
+) -> Result<std::thread::JoinHandle<()>, String> {
+    std::thread::Builder::new()
+        .name("et-server-daemon-status".to_owned())
+        .spawn(move || {
+            let _ = sender.send(read_status(stdout));
+        })
+        .map_err(|error| format!("could not start daemon status worker: {error}"))
+}
+
+fn read_status(mut stdout: impl Read) -> Result<(), String> {
+    let mut frame = [0u8; STATUS_FRAME.len()];
+    stdout
+        .read_exact(&mut frame)
+        .map_err(|error| format!("daemon status channel closed: {error}"))?;
+    if &frame != STATUS_FRAME {
+        return Err("malformed daemon startup status".to_owned());
+    }
+    Ok(())
 }
 
 /// Working directory for the detached server.

--- a/crates/et-bin/src/server_daemon.rs
+++ b/crates/et-bin/src/server_daemon.rs
@@ -22,6 +22,12 @@ pub const DEFAULT_PID_FILE: &str = "etserver.pid";
 const STATUS_ENV: &str = "ET_SERVER_DAEMON_STATUS";
 const STATUS_TOKEN: &str = "ready-v1";
 const STATUS_FRAME: &[u8; 4] = b"ETD1";
+#[cfg(unix)]
+const SHUTDOWN_STATUS_ENV: &str = "ET_RS_TEST_SERVER_SHUTDOWN_SOCKET";
+#[cfg(unix)]
+const RUNTIME_STATUS_FRAME: &[u8; 4] = b"ETD0";
+#[cfg(unix)]
+const SHUTDOWN_STATUS_FRAME: &[u8; 4] = b"ETD2";
 const READY_TIMEOUT: Duration = Duration::from_secs(45);
 
 /// Re-exec this binary as a detached background server and return after the
@@ -129,6 +135,33 @@ fn read_status(mut stdout: impl Read) -> Result<(), String> {
         return Err("malformed daemon startup status".to_owned());
     }
     Ok(())
+}
+
+/// Signal an opt-in test observer after signal handling and runtime startup.
+pub fn signal_runtime_started() -> Result<(), String> {
+    #[cfg(unix)]
+    signal_test_status(RUNTIME_STATUS_FRAME, "runtime startup")?;
+    Ok(())
+}
+
+/// Signal an opt-in test observer after runtime shutdown and router cleanup.
+pub fn signal_shutdown_complete() -> Result<(), String> {
+    #[cfg(unix)]
+    signal_test_status(SHUTDOWN_STATUS_FRAME, "shutdown completion")?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn signal_test_status(frame: &[u8; 4], phase: &str) -> Result<(), String> {
+    let Some(path) = std::env::var_os(SHUTDOWN_STATUS_ENV) else {
+        return Ok(());
+    };
+    let mut stream = std::os::unix::net::UnixStream::connect(path)
+        .map_err(|error| format!("could not connect daemon {phase} status: {error}"))?;
+    stream
+        .write_all(frame)
+        .and_then(|()| stream.flush())
+        .map_err(|error| format!("could not signal daemon {phase}: {error}"))
 }
 
 /// Working directory for the detached server.

--- a/crates/et-bin/src/ssh_process.rs
+++ b/crates/et-bin/src/ssh_process.rs
@@ -14,7 +14,10 @@ use crate::deadline::Deadline;
 use crate::error::ClientError;
 
 pub const MAX_SSH_STDOUT: usize = 1024 * 1024;
-pub const DEFAULT_BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(60);
+// The remote registration phase is bounded at 45 seconds. Leave explicit
+// budget for SSH configuration, authentication, propagation of a structured
+// remote timeout, and cancellation cleanup.
+pub const DEFAULT_BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(Debug)]
 pub struct SshOutput {

--- a/crates/et-bin/src/ssh_process.rs
+++ b/crates/et-bin/src/ssh_process.rs
@@ -726,12 +726,16 @@ mod tests {
 
     #[test]
     fn system_runner_terminates_on_deadline() {
-        let runner = SystemSsh::with_timeout(Duration::from_millis(50));
-        let invocation = invocation("/bin/sh", &["-c", "exec /bin/sleep 30"]);
-        let started = Instant::now();
-        let result = runner.run(&invocation, runner.deadline());
+        let (sender, receiver) = mpsc::sync_channel(1);
+        thread::spawn(move || {
+            let runner = SystemSsh::with_timeout(Duration::from_millis(50));
+            let invocation = invocation("/bin/sh", &["-c", "exec /bin/sleep 30"]);
+            let _ = sender.send(runner.run(&invocation, runner.deadline()));
+        });
+        let result = receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("SSH deadline did not terminate its process within the test bound");
         assert!(matches!(result, Err(ClientError::SshTimeout(_))));
-        assert!(started.elapsed() < Duration::from_secs(2));
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/et-bin/src/ssh_process.rs
+++ b/crates/et-bin/src/ssh_process.rs
@@ -497,7 +497,6 @@ fn join_reader(reader: JoinHandle<()>) -> Result<(), ClientError> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Instant;
     #[cfg(target_os = "linux")]
     use std::{
         fs::{self, File, OpenOptions},
@@ -653,8 +652,13 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     fn poll_readable(fd: &impl AsFd) -> bool {
+        poll_readable_with(fd, EVENT_WAIT_MILLIS)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn poll_readable_with(fd: &impl AsFd, timeout_millis: u16) -> bool {
         let mut events = [PollFd::new(fd.as_fd(), PollFlags::POLLIN)];
-        let ready = poll(&mut events, EVENT_WAIT_MILLIS).unwrap();
+        let ready = poll(&mut events, timeout_millis).unwrap();
         ready == 1 && events[0].revents().unwrap().contains(PollFlags::POLLIN)
     }
 
@@ -742,17 +746,16 @@ mod tests {
     #[test]
     fn system_runner_times_out_and_kills_stdout_holding_descendant() {
         const SSH_TIMEOUT: Duration = Duration::from_secs(2);
+        const CLEANUP_WATCHDOG_MILLIS: u16 = 15_000;
         const SCRIPT: &str = r#"
-(IFS= read -r _ < "$3") &
+(IFS= read -r _ < "$2") &
 descendant=$!
 printf '%s %s\n' "$$" "$descendant" > "$1"
-IFS= read -r _ < "$2"
 exit 0
 "#;
 
         let dir = ProcessGroupTestDir::new();
         let pid_fifo = dir.fifo("pid");
-        let ack_fifo = dir.fifo("ack");
         let hold_fifo = dir.fifo("hold");
 
         let _pid_control = OpenOptions::new()
@@ -761,12 +764,6 @@ exit 0
             .open(&pid_fifo)
             .unwrap();
         let pid_pipe = File::open(&pid_fifo).unwrap();
-        let _ack_control = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(&ack_fifo)
-            .unwrap();
-        let mut ack_pipe = OpenOptions::new().write(true).open(&ack_fifo).unwrap();
         let hold_control = OpenOptions::new()
             .read(true)
             .write(true)
@@ -781,69 +778,60 @@ exit 0
                 SCRIPT,
                 "ssh-process-group-test",
                 pid_fifo.to_str().unwrap(),
-                ack_fifo.to_str().unwrap(),
                 hold_fifo.to_str().unwrap(),
             ],
         );
-        let (result_sender, result_receiver) = mpsc::sync_channel(1);
-        let worker = thread::spawn(move || {
-            let started = Instant::now();
-            let result = runner.run(&invocation, runner.deadline());
-            let _ = result_sender.send((result, started.elapsed()));
+        let observer = thread::spawn(move || {
+            assert!(
+                poll_readable(&pid_pipe),
+                "SSH child did not report its process IDs"
+            );
+            let mut process_ids = String::new();
+            assert_ne!(
+                BufReader::new(pid_pipe)
+                    .read_line(&mut process_ids)
+                    .unwrap(),
+                0
+            );
+            let mut process_ids = process_ids.split_whitespace();
+            let direct_pid = process_ids.next().unwrap().parse::<i32>().unwrap();
+            let descendant_pid = process_ids.next().unwrap().parse::<i32>().unwrap();
+            assert_eq!(process_ids.next(), None);
+            let direct_pidfd = pidfd_open(
+                RustixPid::from_raw(direct_pid).unwrap(),
+                PidfdFlags::empty(),
+            )
+            .unwrap();
+            let descendant_pidfd = pidfd_open(
+                RustixPid::from_raw(descendant_pid).unwrap(),
+                PidfdFlags::empty(),
+            )
+            .unwrap();
+            assert!(
+                poll_readable_with(&direct_pidfd, CLEANUP_WATCHDOG_MILLIS),
+                "direct SSH child did not exit"
+            );
+            let descendant_exited = poll_readable_with(&descendant_pidfd, CLEANUP_WATCHDOG_MILLIS);
+            if !descendant_exited {
+                // Release the stdout reader so a broken implementation returns
+                // and the assertion below fails instead of hanging the suite.
+                pidfd_send_signal(&descendant_pidfd, RustixSignal::KILL).unwrap();
+            }
+            drop(hold_control);
+            descendant_exited
         });
 
-        assert!(
-            poll_readable(&pid_pipe),
-            "SSH child did not report its process IDs"
-        );
-        let mut process_ids = String::new();
-        assert_ne!(
-            BufReader::new(pid_pipe)
-                .read_line(&mut process_ids)
-                .unwrap(),
-            0
-        );
-        let mut process_ids = process_ids.split_whitespace();
-        let direct_pid = process_ids.next().unwrap().parse::<i32>().unwrap();
-        let descendant_pid = process_ids.next().unwrap().parse::<i32>().unwrap();
-        assert_eq!(process_ids.next(), None);
-
-        let direct_pidfd = pidfd_open(
-            RustixPid::from_raw(direct_pid).unwrap(),
-            PidfdFlags::empty(),
-        )
-        .unwrap();
-        let descendant_pidfd = pidfd_open(
-            RustixPid::from_raw(descendant_pid).unwrap(),
-            PidfdFlags::empty(),
-        )
-        .unwrap();
-
-        ack_pipe.write_all(b"exit\n").unwrap();
-        drop(ack_pipe);
-        assert!(
-            poll_readable(&direct_pidfd),
-            "direct SSH child did not exit before the timeout"
-        );
-
-        let (result, elapsed) = result_receiver
-            .recv_timeout(SSH_TIMEOUT + Duration::from_secs(1))
-            .expect("SystemSsh did not return within its cleanup bound");
-        worker.join().unwrap();
-        let descendant_exited = poll_readable(&descendant_pidfd);
-        if !descendant_exited {
-            pidfd_send_signal(&descendant_pidfd, RustixSignal::KILL).unwrap();
-        }
-        drop(hold_control);
+        // Run synchronously: completion is no longer inferred from whether a
+        // separately scheduled runner thread manages to send within one second.
+        let result = runner.run(&invocation, runner.deadline());
+        // The observer has its own bounded pidfd watchdog, so this join waits
+        // for an exact process-exit result rather than another wall-clock race.
+        let descendant_exited = observer.join().unwrap();
 
         assert!(matches!(result, Err(ClientError::SshTimeout(_))));
         assert!(
-            elapsed < SSH_TIMEOUT + Duration::from_secs(1),
-            "SystemSsh returned after {elapsed:?}"
-        );
-        assert!(
             descendant_exited,
-            "SSH descendant survived process-group cleanup"
+            "SSH descendant survived stdout-holder cleanup"
         );
     }
 

--- a/crates/et-bin/src/terminal.rs
+++ b/crates/et-bin/src/terminal.rs
@@ -62,6 +62,12 @@ pub fn run(args: &[OsString]) -> Result<i32, clap::Error> {
             .map(|value| OsString::from(*value))
             .chain(args.iter().cloned()),
     )?;
+    #[cfg(unix)]
+    if parsed.session_child {
+        crate::detach::close_inherited_descriptors().map_err(|error| {
+            clap_error(format!("could not close inherited descriptors: {error}"))
+        })?;
+    }
     parsed.verbose = et_cli::logging::effective_verbose(parsed.verbose);
     let log_directory = et_cli::logging::effective_log_directory(parsed.logdir.clone());
     let input = load_credentials(&parsed).map_err(clap_error)?;

--- a/crates/et-bin/src/terminal.rs
+++ b/crates/et-bin/src/terminal.rs
@@ -96,9 +96,10 @@ pub fn run(args: &[OsString]) -> Result<i32, clap::Error> {
         return print_marker(&input);
     }
     let result = (|| {
+        let registration_ack = et_net::local::supports_registration_ack(router_path.path());
         let mut router = et_net::local::connect(router_path.path())
             .map_err(|error| clap_error(format!("could not connect terminal router: {error}")))?;
-        register(&mut router, &input).map_err(clap_error)?;
+        register(&mut router, &input, registration_ack).map_err(clap_error)?;
         let ready_socket = parsed
             .ready_socket
             .as_deref()
@@ -108,10 +109,15 @@ pub fn run(args: &[OsString]) -> Result<i32, clap::Error> {
             .try_clone()
             .map_err(|error| clap_error(format!("could not clone startup channel: {error}")))?;
         let result = terminal_pty::run_with_startup(router, &input.term, |router| {
-            report_startup(router, Ok(()))
+            if registration_ack {
+                report_startup(router, Ok(()))?;
+            }
+            Ok(())
         });
-        if let Err(error) = &result {
-            let _ = report_startup(&mut startup, Err(error));
+        if registration_ack {
+            if let Err(error) = &result {
+                let _ = report_startup(&mut startup, Err(error));
+            }
         }
         result.map_err(clap_error)
     })();
@@ -152,9 +158,10 @@ fn run_jump(
         return print_marker(input);
     }
     let result = (|| {
+        let registration_ack = et_net::local::supports_registration_ack(router_path);
         let mut router = et_net::local::connect(router_path)
             .map_err(|error| clap_error(format!("could not connect terminal router: {error}")))?;
-        register(&mut router, input).map_err(clap_error)?;
+        register(&mut router, input, registration_ack).map_err(clap_error)?;
         let ready_socket = parsed_ready_socket(args)?;
         crate::terminal_daemon::signal(ready_socket).map_err(clap_error)?;
         let mut startup = router
@@ -165,10 +172,17 @@ fn run_jump(
             input,
             &destination_host,
             args.dstport,
-            |router| report_startup(router, Ok(())),
+            |router| {
+                if registration_ack {
+                    report_startup(router, Ok(()))?;
+                }
+                Ok(())
+            },
         );
-        if let Err(error) = &result {
-            let _ = report_startup(&mut startup, Err(error));
+        if registration_ack {
+            if let Err(error) = &result {
+                let _ = report_startup(&mut startup, Err(error));
+            }
         }
         result.map_err(clap_error)
     })();
@@ -224,7 +238,11 @@ fn load_credentials(args: &TerminalArgs) -> Result<CredentialInput, String> {
     parse_credential_input(text.trim())
 }
 
-fn register(router: &mut LocalStream, input: &CredentialInput) -> Result<(), String> {
+fn register(
+    router: &mut LocalStream,
+    input: &CredentialInput,
+    registration_ack: bool,
+) -> Result<(), String> {
     // Upstream uses these to chown forwarded named pipes; Windows has no
     // POSIX ids, so the session reports zero there.
     let (uid, gid) = registration_identity();
@@ -233,9 +251,10 @@ fn register(router: &mut LocalStream, input: &CredentialInput) -> Result<(), Str
         passkey: Some(input.passkey.clone()),
         uid: Some(uid),
         gid: Some(gid),
-        // Local protocol-v6 capability sentinel: this terminal acknowledges
-        // PTY/relay startup before the server answers INITIAL_RESPONSE.
-        fd: Some(-6),
+        // Local-only capability sentinel, sent only after the router advertises
+        // support out of band. Old routers and old terminals therefore retain
+        // their original packet sequence in both mixed-version directions.
+        fd: registration_ack.then_some(-6),
     };
     let packet = Packet::new(
         TerminalPacketType::TerminalUserInfo as u8,
@@ -243,8 +262,11 @@ fn register(router: &mut LocalStream, input: &CredentialInput) -> Result<(), Str
     );
     write_local_packet(router, &packet)
         .map_err(|error| format!("could not register terminal: {error}"))?;
+    if !registration_ack {
+        return Ok(());
+    }
     router
-        .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+        .set_read_timeout(Some(crate::terminal_daemon::registration_timeout()))
         .map_err(|error| format!("could not set registration acknowledgement deadline: {error}"))?;
     let acknowledgement = read_local_packet(router)
         .map_err(|error| format!("could not read registration acknowledgement: {error}"))

--- a/crates/et-bin/src/terminal.rs
+++ b/crates/et-bin/src/terminal.rs
@@ -8,7 +8,10 @@ use clap::error::ErrorKind;
 use clap::Parser;
 use et_core::packet::Packet;
 use et_core::proto::{TerminalPacketType, TerminalUserInfo};
-use et_net::local_packet::write_local_packet;
+use et_net::local_packet::{
+    parse_status, read_local_packet, status_packet, write_local_packet, REGISTRATION_STATUS,
+    STARTUP_STATUS,
+};
 use et_server::path::select_router_path;
 use prost::Message;
 
@@ -79,6 +82,11 @@ pub fn run(args: &[OsString]) -> Result<i32, clap::Error> {
     });
     let router_path = select_router_path(parsed.serverfifo.as_deref())
         .map_err(|error| clap_error(error.to_string()))?;
+    #[cfg(unix)]
+    if parsed.session_child {
+        rustix::process::setsid()
+            .map_err(|error| clap_error(format!("could not create terminal session: {error}")))?;
+    }
     if parsed.jump {
         return run_jump(&parsed, router_path.path(), &input);
     }
@@ -87,15 +95,30 @@ pub fn run(args: &[OsString]) -> Result<i32, clap::Error> {
             .map_err(clap_error)?;
         return print_marker(&input);
     }
-    let mut router = et_net::local::connect(router_path.path())
-        .map_err(|error| clap_error(format!("could not connect terminal router: {error}")))?;
-    register(&mut router, &input).map_err(clap_error)?;
-    let ready_socket = parsed
-        .ready_socket
-        .as_deref()
-        .ok_or_else(|| clap_error("terminal session child has no readiness socket"))?;
-    crate::terminal_daemon::signal(ready_socket).map_err(clap_error)?;
-    terminal_pty::run(router, &input.term).map_err(clap_error)
+    let result = (|| {
+        let mut router = et_net::local::connect(router_path.path())
+            .map_err(|error| clap_error(format!("could not connect terminal router: {error}")))?;
+        register(&mut router, &input).map_err(clap_error)?;
+        let ready_socket = parsed
+            .ready_socket
+            .as_deref()
+            .ok_or_else(|| clap_error("terminal session child has no readiness socket"))?;
+        crate::terminal_daemon::signal(ready_socket).map_err(clap_error)?;
+        let mut startup = router
+            .try_clone()
+            .map_err(|error| clap_error(format!("could not clone startup channel: {error}")))?;
+        let result = terminal_pty::run_with_startup(router, &input.term, |router| {
+            report_startup(router, Ok(()))
+        });
+        if let Err(error) = &result {
+            let _ = report_startup(&mut startup, Err(error));
+        }
+        result.map_err(clap_error)
+    })();
+    if let Err(error) = &result {
+        crate::terminal_daemon::fail(&error.to_string());
+    }
+    result
 }
 
 /// `etterminal --jump`: print the marker the client scrapes, then relay the
@@ -128,12 +151,31 @@ fn run_jump(
         .map_err(clap_error)?;
         return print_marker(input);
     }
-    let mut router = et_net::local::connect(router_path)
-        .map_err(|error| clap_error(format!("could not connect terminal router: {error}")))?;
-    register(&mut router, input).map_err(clap_error)?;
-    let ready_socket = parsed_ready_socket(args)?;
-    crate::terminal_daemon::signal(ready_socket).map_err(clap_error)?;
-    crate::terminal_jump::run(router, input, &destination_host, args.dstport).map_err(clap_error)
+    let result = (|| {
+        let mut router = et_net::local::connect(router_path)
+            .map_err(|error| clap_error(format!("could not connect terminal router: {error}")))?;
+        register(&mut router, input).map_err(clap_error)?;
+        let ready_socket = parsed_ready_socket(args)?;
+        crate::terminal_daemon::signal(ready_socket).map_err(clap_error)?;
+        let mut startup = router
+            .try_clone()
+            .map_err(|error| clap_error(format!("could not clone startup channel: {error}")))?;
+        let result = crate::terminal_jump::run_with_startup(
+            router,
+            input,
+            &destination_host,
+            args.dstport,
+            |router| report_startup(router, Ok(())),
+        );
+        if let Err(error) = &result {
+            let _ = report_startup(&mut startup, Err(error));
+        }
+        result.map_err(clap_error)
+    })();
+    if let Err(error) = &result {
+        crate::terminal_daemon::fail(&error.to_string());
+    }
+    result
 }
 
 fn parsed_ready_socket(args: &TerminalArgs) -> Result<&std::path::Path, clap::Error> {
@@ -191,14 +233,33 @@ fn register(router: &mut LocalStream, input: &CredentialInput) -> Result<(), Str
         passkey: Some(input.passkey.clone()),
         uid: Some(uid),
         gid: Some(gid),
-        fd: None,
+        // Local protocol-v6 capability sentinel: this terminal acknowledges
+        // PTY/relay startup before the server answers INITIAL_RESPONSE.
+        fd: Some(-6),
     };
     let packet = Packet::new(
         TerminalPacketType::TerminalUserInfo as u8,
         user.encode_to_vec(),
     );
     write_local_packet(router, &packet)
-        .map_err(|error| format!("could not register terminal: {error}"))
+        .map_err(|error| format!("could not register terminal: {error}"))?;
+    router
+        .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+        .map_err(|error| format!("could not set registration acknowledgement deadline: {error}"))?;
+    let acknowledgement = read_local_packet(router)
+        .map_err(|error| format!("could not read registration acknowledgement: {error}"))
+        .and_then(|packet| {
+            parse_status(&packet, REGISTRATION_STATUS)
+                .map_err(|error| format!("terminal registration rejected: {error}"))
+        });
+    let _ = router.set_read_timeout(None);
+    acknowledgement
+}
+
+fn report_startup(router: &mut LocalStream, result: Result<(), &String>) -> Result<(), String> {
+    let packet = status_packet(STARTUP_STATUS, result.map_err(String::as_str));
+    write_local_packet(router, &packet)
+        .map_err(|error| format!("could not report terminal startup: {error}"))
 }
 
 #[cfg(unix)]

--- a/crates/et-bin/src/terminal_daemon.rs
+++ b/crates/et-bin/src/terminal_daemon.rs
@@ -1,56 +1,46 @@
-//! Detaching the per-session terminal process.
+//! Detached per-session terminal startup over an inherited, bounded status pipe.
 //!
-//! Upstream's `etterminal` prints the `IDPASSKEY:` marker and then becomes a
-//! session leader (`DaemonCreator::createSessionLeader`) so the bootstrap `ssh`
-//! can return while the session keeps running. Forking is not expressible in
-//! safe Rust, so the same end state is reached by re-executing this binary as a
-//! detached child and waiting for it to report readiness.
-//!
-//! The readiness channel is a Unix socket on POSIX and a loopback TCP socket on
-//! Windows, where the `--ready-socket` value carries `127.0.0.1:<port>`.
+//! The bootstrap parent owns the child until it receives a structured
+//! `Registered` status. Every earlier return kills and reaps the child. The
+//! anonymous stdout pipe is inherited across exec, unlike the old discoverable
+//! readiness listener, so unrelated local processes cannot forge readiness.
 
-#[cfg(unix)]
-use std::fs;
 use std::io::{Read, Write};
 use std::path::Path;
-#[cfg(unix)]
-use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::process::{Child, Stdio};
 use std::sync::mpsc;
+use std::thread::JoinHandle;
 use std::time::Duration;
 
 use crate::terminal_credentials::CredentialInput;
 
-// Process creation and router registration can take longer than ten seconds
-// when the destination is under severe CPU, memory, or I/O pressure. Actual
-// child failures are reported through stderr, so this deadline only bounds a
-// genuinely stuck startup.
-const READY_TIMEOUT: Duration = Duration::from_secs(60);
+pub(crate) const READY_TIMEOUT: Duration = Duration::from_secs(45);
+const STATUS_MAGIC: &[u8; 4] = b"ETS1";
+const STATUS_REGISTERED: u8 = 1;
+const STATUS_FAILED: u8 = 2;
+const MAX_STATUS_MESSAGE: usize = 8 * 1024;
 
 pub fn spawn(router: &Path, input: &CredentialInput, verbose: u8) -> Result<(), String> {
     spawn_with_args(router, input, verbose, &[])
 }
 
-/// Spawn the detached session process, forwarding `extra` arguments (used by
-/// `--jump` to pass the relay destination).
 pub fn spawn_with_args(
     router: &Path,
     input: &CredentialInput,
     verbose: u8,
     extra: &[String],
 ) -> Result<(), String> {
-    let readiness = Readiness::bind()?;
     let executable = std::env::current_exe()
         .map_err(|error| format!("could not locate et executable: {error}"))?
         .canonicalize()
         .map_err(|error| format!("could not resolve et executable: {error}"))?;
-    let mut child = Command::new(executable);
-    child
+    let mut command = crate::detach::command(executable.as_os_str());
+    command
         .args([
             "terminal",
             "--session-child",
             "--ready-socket",
-            &readiness.address(),
+            "inherited",
             "--serverfifo",
             router
                 .to_str()
@@ -59,205 +49,212 @@ pub fn spawn_with_args(
         ])
         .args(extra)
         .stdin(Stdio::piped())
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped());
-    crate::detach::configure(&mut child);
-    let mut child = crate::detach::spawn(&mut child)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    crate::detach::configure(&mut command);
+    let child = crate::detach::spawn(&mut command)
         .map_err(|error| format!("could not start terminal session process: {error}"))?;
+    let mut startup = StartupChild::new(child);
+
     let credential_line = format!("{}/{}_{}\n", input.id, input.passkey, input.term);
-    let write_result = child
+    startup
+        .child_mut()
         .stdin
         .take()
-        .ok_or_else(|| "terminal child stdin was not created".to_owned())
-        .and_then(|mut stdin| {
-            stdin
-                .write_all(credential_line.as_bytes())
-                .map_err(|error| format!("could not send terminal credentials: {error}"))
-        });
-    if let Err(error) = write_result {
-        stop(&mut child);
-        readiness.cleanup();
-        return Err(error);
-    }
-    let child_stderr = child
-        .stderr
+        .ok_or_else(|| "terminal child stdin was not created".to_owned())?
+        .write_all(credential_line.as_bytes())
+        .map_err(|error| format!("could not send terminal credentials: {error}"))?;
+
+    let stdout = startup
+        .child_mut()
+        .stdout
         .take()
-        .ok_or_else(|| "terminal child stderr was not created".to_owned())?;
-    let (sender, receiver) = mpsc::sync_channel(2);
-    let acceptor = readiness.acceptor();
-    let ready_sender = sender.clone();
+        .ok_or_else(|| "terminal child status pipe was not created".to_owned())?;
+    let (sender, receiver) = mpsc::sync_channel(1);
     let worker = std::thread::Builder::new()
-        .name("et-terminal-ready".to_owned())
+        .name("et-terminal-status".to_owned())
         .spawn(move || {
-            let _ = ready_sender.send(StartupEvent::Ready(acceptor.accept_ready()));
+            let _ = sender.send(read_status(stdout));
         })
-        .map_err(|error| format!("could not start terminal readiness worker: {error}"))?;
-    std::thread::Builder::new()
-        .name("et-terminal-stderr".to_owned())
-        .spawn(move || {
-            let mut stderr = String::new();
-            let result = std::io::BufReader::new(child_stderr).read_to_string(&mut stderr);
-            let message = match result {
-                Ok(_) if stderr.trim().is_empty() => {
-                    "terminal session process exited before becoming ready".to_owned()
-                }
-                Ok(_) => stderr.trim().to_owned(),
-                Err(error) => format!("could not read terminal session process error: {error}"),
-            };
-            let _ = sender.send(StartupEvent::Exited(message));
-        })
-        .map_err(|error| format!("could not start terminal stderr worker: {error}"))?;
+        .map_err(|error| format!("could not start terminal status worker: {error}"))?;
+    startup.worker = Some(worker);
+
     let result = receiver
         .recv_timeout(READY_TIMEOUT)
-        .map_err(|_| "timed out waiting for terminal session process".to_owned())
-        .and_then(|event| match event {
-            StartupEvent::Ready(result) => result
-                .map_err(|error| format!("terminal session process did not become ready: {error}")),
-            StartupEvent::Exited(message) => Err(message),
-        });
-    if result.is_err() {
-        stop(&mut child);
-        readiness.unblock();
+        .map_err(|_| "timed out waiting for terminal registration".to_owned())?
+        .map_err(|error| format!("terminal session process did not become ready: {error}"));
+    if result.is_ok() {
+        startup.commit();
     }
-    let _ = worker.join();
-    readiness.cleanup();
     result
 }
 
-enum StartupEvent {
-    Ready(std::io::Result<()>),
-    Exited(String),
-}
-
-/// Tell the parent this session is live. `target` is the value that was passed
-/// through `--ready-socket`.
+/// Report committed router registration over the inherited stdout pipe.
 pub fn signal(target: &Path) -> Result<(), String> {
+    if target == Path::new("inherited") {
+        return write_status(STATUS_REGISTERED, "");
+    }
+    // Compatibility for directly launched session-child test harnesses and
+    // mixed local upgrades. Production bootstrap always uses the inherited
+    // status pipe above.
     #[cfg(unix)]
-    let mut stream = std::os::unix::net::UnixStream::connect(target)
-        .map_err(|error| format!("could not connect terminal readiness socket: {error}"))?;
+    {
+        let mut stream = std::os::unix::net::UnixStream::connect(target)
+            .map_err(|error| format!("could not connect terminal readiness socket: {error}"))?;
+        stream
+            .write_all(&[1])
+            .map_err(|error| format!("could not signal terminal readiness: {error}"))
+    }
     #[cfg(windows)]
-    let mut stream = {
-        let address = target
-            .to_str()
-            .and_then(|value| value.parse::<std::net::SocketAddr>().ok())
-            .ok_or_else(|| "invalid terminal readiness address".to_owned())?;
-        std::net::TcpStream::connect(address)
-            .map_err(|error| format!("could not connect terminal readiness socket: {error}"))?
-    };
-    stream
-        .write_all(&[1])
-        .map_err(|error| format!("could not signal terminal readiness: {error}"))
-}
-
-/// Readiness listener, owned by the spawning parent.
-struct Readiness {
-    #[cfg(unix)]
-    listener: std::os::unix::net::UnixListener,
-    #[cfg(unix)]
-    directory: PathBuf,
-    #[cfg(unix)]
-    socket: PathBuf,
-    #[cfg(windows)]
-    listener: std::net::TcpListener,
-    #[cfg(windows)]
-    address: std::net::SocketAddr,
-}
-
-struct Acceptor {
-    #[cfg(unix)]
-    listener: std::os::unix::net::UnixListener,
-    #[cfg(windows)]
-    listener: std::net::TcpListener,
-}
-
-impl Readiness {
-    fn bind() -> Result<Self, String> {
-        #[cfg(unix)]
-        {
-            let directory = readiness_directory()?;
-            let socket = directory.join("ready.sock");
-            let listener = std::os::unix::net::UnixListener::bind(&socket)
-                .map_err(|error| format!("could not bind terminal readiness socket: {error}"))?;
-            Ok(Self {
-                listener,
-                directory,
-                socket,
-            })
-        }
-        #[cfg(windows)]
-        {
-            let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
-                .map_err(|error| format!("could not bind terminal readiness socket: {error}"))?;
-            let address = listener
-                .local_addr()
-                .map_err(|error| format!("could not inspect readiness socket: {error}"))?;
-            Ok(Self { listener, address })
-        }
-    }
-
-    fn address(&self) -> String {
-        #[cfg(unix)]
-        {
-            self.socket.to_string_lossy().into_owned()
-        }
-        #[cfg(windows)]
-        {
-            self.address.to_string()
-        }
-    }
-
-    fn acceptor(&self) -> Acceptor {
-        Acceptor {
-            listener: self
-                .listener
-                .try_clone()
-                .expect("readiness listener clone must succeed"),
-        }
-    }
-
-    /// Release a blocked acceptor when the child failed to start.
-    fn unblock(&self) {
-        #[cfg(unix)]
-        let _ = std::os::unix::net::UnixStream::connect(&self.socket);
-        #[cfg(windows)]
-        let _ = std::net::TcpStream::connect(self.address);
-    }
-
-    fn cleanup(&self) {
-        #[cfg(unix)]
-        let _ = fs::remove_dir_all(&self.directory);
+    {
+        Err("legacy readiness sockets are unsupported on Windows".to_owned())
     }
 }
 
-impl Acceptor {
-    fn accept_ready(&self) -> std::io::Result<()> {
-        let (mut stream, _) = self.listener.accept()?;
-        let mut ready = [0u8; 1];
-        stream.read_exact(&mut ready)?;
-        if ready == [1] {
-            Ok(())
-        } else {
-            Err(std::io::Error::other("invalid readiness byte"))
+/// Report a bounded startup failure before the bootstrap parent commits.
+pub fn fail(message: &str) {
+    let _ = write_status(STATUS_FAILED, message);
+}
+
+fn write_status(code: u8, message: &str) -> Result<(), String> {
+    let bytes = message.as_bytes();
+    let bytes = &bytes[..bytes.len().min(MAX_STATUS_MESSAGE)];
+    let length = u16::try_from(bytes.len()).expect("status bound fits u16");
+    let stdout = std::io::stdout();
+    let mut output = stdout.lock();
+    output
+        .write_all(STATUS_MAGIC)
+        .and_then(|()| output.write_all(&[code]))
+        .and_then(|()| output.write_all(&length.to_be_bytes()))
+        .and_then(|()| output.write_all(bytes))
+        .and_then(|()| output.flush())
+        .map_err(|error| format!("could not write terminal startup status: {error}"))
+}
+
+fn read_status(mut reader: impl Read) -> Result<(), String> {
+    let mut header = [0u8; 7];
+    reader
+        .read_exact(&mut header)
+        .map_err(|error| format!("terminal status channel closed: {error}"))?;
+    if &header[..4] != STATUS_MAGIC {
+        return Err("malformed terminal startup status".to_owned());
+    }
+    let length = usize::from(u16::from_be_bytes([header[5], header[6]]));
+    if length > MAX_STATUS_MESSAGE {
+        return Err("terminal startup status exceeds 8 KiB".to_owned());
+    }
+    let mut message = vec![0; length];
+    reader
+        .read_exact(&mut message)
+        .map_err(|error| format!("truncated terminal startup status: {error}"))?;
+    match header[4] {
+        STATUS_REGISTERED if message.is_empty() => Ok(()),
+        STATUS_FAILED => Err(String::from_utf8_lossy(&message).into_owned()),
+        _ => Err("invalid terminal startup status".to_owned()),
+    }
+}
+
+struct StartupChild {
+    child: Option<Child>,
+    worker: Option<JoinHandle<()>>,
+    committed: bool,
+}
+
+impl StartupChild {
+    fn new(child: Child) -> Self {
+        Self {
+            child: Some(child),
+            worker: None,
+            committed: false,
+        }
+    }
+
+    fn child_mut(&mut self) -> &mut Child {
+        self.child.as_mut().expect("startup child is owned")
+    }
+
+    fn commit(&mut self) {
+        self.committed = true;
+        self.child.take();
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
         }
     }
 }
 
-#[cfg(unix)]
-fn readiness_directory() -> Result<PathBuf, String> {
-    use std::os::unix::fs::DirBuilderExt;
-    let directory = std::env::temp_dir().join(format!(
-        "et-rs-terminal-ready-{}-{}",
-        std::process::id(),
-        et_core::keys::gen_id_passkey().0
-    ));
-    fs::DirBuilder::new()
-        .mode(0o700)
-        .create(&directory)
-        .map_err(|error| format!("could not create terminal readiness directory: {error}"))?;
-    Ok(directory)
+impl Drop for StartupChild {
+    fn drop(&mut self) {
+        if !self.committed {
+            if let Some(child) = self.child.as_mut() {
+                stop(child);
+            }
+        }
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
 }
 
-fn stop(child: &mut std::process::Child) {
+fn stop(child: &mut Child) {
     let _ = child.kill();
     let _ = child.wait();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn structured_status_is_bounded_and_rejects_truncation() {
+        let mut frame = Vec::new();
+        frame.extend_from_slice(STATUS_MAGIC);
+        frame.push(STATUS_FAILED);
+        frame.extend_from_slice(&3u16.to_be_bytes());
+        frame.extend_from_slice(b"bad");
+        assert_eq!(read_status(frame.as_slice()), Err("bad".to_owned()));
+        frame.pop();
+        assert!(read_status(frame.as_slice())
+            .unwrap_err()
+            .contains("truncated"));
+    }
+
+    #[test]
+    fn arbitrary_readiness_bytes_are_not_accepted() {
+        assert!(read_status(b"\x01".as_slice()).is_err());
+    }
+
+    #[test]
+    fn remote_deadline_leaves_outer_propagation_and_cleanup_margin() {
+        let outer = crate::ssh_process::DEFAULT_BOOTSTRAP_TIMEOUT;
+        assert!(outer >= READY_TIMEOUT + Duration::from_secs(30));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn uncommitted_startup_guard_kills_and_reaps_child() {
+        let child = std::process::Command::new("/bin/sh")
+            .args(["-c", "exec sleep 30"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let pid = i32::try_from(child.id()).unwrap();
+        drop(StartupChild::new(child));
+        assert!(nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn signal_exit_is_observed_as_closed_status_channel() {
+        let mut child = std::process::Command::new("/bin/sh")
+            .args(["-c", "kill -TERM $$"])
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let error = read_status(child.stdout.take().unwrap()).unwrap_err();
+        let status = child.wait().unwrap();
+        assert!(!status.success());
+        assert!(error.contains("closed"));
+    }
 }

--- a/crates/et-bin/src/terminal_daemon.rs
+++ b/crates/et-bin/src/terminal_daemon.rs
@@ -1,13 +1,16 @@
 //! Detached per-session terminal startup over an inherited, bounded status pipe.
 //!
 //! The bootstrap parent owns the child until it receives a structured
-//! `Registered` status. Every earlier return kills and reaps the child. The
+//! `Registered` status. That phase means credentials are committed and the
+//! client may connect; full PTY/relay readiness is acknowledged separately by
+//! `STARTUP_STATUS` before the server sends successful `INITIAL_RESPONSE`.
+//! Every earlier return kills and reaps the child. The
 //! anonymous stdout pipe is inherited across exec, unlike the old discoverable
 //! readiness listener, so unrelated local processes cannot forge readiness.
 
+use crate::detach::{Child, ChildStdout, Stdio};
 use std::io::{Read, Write};
 use std::path::Path;
-use std::process::{Child, Stdio};
 use std::sync::mpsc;
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -15,6 +18,10 @@ use std::time::Duration;
 use crate::terminal_credentials::CredentialInput;
 
 pub(crate) const READY_TIMEOUT: Duration = Duration::from_secs(45);
+
+pub(crate) const fn registration_timeout() -> Duration {
+    READY_TIMEOUT
+}
 const STATUS_MAGIC: &[u8; 4] = b"ETS1";
 const STATUS_REGISTERED: u8 = 1;
 const STATUS_FAILED: u8 = 2;
@@ -71,12 +78,7 @@ pub fn spawn_with_args(
         .take()
         .ok_or_else(|| "terminal child status pipe was not created".to_owned())?;
     let (sender, receiver) = mpsc::sync_channel(1);
-    let worker = std::thread::Builder::new()
-        .name("et-terminal-status".to_owned())
-        .spawn(move || {
-            let _ = sender.send(read_status(stdout));
-        })
-        .map_err(|error| format!("could not start terminal status worker: {error}"))?;
+    let worker = spawn_status_worker(stdout, sender, false)?;
     startup.worker = Some(worker);
 
     let result = receiver
@@ -87,6 +89,22 @@ pub fn spawn_with_args(
         startup.commit();
     }
     result
+}
+
+fn spawn_status_worker(
+    stdout: ChildStdout,
+    sender: mpsc::SyncSender<Result<(), String>>,
+    force_failure: bool,
+) -> Result<JoinHandle<()>, String> {
+    if force_failure {
+        return Err("could not start terminal status worker: injected failure".to_owned());
+    }
+    std::thread::Builder::new()
+        .name("et-terminal-status".to_owned())
+        .spawn(move || {
+            let _ = sender.send(read_status(stdout));
+        })
+        .map_err(|error| format!("could not start terminal status worker: {error}"))
 }
 
 /// Report committed router registration over the inherited stdout pipe.
@@ -241,6 +259,23 @@ mod tests {
             .unwrap();
         let pid = i32::try_from(child.id()).unwrap();
         drop(StartupChild::new(child));
+        assert!(nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn waiter_spawn_failure_leaves_guard_owning_and_reaping_child() {
+        let mut child = std::process::Command::new("/bin/sh")
+            .args(["-c", "exec sleep 30"])
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let pid = i32::try_from(child.id()).unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let guard = StartupChild::new(child);
+        let (sender, _receiver) = mpsc::sync_channel(1);
+        assert!(spawn_status_worker(stdout, sender, true).is_err());
+        drop(guard);
         assert!(nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_err());
     }
 

--- a/crates/et-bin/src/terminal_daemon.rs
+++ b/crates/et-bin/src/terminal_daemon.rs
@@ -21,7 +21,11 @@ use std::time::Duration;
 
 use crate::terminal_credentials::CredentialInput;
 
-const READY_TIMEOUT: Duration = Duration::from_secs(10);
+// Process creation and router registration can take longer than ten seconds
+// when the destination is under severe CPU, memory, or I/O pressure. Actual
+// child failures are reported through stderr, so this deadline only bounds a
+// genuinely stuck startup.
+const READY_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub fn spawn(router: &Path, input: &CredentialInput, verbose: u8) -> Result<(), String> {
     spawn_with_args(router, input, verbose, &[])
@@ -56,7 +60,7 @@ pub fn spawn_with_args(
         .args(extra)
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stderr(Stdio::piped());
     crate::detach::configure(&mut child);
     let mut child = crate::detach::spawn(&mut child)
         .map_err(|error| format!("could not start terminal session process: {error}"))?;
@@ -75,20 +79,41 @@ pub fn spawn_with_args(
         readiness.cleanup();
         return Err(error);
     }
-    let (sender, receiver) = mpsc::sync_channel(1);
+    let child_stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "terminal child stderr was not created".to_owned())?;
+    let (sender, receiver) = mpsc::sync_channel(2);
     let acceptor = readiness.acceptor();
+    let ready_sender = sender.clone();
     let worker = std::thread::Builder::new()
         .name("et-terminal-ready".to_owned())
         .spawn(move || {
-            let _ = sender.send(acceptor.accept_ready());
+            let _ = ready_sender.send(StartupEvent::Ready(acceptor.accept_ready()));
         })
         .map_err(|error| format!("could not start terminal readiness worker: {error}"))?;
+    std::thread::Builder::new()
+        .name("et-terminal-stderr".to_owned())
+        .spawn(move || {
+            let mut stderr = String::new();
+            let result = std::io::BufReader::new(child_stderr).read_to_string(&mut stderr);
+            let message = match result {
+                Ok(_) if stderr.trim().is_empty() => {
+                    "terminal session process exited before becoming ready".to_owned()
+                }
+                Ok(_) => stderr.trim().to_owned(),
+                Err(error) => format!("could not read terminal session process error: {error}"),
+            };
+            let _ = sender.send(StartupEvent::Exited(message));
+        })
+        .map_err(|error| format!("could not start terminal stderr worker: {error}"))?;
     let result = receiver
         .recv_timeout(READY_TIMEOUT)
         .map_err(|_| "timed out waiting for terminal session process".to_owned())
-        .and_then(|result| {
-            result
-                .map_err(|error| format!("terminal session process did not become ready: {error}"))
+        .and_then(|event| match event {
+            StartupEvent::Ready(result) => result
+                .map_err(|error| format!("terminal session process did not become ready: {error}")),
+            StartupEvent::Exited(message) => Err(message),
         });
     if result.is_err() {
         stop(&mut child);
@@ -97,6 +122,11 @@ pub fn spawn_with_args(
     let _ = worker.join();
     readiness.cleanup();
     result
+}
+
+enum StartupEvent {
+    Ready(std::io::Result<()>),
+    Exited(String),
 }
 
 /// Tell the parent this session is live. `target` is the value that was passed

--- a/crates/et-bin/src/terminal_daemon.rs
+++ b/crates/et-bin/src/terminal_daemon.rs
@@ -41,7 +41,7 @@ pub fn spawn_with_args(
         .map_err(|error| format!("could not locate et executable: {error}"))?
         .canonicalize()
         .map_err(|error| format!("could not resolve et executable: {error}"))?;
-    let mut command = crate::detach::command(executable.as_os_str());
+    let mut command = crate::detach::direct_command(executable.as_os_str());
     command
         .args([
             "terminal",
@@ -57,7 +57,7 @@ pub fn spawn_with_args(
         .args(extra)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null());
+        .stderr(Stdio::piped());
     crate::detach::configure(&mut command);
     let child = crate::detach::spawn(&mut command)
         .map_err(|error| format!("could not start terminal session process: {error}"))?;
@@ -85,10 +85,13 @@ pub fn spawn_with_args(
         .recv_timeout(READY_TIMEOUT)
         .map_err(|_| "timed out waiting for terminal registration".to_owned())?
         .map_err(|error| format!("terminal session process did not become ready: {error}"));
-    if result.is_ok() {
-        startup.commit();
+    match result {
+        Ok(()) => {
+            startup.commit();
+            Ok(())
+        }
+        Err(error) => Err(format!("{error}; {}", startup.stop_and_diagnose())),
     }
-    result
 }
 
 fn spawn_status_worker(
@@ -198,6 +201,36 @@ impl StartupChild {
             let _ = worker.join();
         }
     }
+
+    fn stop_and_diagnose(&mut self) -> String {
+        let status = if let Some(child) = self.child.as_mut() {
+            match child.try_wait() {
+                Ok(Some(status)) => format!("child exited with {status}"),
+                Ok(None) => {
+                    let _ = child.kill();
+                    match child.wait() {
+                        Ok(status) => format!("child was still running and was killed: {status}"),
+                        Err(error) => format!("child kill/wait failed: {error}"),
+                    }
+                }
+                Err(error) => format!("could not inspect child exit status: {error}"),
+            }
+        } else {
+            "child was not owned".to_owned()
+        };
+        let stderr = self
+            .child
+            .as_mut()
+            .and_then(|child| child.stderr.take())
+            .map(read_bounded_stderr)
+            .unwrap_or_else(|| "<unavailable>".to_owned());
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+        self.child.take();
+        self.committed = true;
+        format!("{status}; stderr={stderr}")
+    }
 }
 
 impl Drop for StartupChild {
@@ -216,6 +249,19 @@ impl Drop for StartupChild {
 fn stop(child: &mut Child) {
     let _ = child.kill();
     let _ = child.wait();
+}
+
+fn read_bounded_stderr(mut stderr: impl Read) -> String {
+    let mut bytes = Vec::new();
+    let _ = stderr
+        .by_ref()
+        .take(u64::try_from(MAX_STATUS_MESSAGE).expect("status bound fits u64"))
+        .read_to_end(&mut bytes);
+    if bytes.is_empty() {
+        "<empty>".to_owned()
+    } else {
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
 }
 
 #[cfg(test)]

--- a/crates/et-bin/src/terminal_jump.rs
+++ b/crates/et-bin/src/terminal_jump.rs
@@ -32,12 +32,16 @@ const READ_BUFFER: usize = 16 * 1024;
 /// Upstream retries the destination connection three times before failing.
 const CONNECT_ATTEMPTS: usize = 3;
 
-pub fn run(
+pub fn run_with_startup<F>(
     mut router: LocalStream,
     input: &CredentialInput,
     destination_host: &str,
     destination_port: u16,
-) -> Result<i32, String> {
+    started: F,
+) -> Result<i32, String>
+where
+    F: FnOnce(&mut LocalStream) -> Result<(), String>,
+{
     let payload = read_jumphost_init(&mut router)?;
     if !payload.jumphost.unwrap_or(false) {
         return Err("Jumphost should be set by the initial client".to_owned());
@@ -48,6 +52,7 @@ pub fn run(
     payload.jumphost = Some(false);
 
     let mut destination = connect_destination(input, destination_host, destination_port, &payload)?;
+    started(&mut router)?;
     write_local_packet(
         &mut router,
         &Packet::new(

--- a/crates/et-bin/src/terminal_pty.rs
+++ b/crates/et-bin/src/terminal_pty.rs
@@ -1,5 +1,5 @@
 use std::io::{self, Read, Write};
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 
 use et_core::packet::Packet;
@@ -93,13 +93,25 @@ where
             return Err(format!("could not start PTY output worker: {error}"));
         }
     };
+    let child_owner = Arc::new(Mutex::new(Some(child)));
+    let waiter_owner = child_owner.clone();
     let child_worker = match thread::Builder::new()
         .name("et-pty-child".to_owned())
         .spawn(move || {
-            let result = child
-                .wait()
-                .map(|status| status.exit_code())
-                .map_err(|error| format!("could not wait for terminal shell: {error}"));
+            let result = waiter_owner
+                .lock()
+                .map_err(|_| "terminal shell owner is unavailable".to_owned())
+                .and_then(|mut owner| {
+                    owner
+                        .take()
+                        .ok_or_else(|| "terminal shell is not owned".to_owned())
+                })
+                .and_then(|mut child| {
+                    child
+                        .wait()
+                        .map(|status| status.exit_code())
+                        .map_err(|error| format!("could not wait for terminal shell: {error}"))
+                });
             let _ = events_tx.send(WorkerEvent::Child(result));
             signal(wake_writer);
         }) {
@@ -107,6 +119,11 @@ where
         Err(error) => {
             kill_process_group(child_pid);
             let _ = killer.kill();
+            if let Ok(mut owner) = child_owner.lock() {
+                if let Some(mut child) = owner.take() {
+                    let _ = child.wait();
+                }
+            }
             drop(pty_writer);
             let _ = output_worker.join();
             return Err(format!("could not start PTY child worker: {error}"));

--- a/crates/et-bin/src/terminal_pty.rs
+++ b/crates/et-bin/src/terminal_pty.rs
@@ -26,7 +26,10 @@ enum WorkerEvent {
     Child(Result<u32, String>),
 }
 
-pub fn run(mut router: LocalStream, term: &str) -> Result<i32, String> {
+pub fn run_with_startup<F>(mut router: LocalStream, term: &str, started: F) -> Result<i32, String>
+where
+    F: FnOnce(&mut LocalStream) -> Result<(), String>,
+{
     let environment = read_initial_environment(&mut router)?;
     // Upstream issue #257: show the login banner an interactive ssh would have
     // printed, before the shell writes anything.
@@ -47,13 +50,8 @@ pub fn run(mut router: LocalStream, term: &str) -> Result<i32, String> {
     for (name, value) in environment {
         command.env(name, value);
     }
-    let mut child = pair
-        .slave
-        .spawn_command(command)
-        .map_err(|error| format!("could not spawn terminal shell: {error}"))?;
-    let child_pid = child.process_id();
-    drop(pair.slave);
-    let mut killer = child.clone_killer();
+    // Complete every fallible descriptor allocation before creating the shell.
+    // Once the process exists, all returns below pass through one cleanup path.
     let mut pty_reader = pair
         .master
         .try_clone_reader()
@@ -70,17 +68,32 @@ pub fn run(mut router: LocalStream, term: &str) -> Result<i32, String> {
     let output_wake = wake_writer
         .try_clone()
         .map_err(|error| format!("could not clone PTY wakeup: {error}"))?;
+
+    let mut child = pair
+        .slave
+        .spawn_command(command)
+        .map_err(|error| format!("could not spawn terminal shell: {error}"))?;
+    let child_pid = child.process_id();
+    drop(pair.slave);
+    let mut killer = child.clone_killer();
     let (events_tx, events_rx) = mpsc::channel();
     let output_tx = events_tx.clone();
-    let output_worker = thread::Builder::new()
+    let output_worker = match thread::Builder::new()
         .name("et-pty-output".to_owned())
         .spawn(move || {
             let result = forward_output(&mut pty_reader, &mut router_writer);
             let _ = output_tx.send(WorkerEvent::Output(result));
             signal(output_wake);
-        })
-        .map_err(|error| format!("could not start PTY output worker: {error}"))?;
-    let child_worker = thread::Builder::new()
+        }) {
+        Ok(worker) => worker,
+        Err(error) => {
+            kill_process_group(child_pid);
+            let _ = killer.kill();
+            let _ = child.wait();
+            return Err(format!("could not start PTY output worker: {error}"));
+        }
+    };
+    let child_worker = match thread::Builder::new()
         .name("et-pty-child".to_owned())
         .spawn(move || {
             let result = child
@@ -89,22 +102,35 @@ pub fn run(mut router: LocalStream, term: &str) -> Result<i32, String> {
                 .map_err(|error| format!("could not wait for terminal shell: {error}"));
             let _ = events_tx.send(WorkerEvent::Child(result));
             signal(wake_writer);
-        })
-        .map_err(|error| format!("could not start PTY child worker: {error}"))?;
+        }) {
+        Ok(worker) => worker,
+        Err(error) => {
+            kill_process_group(child_pid);
+            let _ = killer.kill();
+            drop(pty_writer);
+            let _ = output_worker.join();
+            return Err(format!("could not start PTY child worker: {error}"));
+        }
+    };
 
-    router
+    let setup = router
         .set_nonblocking(true)
-        .map_err(|error| format!("could not configure terminal router: {error}"))?;
-    wake_reader
-        .set_nonblocking(true)
-        .map_err(|error| format!("could not configure PTY wakeup: {error}"))?;
-    let result = pump(
-        &mut router,
-        wake_reader,
-        pair.master.as_ref(),
-        &mut pty_writer,
-        &events_rx,
-    );
+        .map_err(|error| format!("could not configure terminal router: {error}"))
+        .and_then(|()| {
+            wake_reader
+                .set_nonblocking(true)
+                .map_err(|error| format!("could not configure PTY wakeup: {error}"))
+        })
+        .and_then(|()| started(&mut router));
+    let result = setup.and_then(|()| {
+        pump(
+            &mut router,
+            wake_reader,
+            pair.master.as_ref(),
+            &mut pty_writer,
+            &events_rx,
+        )
+    });
     kill_process_group(child_pid);
     if result.is_err() {
         let _ = killer.kill();

--- a/crates/et-bin/src/terminal_pty.rs
+++ b/crates/et-bin/src/terminal_pty.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use et_core::packet::Packet;
 use et_core::proto::{TerminalBuffer, TerminalPacketType};
 use et_net::local::LocalStream;
-use et_net::local_packet::{write_local_packet_cancelled, LocalPacketDecoder};
+use et_net::local_packet::{write_local_packet_until_cancelled, LocalPacketDecoder};
 #[cfg(unix)]
 use nix::sys::signal::{kill, Signal};
 #[cfg(unix)]
@@ -21,7 +21,6 @@ use rustix::event::{poll, PollFd, PollFlags};
 use sysinfo::{Pid as SystemPid, ProcessesToUpdate, Signal as SystemSignal, System};
 
 const MAX_OUTPUT_CHUNK: usize = 16 * 1024;
-const OUTPUT_WRITE_TIMEOUT: Duration = Duration::from_secs(2);
 const FINAL_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
 
 use crate::terminal_protocol::{handle_packet, read_initial_environment, read_ready_packet};
@@ -56,10 +55,6 @@ where
     F: FnOnce(&mut LocalStream) -> Result<(), String>,
 {
     let environment = read_initial_environment(&mut router)?;
-    // Upstream issue #257: show the login banner an interactive ssh would have
-    // printed, before the shell writes anything.
-    #[cfg(unix)]
-    crate::terminal_motd::emit(&mut router)?;
     let pair = native_pty_system()
         .openpty(PtySize {
             rows: 24,
@@ -181,7 +176,12 @@ where
             let mut writer = router_writer
                 .lock()
                 .map_err(|_| "terminal router writer is unavailable".to_owned())?;
-            started(&mut writer)
+            started(&mut writer)?;
+            // Keep startup status ahead of every user-visible byte while
+            // preserving current-main's MOTD-before-shell ordering.
+            #[cfg(unix)]
+            crate::terminal_motd::emit(&mut writer)?;
+            Ok(())
         });
     let output_started = setup.is_ok();
     if output_started {
@@ -305,13 +305,8 @@ fn forward_output(
         let mut router = router
             .lock()
             .map_err(|_| "terminal router writer is unavailable".to_owned())?;
-        write_local_packet_cancelled(
-            &mut *router,
-            &packet,
-            cancelled,
-            Instant::now() + OUTPUT_WRITE_TIMEOUT,
-        )
-        .map_err(|error| format!("could not forward PTY output: {error}"))?;
+        write_local_packet_until_cancelled(&mut *router, &packet, cancelled)
+            .map_err(|error| format!("could not forward PTY output: {error}"))?;
     }
 }
 

--- a/crates/et-bin/src/terminal_pty.rs
+++ b/crates/et-bin/src/terminal_pty.rs
@@ -22,6 +22,7 @@ use sysinfo::{Pid as SystemPid, ProcessesToUpdate, Signal as SystemSignal, Syste
 
 const MAX_OUTPUT_CHUNK: usize = 16 * 1024;
 const OUTPUT_WRITE_TIMEOUT: Duration = Duration::from_secs(2);
+const FINAL_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
 
 use crate::terminal_protocol::{handle_packet, read_initial_environment, read_ready_packet};
 
@@ -30,7 +31,27 @@ enum WorkerEvent {
     Child(Result<u32, String>),
 }
 
-pub fn run_with_startup<F>(mut router: LocalStream, term: &str, started: F) -> Result<i32, String>
+pub fn run_with_startup<F>(router: LocalStream, term: &str, started: F) -> Result<i32, String>
+where
+    F: FnOnce(&mut LocalStream) -> Result<(), String>,
+{
+    let command = CommandBuilder::new(default_shell());
+    #[cfg(unix)]
+    let command = {
+        let mut command = command;
+        command.arg("-l");
+        command
+    };
+    run_with_command(router, term, command, Duration::ZERO, started)
+}
+
+fn run_with_command<F>(
+    mut router: LocalStream,
+    term: &str,
+    mut command: CommandBuilder,
+    output_delay: Duration,
+    started: F,
+) -> Result<i32, String>
 where
     F: FnOnce(&mut LocalStream) -> Result<(), String>,
 {
@@ -47,9 +68,6 @@ where
             pixel_height: 0,
         })
         .map_err(|error| format!("could not open PTY: {error}"))?;
-    let mut command = CommandBuilder::new(default_shell());
-    #[cfg(unix)]
-    command.arg("-l");
     command.env("TERM", term);
     for (name, value) in environment {
         command.env(name, value);
@@ -91,8 +109,12 @@ where
     let output_worker = match thread::Builder::new()
         .name("et-pty-output".to_owned())
         .spawn(move || {
-            let result = wait_for_output_gate(&worker_gate, &worker_cancelled)
-                .and_then(|()| forward_output(&mut pty_reader, &worker_writer, &worker_cancelled));
+            let result = wait_for_output_gate(&worker_gate, &worker_cancelled).and_then(|()| {
+                if !output_delay.is_zero() {
+                    thread::sleep(output_delay);
+                }
+                forward_output(&mut pty_reader, &worker_writer, &worker_cancelled)
+            });
             let _ = output_tx.send(WorkerEvent::Output(result));
             signal(output_wake);
         }) {
@@ -178,14 +200,17 @@ where
             &events_rx,
         )
     });
+    let graceful_drain = result.as_ref().is_ok_and(|completion| completion.drained);
     kill_process_group(child_pid);
-    cancelled.store(true, Ordering::Release);
+    // Preserve normal output through PTY EOF. If the bounded fallback elapsed,
+    // cancel and close the writer even though the shell itself exited normally.
+    cancelled.store(!graceful_drain, Ordering::Release);
     let (ready, changed) = &*output_gate;
     if let Ok(mut ready) = ready.lock() {
         *ready = true;
         changed.notify_all();
     }
-    if output_started {
+    if output_started && !graceful_drain {
         let _ = router.shutdown(Shutdown::Both);
         if let Ok(writer) = router_writer.lock() {
             let _ = writer.shutdown(Shutdown::Both);
@@ -201,10 +226,11 @@ where
     let child_join = child_worker
         .join()
         .map_err(|_| "PTY child worker panicked".to_owned());
-    let status = result?;
+    let completion = result?;
     output_join?;
     child_join?;
-    i32::try_from(status).map_err(|_| "terminal shell exit status is out of range".to_owned())
+    i32::try_from(completion.status)
+        .map_err(|_| "terminal shell exit status is out of range".to_owned())
 }
 
 /// Shell the session hosts.
@@ -289,13 +315,60 @@ fn forward_output(
     }
 }
 
+struct PumpCompletion {
+    status: u32,
+    drained: bool,
+}
+
+#[derive(Default)]
+struct CompletionState {
+    child_status: Option<u32>,
+    output_done: bool,
+    drain_deadline: Option<Instant>,
+}
+
+impl CompletionState {
+    fn observe(&mut self, event: WorkerEvent) -> Result<Option<PumpCompletion>, String> {
+        match event {
+            WorkerEvent::Output(Err(error)) | WorkerEvent::Child(Err(error)) => Err(error),
+            WorkerEvent::Child(Ok(status)) => {
+                self.child_status = Some(status);
+                self.drain_deadline = Some(Instant::now() + FINAL_OUTPUT_DRAIN_TIMEOUT);
+                Ok(self.output_done.then_some(PumpCompletion {
+                    status,
+                    drained: true,
+                }))
+            }
+            WorkerEvent::Output(Ok(())) => {
+                self.output_done = true;
+                Ok(self.child_status.map(|status| PumpCompletion {
+                    status,
+                    drained: true,
+                }))
+            }
+        }
+    }
+
+    fn expired_status(&self) -> Option<PumpCompletion> {
+        self.child_status
+            .filter(|_| {
+                self.drain_deadline
+                    .is_some_and(|deadline| Instant::now() >= deadline)
+            })
+            .map(|status| PumpCompletion {
+                status,
+                drained: false,
+            })
+    }
+}
+
 fn pump(
     router: &mut LocalStream,
     wake_reader: LocalStream,
     master: &dyn portable_pty::MasterPty,
     pty_writer: &mut dyn Write,
     events: &mpsc::Receiver<WorkerEvent>,
-) -> Result<u32, String> {
+) -> Result<PumpCompletion, String> {
     #[cfg(unix)]
     return pump_poll(router, wake_reader, master, pty_writer, events);
     #[cfg(windows)]
@@ -309,8 +382,9 @@ fn pump_poll(
     master: &dyn portable_pty::MasterPty,
     pty_writer: &mut dyn Write,
     events: &mpsc::Receiver<WorkerEvent>,
-) -> Result<u32, String> {
+) -> Result<PumpCompletion, String> {
     let mut decoder = LocalPacketDecoder::new();
+    let mut completion = CompletionState::default();
     loop {
         let (router_events, wake_events) = {
             let mut descriptors = [
@@ -320,7 +394,13 @@ fn pump_poll(
             // poll() is never restarted by SA_RESTART; retry on EINTR so a
             // stray signal cannot kill the terminal session.
             loop {
-                match poll(&mut descriptors, None) {
+                let timeout = completion.drain_deadline.map(|deadline| {
+                    rustix::time::Timespec::try_from(
+                        deadline.saturating_duration_since(Instant::now()),
+                    )
+                    .expect("two-second PTY drain timeout fits timespec")
+                });
+                match poll(&mut descriptors, timeout.as_ref()) {
                     Ok(_) => break,
                     Err(error) if error == rustix::io::Errno::INTR => {}
                     Err(error) => {
@@ -332,15 +412,14 @@ fn pump_poll(
         };
         if wake_events.intersects(PollFlags::IN | PollFlags::HUP) {
             while let Ok(event) = events.try_recv() {
-                match event {
-                    WorkerEvent::Output(Err(error)) | WorkerEvent::Child(Err(error)) => {
-                        return Err(error);
-                    }
-                    WorkerEvent::Child(Ok(status)) => return Ok(status),
-                    WorkerEvent::Output(Ok(())) => {}
+                if let Some(status) = completion.observe(event)? {
+                    return Ok(status);
                 }
             }
             drain_wakeup(&mut wake_reader)?;
+        }
+        if let Some(status) = completion.expired_status() {
+            return Ok(status);
         }
         if router_events.intersects(PollFlags::HUP | PollFlags::ERR) {
             return Err("terminal router disconnected".to_owned());
@@ -364,20 +443,20 @@ fn pump_windows(
     master: &dyn portable_pty::MasterPty,
     pty_writer: &mut dyn Write,
     events: &mpsc::Receiver<WorkerEvent>,
-) -> Result<u32, String> {
+) -> Result<PumpCompletion, String> {
     const IDLE: std::time::Duration = std::time::Duration::from_millis(10);
     let mut decoder = LocalPacketDecoder::new();
+    let mut completion = CompletionState::default();
     loop {
         let mut progress = false;
         while let Ok(event) = events.try_recv() {
             progress = true;
-            match event {
-                WorkerEvent::Output(Err(error)) | WorkerEvent::Child(Err(error)) => {
-                    return Err(error);
-                }
-                WorkerEvent::Child(Ok(status)) => return Ok(status),
-                WorkerEvent::Output(Ok(())) => {}
+            if let Some(status) = completion.observe(event)? {
+                return Ok(status);
             }
+        }
+        if let Some(status) = completion.expired_status() {
+            return Ok(status);
         }
         drain_wakeup(&mut wake_reader)?;
         match read_ready_packet(router, &mut decoder) {
@@ -480,6 +559,65 @@ mod tests {
     };
     use prost::Message;
     use std::io::Cursor;
+
+    #[cfg(unix)]
+    #[test]
+    fn normal_immediate_exit_drains_delayed_output_before_eof() {
+        let (router, mut peer) = et_net::local::wake_pair().unwrap();
+        peer.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        write_local_packet(
+            &mut peer,
+            &Packet::new(
+                TerminalPacketType::TerminalInit as u8,
+                TermInit::default().encode_to_vec(),
+            ),
+        )
+        .unwrap();
+        let mut command = CommandBuilder::new("/bin/sh");
+        command.args(["-c", "printf FINAL-OUTPUT-MARKER"]);
+        let (done_tx, done_rx) = mpsc::channel();
+        thread::spawn(move || {
+            let result = run_with_command(
+                router,
+                "xterm",
+                command,
+                Duration::from_millis(250),
+                |writer| {
+                    write_local_packet(writer, &status_packet(STARTUP_STATUS, Ok(())))
+                        .map_err(|error| error.to_string())
+                },
+            );
+            let _ = done_tx.send(result);
+        });
+
+        thread::sleep(Duration::from_millis(100));
+        let status = read_local_packet(&mut peer).unwrap();
+        assert_eq!(status.header(), STARTUP_STATUS);
+        let mut output = Vec::new();
+        while let Ok(packet) = read_local_packet(&mut peer) {
+            assert_eq!(packet.header(), TerminalPacketType::TerminalBuffer as u8);
+            output.extend(
+                TerminalBuffer::decode(packet.payload())
+                    .unwrap()
+                    .buffer
+                    .unwrap(),
+            );
+        }
+        assert!(
+            output
+                .windows(b"FINAL-OUTPUT-MARKER".len())
+                .any(|window| window == b"FINAL-OUTPUT-MARKER"),
+            "final PTY output was lost: {:?}",
+            String::from_utf8_lossy(&output)
+        );
+        assert_eq!(
+            done_rx
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap()
+                .unwrap(),
+            0
+        );
+    }
 
     #[test]
     fn injected_setup_failure_reaps_shell_while_peer_stays_open_and_unread() {

--- a/crates/et-bin/src/terminal_pty.rs
+++ b/crates/et-bin/src/terminal_pty.rs
@@ -1,11 +1,14 @@
 use std::io::{self, Read, Write};
-use std::sync::{mpsc, Arc, Mutex};
+use std::net::Shutdown;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc, Condvar, Mutex};
 use std::thread;
+use std::time::{Duration, Instant};
 
 use et_core::packet::Packet;
 use et_core::proto::{TerminalBuffer, TerminalPacketType};
 use et_net::local::LocalStream;
-use et_net::local_packet::{write_local_packet, LocalPacketDecoder};
+use et_net::local_packet::{write_local_packet_cancelled, LocalPacketDecoder};
 #[cfg(unix)]
 use nix::sys::signal::{kill, Signal};
 #[cfg(unix)]
@@ -18,6 +21,7 @@ use rustix::event::{poll, PollFd, PollFlags};
 use sysinfo::{Pid as SystemPid, ProcessesToUpdate, Signal as SystemSignal, System};
 
 const MAX_OUTPUT_CHUNK: usize = 16 * 1024;
+const OUTPUT_WRITE_TIMEOUT: Duration = Duration::from_secs(2);
 
 use crate::terminal_protocol::{handle_packet, read_initial_environment, read_ready_packet};
 
@@ -60,9 +64,12 @@ where
         .master
         .take_writer()
         .map_err(|error| format!("could not open PTY writer: {error}"))?;
-    let mut router_writer = router
-        .try_clone()
-        .map_err(|error| format!("could not clone terminal router: {error}"))?;
+    let router_writer =
+        Arc::new(Mutex::new(router.try_clone().map_err(|error| {
+            format!("could not clone terminal router: {error}")
+        })?));
+    let output_gate = Arc::new((Mutex::new(false), Condvar::new()));
+    let cancelled = Arc::new(AtomicBool::new(false));
     let (wake_reader, wake_writer) = et_net::local::wake_pair()
         .map_err(|error| format!("could not create PTY wakeup: {error}"))?;
     let output_wake = wake_writer
@@ -78,10 +85,14 @@ where
     let mut killer = child.clone_killer();
     let (events_tx, events_rx) = mpsc::channel();
     let output_tx = events_tx.clone();
+    let worker_writer = router_writer.clone();
+    let worker_gate = output_gate.clone();
+    let worker_cancelled = cancelled.clone();
     let output_worker = match thread::Builder::new()
         .name("et-pty-output".to_owned())
         .spawn(move || {
-            let result = forward_output(&mut pty_reader, &mut router_writer);
+            let result = wait_for_output_gate(&worker_gate, &worker_cancelled)
+                .and_then(|()| forward_output(&mut pty_reader, &worker_writer, &worker_cancelled));
             let _ = output_tx.send(WorkerEvent::Output(result));
             signal(output_wake);
         }) {
@@ -124,6 +135,12 @@ where
                     let _ = child.wait();
                 }
             }
+            cancelled.store(true, Ordering::Release);
+            let (ready, changed) = &*output_gate;
+            if let Ok(mut ready) = ready.lock() {
+                *ready = true;
+                changed.notify_all();
+            }
             drop(pty_writer);
             let _ = output_worker.join();
             return Err(format!("could not start PTY child worker: {error}"));
@@ -138,7 +155,20 @@ where
                 .set_nonblocking(true)
                 .map_err(|error| format!("could not configure PTY wakeup: {error}"))
         })
-        .and_then(|()| started(&mut router));
+        .and_then(|()| {
+            let mut writer = router_writer
+                .lock()
+                .map_err(|_| "terminal router writer is unavailable".to_owned())?;
+            started(&mut writer)
+        });
+    let output_started = setup.is_ok();
+    if output_started {
+        let (ready, changed) = &*output_gate;
+        if let Ok(mut ready) = ready.lock() {
+            *ready = true;
+            changed.notify_all();
+        }
+    }
     let result = setup.and_then(|()| {
         pump(
             &mut router,
@@ -149,6 +179,18 @@ where
         )
     });
     kill_process_group(child_pid);
+    cancelled.store(true, Ordering::Release);
+    let (ready, changed) = &*output_gate;
+    if let Ok(mut ready) = ready.lock() {
+        *ready = true;
+        changed.notify_all();
+    }
+    if output_started {
+        let _ = router.shutdown(Shutdown::Both);
+        if let Ok(writer) = router_writer.lock() {
+            let _ = writer.shutdown(Shutdown::Both);
+        }
+    }
     if result.is_err() {
         let _ = killer.kill();
     }
@@ -194,7 +236,31 @@ fn default_shell() -> String {
     }
 }
 
-fn forward_output(reader: &mut dyn Read, router: &mut LocalStream) -> Result<(), String> {
+fn wait_for_output_gate(
+    gate: &(Mutex<bool>, Condvar),
+    cancelled: &AtomicBool,
+) -> Result<(), String> {
+    let (ready, changed) = gate;
+    let mut ready = ready
+        .lock()
+        .map_err(|_| "terminal output gate is unavailable".to_owned())?;
+    while !*ready && !cancelled.load(Ordering::Acquire) {
+        ready = changed
+            .wait(ready)
+            .map_err(|_| "terminal output gate is unavailable".to_owned())?;
+    }
+    if cancelled.load(Ordering::Acquire) {
+        Err("terminal output cancelled before startup".to_owned())
+    } else {
+        Ok(())
+    }
+}
+
+fn forward_output(
+    reader: &mut dyn Read,
+    router: &Mutex<LocalStream>,
+    cancelled: &AtomicBool,
+) -> Result<(), String> {
     let mut buffer = [0u8; MAX_OUTPUT_CHUNK];
     loop {
         let count = reader
@@ -210,8 +276,16 @@ fn forward_output(reader: &mut dyn Read, router: &mut LocalStream) -> Result<(),
             TerminalPacketType::TerminalBuffer as u8,
             message.encode_to_vec(),
         );
-        write_local_packet(router, &packet)
-            .map_err(|error| format!("could not forward PTY output: {error}"))?;
+        let mut router = router
+            .lock()
+            .map_err(|_| "terminal router writer is unavailable".to_owned())?;
+        write_local_packet_cancelled(
+            &mut *router,
+            &packet,
+            cancelled,
+            Instant::now() + OUTPUT_WRITE_TIMEOUT,
+        )
+        .map_err(|error| format!("could not forward PTY output: {error}"))?;
     }
 }
 
@@ -394,5 +468,91 @@ fn kill_process_group(process_id: Option<u32>) {
         .filter(|process| process.session_id() == Some(session))
     {
         let _ = process.kill_with(SystemSignal::Kill);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use et_core::proto::TermInit;
+    use et_net::local_packet::{
+        read_local_packet, status_packet, write_local_packet, STARTUP_STATUS,
+    };
+    use prost::Message;
+    use std::io::Cursor;
+
+    #[test]
+    fn injected_setup_failure_reaps_shell_while_peer_stays_open_and_unread() {
+        let (router, mut peer) = et_net::local::wake_pair().unwrap();
+        let mut startup = router.try_clone().unwrap();
+        write_local_packet(
+            &mut peer,
+            &Packet::new(
+                TerminalPacketType::TerminalInit as u8,
+                TermInit::default().encode_to_vec(),
+            ),
+        )
+        .unwrap();
+        let (done_tx, done_rx) = mpsc::channel();
+        thread::spawn(move || {
+            let result =
+                run_with_startup(router, "xterm", |_| Err("injected setup failure".into()));
+            let _ = done_tx.send(result);
+        });
+        let error = done_rx
+            .recv_timeout(Duration::from_secs(3))
+            .expect("PTY cleanup waited for the non-reading peer")
+            .unwrap_err();
+        assert_eq!(error, "injected setup failure");
+        write_local_packet(
+            &mut startup,
+            &status_packet(STARTUP_STATUS, Err("injected setup failure")),
+        )
+        .unwrap();
+        assert_eq!(
+            read_local_packet(&mut peer).unwrap().header(),
+            STARTUP_STATUS
+        );
+        drop(peer);
+    }
+
+    #[test]
+    fn immediate_output_waits_until_startup_status_is_fully_serialized() {
+        let (writer, mut peer) = et_net::local::wake_pair().unwrap();
+        peer.set_read_timeout(Some(Duration::from_secs(1))).unwrap();
+        let writer = Arc::new(Mutex::new(writer));
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let worker_writer = writer.clone();
+        let worker_gate = gate.clone();
+        let worker_cancelled = cancelled.clone();
+        let worker = thread::spawn(move || {
+            wait_for_output_gate(&worker_gate, &worker_cancelled)?;
+            forward_output(
+                &mut Cursor::new(b"immediate output"),
+                &worker_writer,
+                &worker_cancelled,
+            )
+        });
+
+        // Model delayed main-thread scheduling: output is already readable from
+        // the PTY, but the only socket writer remains owned by startup status.
+        {
+            let mut writer = writer.lock().unwrap();
+            write_local_packet(&mut *writer, &status_packet(STARTUP_STATUS, Ok(()))).unwrap();
+        }
+        let (ready, changed) = &*gate;
+        *ready.lock().unwrap() = true;
+        changed.notify_all();
+
+        assert_eq!(
+            read_local_packet(&mut peer).unwrap().header(),
+            STARTUP_STATUS
+        );
+        assert_eq!(
+            read_local_packet(&mut peer).unwrap().header(),
+            TerminalPacketType::TerminalBuffer as u8
+        );
+        worker.join().unwrap().unwrap();
     }
 }

--- a/crates/et-bin/tests/server_runtime.rs
+++ b/crates/et-bin/tests/server_runtime.rs
@@ -1,9 +1,10 @@
 #![forbid(unsafe_code)]
 
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read};
 use std::net::{Ipv4Addr, TcpListener, TcpStream};
 use std::os::unix::fs::{symlink, PermissionsExt};
+use std::os::unix::net::{UnixListener, UnixStream};
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::thread;
@@ -111,6 +112,23 @@ fn daemon_mode_detaches_and_writes_a_pid_file() {
     {
         let router = directory.join(format!("router-{index}"));
         let pidfile = directory.join(format!("etserver-{index}.pid"));
+        let shutdown_socket =
+            std::env::temp_dir().join(format!("ed{}{}", std::process::id(), index));
+        let shutdown_listener = UnixListener::bind(&shutdown_socket).unwrap();
+        let (runtime_tx, runtime_rx) = mpsc::sync_channel(1);
+        let (shutdown_tx, shutdown_rx) = mpsc::sync_channel(1);
+        let shutdown_worker = thread::spawn(move || {
+            let runtime = accept_daemon_status(&shutdown_listener, b"ETD0", "runtime startup");
+            let runtime_started = runtime.is_ok();
+            let _ = runtime_tx.send(runtime);
+            if runtime_started {
+                let _ = shutdown_tx.send(accept_daemon_status(
+                    &shutdown_listener,
+                    b"ETD2",
+                    "shutdown completion",
+                ));
+            }
+        });
         let mut arguments = Vec::new();
         if index == 0 {
             arguments.push("server".to_owned());
@@ -133,12 +151,15 @@ fn daemon_mode_detaches_and_writes_a_pid_file() {
         let position = arguments.iter().position(|value| value == "0").unwrap();
         arguments[position] = port.to_string();
 
-        let output = Command::new(program).args(&arguments).output().unwrap();
+        let output = Command::new(program)
+            .args(&arguments)
+            .env("ET_RS_TEST_SERVER_SHUTDOWN_SOCKET", &shutdown_socket)
+            .output()
+            .unwrap();
         assert_eq!(output.status.code(), Some(0), "{output:?}");
         assert!(output.stdout.is_empty(), "{output:?}");
 
-        // The parent returns only after the detached child acknowledges its
-        // flushed pid file, so no timing-based filesystem polling is needed.
+        // The parent returns after the detached child flushes its pid file.
         let pid = fs::read_to_string(&pidfile)
             .expect("daemon did not write a pid file")
             .trim()
@@ -148,11 +169,73 @@ fn daemon_mode_detaches_and_writes_a_pid_file() {
         // Owner-only permissions, like upstream's 0600 open().
         let mode = fs::metadata(&pidfile).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600);
-        // The daemon runs detached from this process.
-        let _ = kill(Pid::from_raw(pid), Signal::SIGTERM);
+
+        // The test-only runtime frame proves signal handling and the runtime
+        // are ready before SIGTERM, without changing production startup.
+        let runtime = runtime_rx.recv_timeout(TIMEOUT);
+        if !matches!(runtime, Ok(Ok(()))) {
+            let _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
+            let _ = UnixStream::connect(&shutdown_socket);
+            shutdown_worker.join().unwrap();
+            let _ = fs::remove_file(&shutdown_socket);
+            match runtime {
+                Ok(Ok(())) => unreachable!(),
+                Ok(Err(error)) => panic!("daemon runtime-start signal failed: {error}"),
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    panic!("daemon did not signal runtime startup before the watchdog")
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    panic!("daemon runtime-start observer disconnected")
+                }
+            }
+        }
+
+        // The daemon runs detached from this process. Its completion frame is
+        // emitted only after runtime shutdown retires the router.
+        kill(Pid::from_raw(pid), Signal::SIGTERM).unwrap();
+        let shutdown = shutdown_rx.recv_timeout(TIMEOUT);
+        if !matches!(shutdown, Ok(Ok(()))) {
+            let _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
+            // Wake the observer so failure cleanup can join without polling.
+            let _ = UnixStream::connect(&shutdown_socket);
+        }
+        shutdown_worker.join().unwrap();
+        let _ = fs::remove_file(&shutdown_socket);
+        match shutdown {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => panic!("daemon shutdown completion signal failed: {error}"),
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                panic!("daemon did not signal shutdown completion before the watchdog")
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("daemon shutdown completion observer disconnected")
+            }
+        }
+        assert!(
+            !router.exists(),
+            "daemon retained its router after shutdown"
+        );
+        fs::remove_file(pidfile).unwrap();
     }
     let _ = fs::remove_file(&pidfile);
     fs::remove_dir_all(directory).unwrap();
+}
+
+fn accept_daemon_status(
+    listener: &UnixListener,
+    expected: &[u8; 4],
+    phase: &str,
+) -> std::io::Result<()> {
+    let (mut stream, _) = listener.accept()?;
+    let mut frame = [0u8; 4];
+    stream.read_exact(&mut frame)?;
+    if &frame != expected {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("malformed daemon {phase} frame"),
+        ));
+    }
+    Ok(())
 }
 
 fn tempfile_path(label: &str) -> std::path::PathBuf {

--- a/crates/et-bin/tests/server_runtime.rs
+++ b/crates/et-bin/tests/server_runtime.rs
@@ -123,9 +123,13 @@ fn daemon_mode_detaches_and_writes_a_pid_file() {
 
     // A real daemon run returns immediately and the child records its pid,
     // matching upstream `DaemonCreator::create`.
-    for (index, program) in [env!("CARGO_BIN_EXE_et"), busybox.to_str().unwrap()]
-        .into_iter()
-        .enumerate()
+    for (index, (program, explicit_server_role, log_to_stdout)) in [
+        (env!("CARGO_BIN_EXE_et"), true, false),
+        (busybox.to_str().unwrap(), false, false),
+        (env!("CARGO_BIN_EXE_et"), true, true),
+    ]
+    .into_iter()
+    .enumerate()
     {
         let router = directory.join(format!("router-{index}"));
         let pidfile = directory.join(format!("etserver-{index}.pid"));
@@ -147,7 +151,7 @@ fn daemon_mode_detaches_and_writes_a_pid_file() {
             }
         });
         let mut arguments = Vec::new();
-        if index == 0 {
+        if explicit_server_role {
             arguments.push("server".to_owned());
         }
         arguments.extend([
@@ -159,6 +163,9 @@ fn daemon_mode_detaches_and_writes_a_pid_file() {
             "--serverfifo".to_owned(),
             router.to_str().unwrap().to_owned(),
         ]);
+        if log_to_stdout {
+            arguments.push("--logtostdout".to_owned());
+        }
         // Replace the rejected port with an ephemeral one the OS assigns.
         let port = std::net::TcpListener::bind("127.0.0.1:0")
             .unwrap()
@@ -173,7 +180,11 @@ fn daemon_mode_detaches_and_writes_a_pid_file() {
             .env("ET_RS_TEST_SERVER_SHUTDOWN_SOCKET", &shutdown_socket)
             .output()
             .unwrap();
-        assert_eq!(output.status.code(), Some(0), "{output:?}");
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "daemon scenario index={index} program={program} logtostdout={log_to_stdout}: {output:?}"
+        );
         assert!(output.stdout.is_empty(), "{output:?}");
 
         // The parent returns after the detached child starts its runtime; the

--- a/crates/et-bin/tests/server_runtime.rs
+++ b/crates/et-bin/tests/server_runtime.rs
@@ -137,18 +137,13 @@ fn daemon_mode_detaches_and_writes_a_pid_file() {
         assert_eq!(output.status.code(), Some(0), "{output:?}");
         assert!(output.stdout.is_empty(), "{output:?}");
 
-        // The detached child writes the pid file shortly after starting.
-        let mut recorded = None;
-        for _ in 0..50 {
-            if let Ok(text) = fs::read_to_string(&pidfile) {
-                if let Ok(pid) = text.trim().parse::<i32>() {
-                    recorded = Some(pid);
-                    break;
-                }
-            }
-            std::thread::sleep(std::time::Duration::from_millis(100));
-        }
-        let pid = recorded.expect("daemon did not write a pid file");
+        // The parent returns only after the detached child acknowledges its
+        // flushed pid file, so no timing-based filesystem polling is needed.
+        let pid = fs::read_to_string(&pidfile)
+            .expect("daemon did not write a pid file")
+            .trim()
+            .parse::<i32>()
+            .expect("daemon wrote an invalid pid file");
         assert!(pid > 0);
         // Owner-only permissions, like upstream's 0600 open().
         let mode = fs::metadata(&pidfile).unwrap().permissions().mode() & 0o777;

--- a/crates/et-bin/tests/server_runtime.rs
+++ b/crates/et-bin/tests/server_runtime.rs
@@ -104,6 +104,23 @@ fn daemon_mode_detaches_and_writes_a_pid_file() {
         .unwrap();
     assert_eq!(invalid.status.code(), Some(2));
 
+    // Child failures cross the bounded startup pipe instead of being hidden by
+    // detached stderr or reported as an unclassified EOF.
+    let failed_pidfile = directory.join("missing/etserver.pid");
+    let failed = Command::new(env!("CARGO_BIN_EXE_et"))
+        .args(["server", "--daemon", "--port", "2022", "--pidfile"])
+        .arg(&failed_pidfile)
+        .output()
+        .unwrap();
+    assert_eq!(failed.status.code(), Some(2), "{failed:?}");
+    let failure = String::from_utf8(failed.stderr).unwrap();
+    assert!(
+        failure.contains("Error opening pidfile for writing"),
+        "{failure}"
+    );
+    assert!(failure.contains(&failed_pidfile.to_string_lossy().into_owned()));
+    assert!(!failure.contains("status channel closed"), "{failure}");
+
     // A real daemon run returns immediately and the child records its pid,
     // matching upstream `DaemonCreator::create`.
     for (index, program) in [env!("CARGO_BIN_EXE_et"), busybox.to_str().unwrap()]
@@ -159,7 +176,8 @@ fn daemon_mode_detaches_and_writes_a_pid_file() {
         assert_eq!(output.status.code(), Some(0), "{output:?}");
         assert!(output.stdout.is_empty(), "{output:?}");
 
-        // The parent returns after the detached child flushes its pid file.
+        // The parent returns after the detached child starts its runtime; the
+        // pid file is therefore complete without filesystem polling.
         let pid = fs::read_to_string(&pidfile)
             .expect("daemon did not write a pid file")
             .trim()

--- a/crates/et-bin/tests/terminal_adversarial.rs
+++ b/crates/et-bin/tests/terminal_adversarial.rs
@@ -10,7 +10,10 @@ use std::time::Duration;
 
 use et_core::packet::Packet;
 use et_core::proto::{TermInit, TerminalBuffer, TerminalPacketType};
-use et_net::local_packet::{read_local_packet, write_local_packet};
+use et_net::local_packet::{
+    parse_status, read_local_packet, status_packet, write_local_packet, REGISTRATION_STATUS,
+    STARTUP_STATUS,
+};
 use nix::sys::signal::kill;
 use nix::unistd::Pid;
 use prost::Message;
@@ -27,6 +30,7 @@ fn malformed_initialization_and_shell_spawn_failure_are_typed() {
     write_credentials(&mut malformed_child);
     let (mut malformed_router, _) = malformed.listener.accept().unwrap();
     let _ = read_local_packet(&mut malformed_router).unwrap();
+    acknowledge_registration(&mut malformed_router);
     malformed.wait_ready();
     send(
         &mut malformed_router,
@@ -46,6 +50,7 @@ fn malformed_initialization_and_shell_spawn_failure_are_typed() {
     write_credentials(&mut failed_child);
     let (mut failed_router, _) = spawn_failure.listener.accept().unwrap();
     let _ = read_local_packet(&mut failed_router).unwrap();
+    acknowledge_registration(&mut failed_router);
     spawn_failure.wait_ready();
     send(
         &mut failed_router,
@@ -72,6 +77,7 @@ fn shell_exit_reaps_background_process_group() {
     write_credentials(&mut child);
     let (mut router, _) = fixture.listener.accept().unwrap();
     let _ = read_local_packet(&mut router).unwrap();
+    acknowledge_registration(&mut router);
     fixture.wait_ready();
     let mut output_reader = router.try_clone().unwrap();
     let (output_tx, output_rx) = mpsc::sync_channel(64);
@@ -93,6 +99,10 @@ fn shell_exit_reaps_background_process_group() {
     let mut output = String::new();
     let pid = loop {
         let packet = output_rx.recv_timeout(TIMEOUT).unwrap();
+        if packet.header() == STARTUP_STATUS {
+            parse_status(&packet, STARTUP_STATUS).unwrap();
+            continue;
+        }
         let bytes = TerminalBuffer::decode(packet.payload())
             .unwrap()
             .buffer
@@ -116,6 +126,10 @@ fn background_pid(output: &str) -> Option<i32> {
             .then(|| digits.parse::<i32>().ok())
             .flatten()
     })
+}
+
+fn acknowledge_registration(router: &mut impl Write) {
+    write_local_packet(router, &status_packet(REGISTRATION_STATUS, Ok(()))).unwrap();
 }
 
 fn send<M: Message>(router: &mut impl Write, kind: TerminalPacketType, message: &M) {

--- a/crates/et-bin/tests/terminal_adversarial.rs
+++ b/crates/et-bin/tests/terminal_adversarial.rs
@@ -28,7 +28,7 @@ fn malformed_initialization_and_shell_spawn_failure_are_typed() {
     let malformed = Fixture::new("malformed-init");
     let mut malformed_child = malformed.spawn();
     write_credentials(&mut malformed_child);
-    let (mut malformed_router, _) = malformed.listener.accept().unwrap();
+    let mut malformed_router = malformed.accept();
     let _ = read_local_packet(&mut malformed_router).unwrap();
     acknowledge_registration(&mut malformed_router);
     malformed.wait_ready();
@@ -48,7 +48,7 @@ fn malformed_initialization_and_shell_spawn_failure_are_typed() {
     let spawn_failure = Fixture::new("spawn-failure");
     let mut failed_child = spawn_failure.spawn_with_shell("/definitely/missing/et-shell");
     write_credentials(&mut failed_child);
-    let (mut failed_router, _) = spawn_failure.listener.accept().unwrap();
+    let mut failed_router = spawn_failure.accept();
     let _ = read_local_packet(&mut failed_router).unwrap();
     acknowledge_registration(&mut failed_router);
     spawn_failure.wait_ready();
@@ -75,7 +75,7 @@ fn shell_exit_reaps_background_process_group() {
     fs::set_permissions(&shell, fs::Permissions::from_mode(0o700)).unwrap();
     let mut child = fixture.spawn_with_shell(shell.to_str().unwrap());
     write_credentials(&mut child);
-    let (mut router, _) = fixture.listener.accept().unwrap();
+    let mut router = fixture.accept();
     let _ = read_local_packet(&mut router).unwrap();
     acknowledge_registration(&mut router);
     fixture.wait_ready();
@@ -158,6 +158,7 @@ impl Fixture {
         fs::set_permissions(&directory, fs::Permissions::from_mode(0o700)).unwrap();
         let socket = directory.join("router.sock");
         let listener = UnixListener::bind(&socket).unwrap();
+        et_net::local::write_registration_ack_capability(&socket).unwrap();
         let ready_socket = directory.join("ready.sock");
         let ready_listener = UnixListener::bind(&ready_socket).unwrap();
         Self {
@@ -167,6 +168,21 @@ impl Fixture {
             ready_socket,
             ready_listener,
         }
+    }
+
+    fn accept(&self) -> std::os::unix::net::UnixStream {
+        let listener = self.listener.try_clone().unwrap();
+        let (sender, receiver) = mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            let _ = sender.send(listener.accept().map(|(stream, _)| stream));
+        });
+        let stream = receiver
+            .recv_timeout(TIMEOUT)
+            .expect("timed out waiting for terminal router connection")
+            .unwrap();
+        stream.set_read_timeout(Some(TIMEOUT)).unwrap();
+        stream.set_write_timeout(Some(TIMEOUT)).unwrap();
+        stream
     }
 
     fn spawn(&self) -> std::process::Child {

--- a/crates/et-bin/tests/terminal_runtime.rs
+++ b/crates/et-bin/tests/terminal_runtime.rs
@@ -3,7 +3,7 @@
 #[path = "terminal_runtime_support/mod.rs"]
 mod terminal_runtime_support;
 
-use std::io::Write;
+use std::io::{BufRead, BufReader, Read, Write};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
@@ -11,11 +11,13 @@ use et_core::packet::Packet;
 use et_core::proto::{
     TermInit, TerminalBuffer, TerminalInfo, TerminalPacketType, TerminalUserInfo,
 };
-use et_net::local_packet::{read_local_packet, write_local_packet};
+use et_net::local_packet::{
+    parse_status, read_local_packet, status_packet, write_local_packet, REGISTRATION_STATUS,
+    STARTUP_STATUS,
+};
 use prost::Message;
 use terminal_runtime_support::{
-    collect_until, contains, read_line_timeout, write_credentials, Fixture, LOGIN_COLOR_MARKER,
-    NON_LOGIN_MARKER,
+    collect_until, contains, write_credentials, Fixture, LOGIN_COLOR_MARKER, NON_LOGIN_MARKER,
 };
 use wait_timeout::ChildExt;
 
@@ -37,8 +39,20 @@ fn bootstrap_parent_reports_marker_and_leaves_registered_session_running() {
         registration.header(),
         TerminalPacketType::TerminalUserInfo as u8
     );
+    let (marker_tx, marker_rx) = std::sync::mpsc::sync_channel(1);
+    let stdout = parent.stdout.take().unwrap();
+    std::thread::spawn(move || {
+        let mut line = String::new();
+        let result = BufReader::new(stdout).read_line(&mut line).map(|_| line);
+        let _ = marker_tx.send(result);
+    });
+    assert!(matches!(
+        marker_rx.try_recv(),
+        Err(std::sync::mpsc::TryRecvError::Empty)
+    ));
+    acknowledge_registration(&mut router);
     assert_eq!(
-        read_line_timeout(parent.stdout.take().unwrap()),
+        marker_rx.recv_timeout(TIMEOUT).unwrap().unwrap(),
         format!("IDPASSKEY:{ID}/{KEY}\n")
     );
     assert!(parent.wait_timeout(TIMEOUT).unwrap().unwrap().success());
@@ -50,6 +64,7 @@ fn bootstrap_parent_reports_marker_and_leaves_registered_session_running() {
             environmentvalues: Vec::new(),
         },
     );
+    expect_startup(&mut router);
     send(
         &mut router,
         TerminalPacketType::TerminalBuffer,
@@ -72,6 +87,50 @@ fn bootstrap_parent_reports_marker_and_leaves_registered_session_running() {
     }
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn detached_terminal_is_session_leader_and_closes_inherited_descriptors() {
+    use nix::fcntl::{fcntl, FcntlArg, FdFlag};
+    use nix::sys::socket::{getsockopt, sockopt::PeerCredentials};
+
+    let sentinel_path = std::env::temp_dir().join(format!(
+        "et-rs-inherited-fd-sentinel-{}",
+        std::process::id()
+    ));
+    let sentinel = std::fs::File::create(&sentinel_path).unwrap();
+    fcntl(&sentinel, FcntlArg::F_SETFD(FdFlag::empty())).unwrap();
+
+    let fixture = Fixture::new("session-leader");
+    let mut parent = fixture.spawn_parent();
+    write_credentials(&mut parent);
+    let (mut router, _) = fixture.listener.accept().unwrap();
+    let credentials = getsockopt(&router, PeerCredentials).unwrap();
+    let pid = credentials.pid();
+    let _registration = read_local_packet(&mut router).unwrap();
+    acknowledge_registration(&mut router);
+    assert!(parent.wait_timeout(TIMEOUT).unwrap().unwrap().success());
+
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).unwrap();
+    let fields: Vec<_> = stat[stat.rfind(')').unwrap() + 2..]
+        .split_whitespace()
+        .collect();
+    let session: i32 = fields[3].parse().unwrap();
+    assert_eq!(session, pid, "detached terminal must satisfy sid == pid");
+    let inherited = std::fs::read_dir(format!("/proc/{pid}/fd"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter_map(|entry| std::fs::read_link(entry.path()).ok())
+        .any(|target| target == sentinel_path);
+    assert!(
+        !inherited,
+        "detached terminal inherited sentinel descriptor"
+    );
+
+    drop(router);
+    drop(sentinel);
+    let _ = std::fs::remove_file(sentinel_path);
+}
+
 #[test]
 fn real_terminal_registers_runs_shell_and_resizes_pty() {
     let fixture = Fixture::new("shell");
@@ -80,6 +139,7 @@ fn real_terminal_registers_runs_shell_and_resizes_pty() {
     let (mut router, _) = fixture.listener.accept().unwrap();
     router.set_read_timeout(Some(TIMEOUT)).unwrap();
     let registration = read_local_packet(&mut router).unwrap();
+    acknowledge_registration(&mut router);
     assert_eq!(
         registration.header(),
         TerminalPacketType::TerminalUserInfo as u8
@@ -97,6 +157,7 @@ fn real_terminal_registers_runs_shell_and_resizes_pty() {
             environmentvalues: vec!["literal-value".to_owned()],
         },
     );
+    expect_startup(&mut router);
     send(
         &mut router,
         TerminalPacketType::TerminalInfo,
@@ -159,24 +220,31 @@ fn malformed_credentials_fail_before_router_connection() {
 fn bootstrap_parent_reports_terminal_child_startup_failure() {
     let missing_router =
         std::env::temp_dir().join(format!("et-rs-missing-router-{}", std::process::id()));
-    let output = Command::new(env!("CARGO_BIN_EXE_et"))
+    let mut child = Command::new(env!("CARGO_BIN_EXE_et"))
         .args(["terminal", "--serverfifo"])
         .arg(&missing_router)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .and_then(|mut child| {
-            writeln!(child.stdin.take().unwrap(), "{ID}/{KEY}_xterm-256color")?;
-            child.wait_with_output()
-        })
+        .unwrap();
+    writeln!(child.stdin.take().unwrap(), "{ID}/{KEY}_xterm-256color").unwrap();
+    let status = child
+        .wait_timeout(TIMEOUT)
+        .unwrap()
+        .expect("terminal bootstrap did not exit within its bounded test deadline");
+    let mut stderr = String::new();
+    child
+        .stderr
+        .take()
+        .unwrap()
+        .read_to_string(&mut stderr)
         .unwrap();
 
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(status.code(), Some(2));
     assert!(
-        String::from_utf8_lossy(&output.stderr).contains("could not connect terminal router"),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
+        stderr.contains("could not connect terminal router"),
+        "{stderr}"
     );
 }
 
@@ -187,6 +255,7 @@ fn router_disconnect_terminates_the_shell() {
     write_credentials(&mut child);
     let (mut router, _) = fixture.listener.accept().unwrap();
     let _ = read_local_packet(&mut router).unwrap();
+    acknowledge_registration(&mut router);
     fixture.wait_ready();
     send(
         &mut router,
@@ -196,6 +265,7 @@ fn router_disconnect_terminates_the_shell() {
             environmentvalues: Vec::new(),
         },
     );
+    expect_startup(&mut router);
     drop(router);
     let status = child.wait_timeout(TIMEOUT).unwrap().unwrap();
     assert!(!status.success());
@@ -210,6 +280,7 @@ fn real_terminal_starts_login_shell_and_loads_profile_color() {
     let (mut router, _) = fixture.listener.accept().unwrap();
     router.set_read_timeout(Some(TIMEOUT)).unwrap();
     let _ = read_local_packet(&mut router).unwrap();
+    acknowledge_registration(&mut router);
     fixture.wait_ready();
     send(
         &mut router,
@@ -219,6 +290,7 @@ fn real_terminal_starts_login_shell_and_loads_profile_color() {
             environmentvalues: Vec::new(),
         },
     );
+    expect_startup(&mut router);
     send(
         &mut router,
         TerminalPacketType::TerminalBuffer,
@@ -252,6 +324,7 @@ fn real_terminal_login_shell_preserves_term_without_colorterm() {
     let (mut router, _) = fixture.listener.accept().unwrap();
     router.set_read_timeout(Some(TIMEOUT)).unwrap();
     let _ = read_local_packet(&mut router).unwrap();
+    acknowledge_registration(&mut router);
     fixture.wait_ready();
     send(
         &mut router,
@@ -261,6 +334,7 @@ fn real_terminal_login_shell_preserves_term_without_colorterm() {
             environmentvalues: Vec::new(),
         },
     );
+    expect_startup(&mut router);
     send(
         &mut router,
         TerminalPacketType::TerminalBuffer,
@@ -415,6 +489,15 @@ fn count(output: &[u8], marker: &[u8]) -> usize {
         .windows(marker.len())
         .filter(|window| *window == marker)
         .count()
+}
+
+fn acknowledge_registration(router: &mut impl Write) {
+    write_local_packet(router, &status_packet(REGISTRATION_STATUS, Ok(()))).unwrap();
+}
+
+fn expect_startup(router: &mut impl std::io::Read) {
+    let packet = read_local_packet(router).unwrap();
+    parse_status(&packet, STARTUP_STATUS).unwrap();
 }
 
 fn send<M: Message>(router: &mut impl Write, kind: TerminalPacketType, message: &M) {

--- a/crates/et-bin/tests/terminal_runtime.rs
+++ b/crates/et-bin/tests/terminal_runtime.rs
@@ -32,7 +32,7 @@ fn bootstrap_parent_reports_marker_and_leaves_registered_session_running() {
     let fixture = Fixture::new("bootstrap-parent");
     let mut parent = fixture.spawn_parent();
     write_credentials(&mut parent);
-    let (mut router, _) = fixture.listener.accept().unwrap();
+    let mut router = fixture.accept();
     router.set_read_timeout(Some(TIMEOUT)).unwrap();
     let registration = read_local_packet(&mut router).unwrap();
     assert_eq!(
@@ -87,6 +87,33 @@ fn bootstrap_parent_reports_marker_and_leaves_registered_session_running() {
     }
 }
 
+#[test]
+fn registration_delayed_beyond_ten_seconds_still_completes_before_absolute_deadline() {
+    let fixture = Fixture::new("delayed-registration");
+    let mut parent = fixture.spawn_parent();
+    write_credentials(&mut parent);
+    let mut router = fixture.accept();
+    let _registration = read_local_packet(&mut router).unwrap();
+    let (marker_tx, marker_rx) = std::sync::mpsc::sync_channel(1);
+    let stdout = parent.stdout.take().unwrap();
+    std::thread::spawn(move || {
+        let mut line = String::new();
+        let result = BufReader::new(stdout).read_line(&mut line).map(|_| line);
+        let _ = marker_tx.send(result);
+    });
+    assert!(matches!(
+        marker_rx.recv_timeout(Duration::from_secs(11)),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+    ));
+    acknowledge_registration(&mut router);
+    assert_eq!(
+        marker_rx.recv_timeout(TIMEOUT).unwrap().unwrap(),
+        format!("IDPASSKEY:{ID}/{KEY}\n")
+    );
+    assert!(parent.wait_timeout(TIMEOUT).unwrap().unwrap().success());
+    drop(router);
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn detached_terminal_is_session_leader_and_closes_inherited_descriptors() {
@@ -103,7 +130,7 @@ fn detached_terminal_is_session_leader_and_closes_inherited_descriptors() {
     let fixture = Fixture::new("session-leader");
     let mut parent = fixture.spawn_parent();
     write_credentials(&mut parent);
-    let (mut router, _) = fixture.listener.accept().unwrap();
+    let mut router = fixture.accept();
     let credentials = getsockopt(&router, PeerCredentials).unwrap();
     let pid = credentials.pid();
     let _registration = read_local_packet(&mut router).unwrap();
@@ -132,11 +159,42 @@ fn detached_terminal_is_session_leader_and_closes_inherited_descriptors() {
 }
 
 #[test]
+fn new_terminal_uses_legacy_sequence_with_old_router() {
+    let fixture = Fixture::new_legacy("old-router-new-terminal");
+    let mut child = fixture.spawn();
+    write_credentials(&mut child);
+    let mut router = fixture.accept();
+    router.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let registration = read_local_packet(&mut router).unwrap();
+    let user = TerminalUserInfo::decode(registration.payload()).unwrap();
+    assert_eq!(user.fd, None);
+    fixture.wait_ready();
+    send(
+        &mut router,
+        TerminalPacketType::TerminalInit,
+        &TermInit {
+            environmentnames: Vec::new(),
+            environmentvalues: Vec::new(),
+        },
+    );
+    send(
+        &mut router,
+        TerminalPacketType::TerminalBuffer,
+        &TerminalBuffer {
+            buffer: Some(b"printf 'MIXED-OLD-ROUTER\\n'; exit\n".to_vec()),
+        },
+    );
+    let output = collect_until(&mut router, |output| contains(output, b"MIXED-OLD-ROUTER"));
+    assert!(contains(&output, b"MIXED-OLD-ROUTER"));
+    assert!(child.wait_timeout(TIMEOUT).unwrap().unwrap().success());
+}
+
+#[test]
 fn real_terminal_registers_runs_shell_and_resizes_pty() {
     let fixture = Fixture::new("shell");
     let mut child = fixture.spawn();
     write_credentials(&mut child);
-    let (mut router, _) = fixture.listener.accept().unwrap();
+    let mut router = fixture.accept();
     router.set_read_timeout(Some(TIMEOUT)).unwrap();
     let registration = read_local_packet(&mut router).unwrap();
     acknowledge_registration(&mut router);
@@ -253,7 +311,7 @@ fn router_disconnect_terminates_the_shell() {
     let fixture = Fixture::new("disconnect");
     let mut child = fixture.spawn();
     write_credentials(&mut child);
-    let (mut router, _) = fixture.listener.accept().unwrap();
+    let mut router = fixture.accept();
     let _ = read_local_packet(&mut router).unwrap();
     acknowledge_registration(&mut router);
     fixture.wait_ready();
@@ -277,7 +335,7 @@ fn real_terminal_starts_login_shell_and_loads_profile_color() {
     let shell = fixture.login_probe_shell();
     let mut child = fixture.spawn_with_shell(shell.to_str().unwrap());
     write_credentials(&mut child);
-    let (mut router, _) = fixture.listener.accept().unwrap();
+    let mut router = fixture.accept();
     router.set_read_timeout(Some(TIMEOUT)).unwrap();
     let _ = read_local_packet(&mut router).unwrap();
     acknowledge_registration(&mut router);
@@ -321,7 +379,7 @@ fn real_terminal_login_shell_preserves_term_without_colorterm() {
     let shell = fixture.login_probe_shell();
     let mut child = fixture.spawn_with_shell(shell.to_str().unwrap());
     write_credentials(&mut child);
-    let (mut router, _) = fixture.listener.accept().unwrap();
+    let mut router = fixture.accept();
     router.set_read_timeout(Some(TIMEOUT)).unwrap();
     let _ = read_local_packet(&mut router).unwrap();
     acknowledge_registration(&mut router);

--- a/crates/et-bin/tests/terminal_runtime.rs
+++ b/crates/et-bin/tests/terminal_runtime.rs
@@ -255,6 +255,60 @@ fn real_terminal_registers_runs_shell_and_resizes_pty() {
 }
 
 #[test]
+fn pty_output_backpressure_longer_than_two_seconds_preserves_session_and_order() {
+    let fixture = Fixture::new("pty-backpressure");
+    let mut child = fixture.spawn();
+    write_credentials(&mut child);
+    let mut router = fixture.accept();
+    router.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let _registration = read_local_packet(&mut router).unwrap();
+    acknowledge_registration(&mut router);
+    fixture.wait_ready();
+    send(
+        &mut router,
+        TerminalPacketType::TerminalInit,
+        &TermInit {
+            environmentnames: Vec::new(),
+            environmentvalues: Vec::new(),
+        },
+    );
+    expect_startup(&mut router);
+    send(
+        &mut router,
+        TerminalPacketType::TerminalBuffer,
+        &TerminalBuffer {
+            buffer: Some(b"stty -echo; printf 'PTY-BACKPRESSURE-%s\\n' READY\n".to_vec()),
+        },
+    );
+    let _ = collect_until(&mut router, |output| {
+        contains(output, b"PTY-BACKPRESSURE-READY")
+    });
+    send(
+        &mut router,
+        TerminalPacketType::TerminalBuffer,
+        &TerminalBuffer {
+            buffer: Some(
+                b"head -c 1048576 /dev/zero | tr '\\000' x; printf 'PTY-BACKPRESSURE-%s\\n' MARKER; exit\n"
+                    .to_vec(),
+            ),
+        },
+    );
+
+    assert!(
+        child
+            .wait_timeout(Duration::from_secs(3))
+            .unwrap()
+            .is_none(),
+        "terminal exited instead of backpressuring PTY output"
+    );
+    let output = collect_until(&mut router, |output| {
+        contains(output, b"PTY-BACKPRESSURE-MARKER")
+    });
+    assert!(contains(&output, b"PTY-BACKPRESSURE-MARKER"));
+    assert!(child.wait_timeout(TIMEOUT).unwrap().unwrap().success());
+}
+
+#[test]
 fn malformed_credentials_fail_before_router_connection() {
     let fixture = Fixture::new("bad-credentials");
     let output = Command::new(env!("CARGO_BIN_EXE_et"))
@@ -444,6 +498,7 @@ fn real_terminal_emits_motd_before_login_shell_output() {
     let (mut router, _) = fixture.listener.accept().unwrap();
     router.set_read_timeout(Some(TIMEOUT)).unwrap();
     let _ = read_local_packet(&mut router).unwrap();
+    acknowledge_registration(&mut router);
     fixture.wait_ready();
 
     // When: the session initializes and the login shell starts producing output.
@@ -455,6 +510,7 @@ fn real_terminal_emits_motd_before_login_shell_output() {
             environmentvalues: Vec::new(),
         },
     );
+    expect_startup(&mut router);
     send(
         &mut router,
         TerminalPacketType::TerminalBuffer,
@@ -506,6 +562,7 @@ fn real_terminal_suppresses_motd_when_home_has_hushlogin() {
     let (mut router, _) = fixture.listener.accept().unwrap();
     router.set_read_timeout(Some(TIMEOUT)).unwrap();
     let _ = read_local_packet(&mut router).unwrap();
+    acknowledge_registration(&mut router);
     fixture.wait_ready();
 
     // When: the session runs to the point the login shell has produced output.
@@ -517,6 +574,7 @@ fn real_terminal_suppresses_motd_when_home_has_hushlogin() {
             environmentvalues: Vec::new(),
         },
     );
+    expect_startup(&mut router);
     send(
         &mut router,
         TerminalPacketType::TerminalBuffer,
@@ -555,7 +613,13 @@ fn acknowledge_registration(router: &mut impl Write) {
 
 fn expect_startup(router: &mut impl std::io::Read) {
     let packet = read_local_packet(router).unwrap();
-    parse_status(&packet, STARTUP_STATUS).unwrap();
+    parse_status(&packet, STARTUP_STATUS).unwrap_or_else(|error| {
+        panic!(
+            "expected startup status, got header={} payload={:?}: {error}",
+            packet.header(),
+            packet.payload()
+        )
+    });
 }
 
 fn send<M: Message>(router: &mut impl Write, kind: TerminalPacketType, message: &M) {

--- a/crates/et-bin/tests/terminal_runtime.rs
+++ b/crates/et-bin/tests/terminal_runtime.rs
@@ -156,6 +156,31 @@ fn malformed_credentials_fail_before_router_connection() {
 }
 
 #[test]
+fn bootstrap_parent_reports_terminal_child_startup_failure() {
+    let missing_router =
+        std::env::temp_dir().join(format!("et-rs-missing-router-{}", std::process::id()));
+    let output = Command::new(env!("CARGO_BIN_EXE_et"))
+        .args(["terminal", "--serverfifo"])
+        .arg(&missing_router)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            writeln!(child.stdin.take().unwrap(), "{ID}/{KEY}_xterm-256color")?;
+            child.wait_with_output()
+        })
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("could not connect terminal router"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn router_disconnect_terminates_the_shell() {
     let fixture = Fixture::new("disconnect");
     let mut child = fixture.spawn();

--- a/crates/et-bin/tests/terminal_runtime_support/mod.rs
+++ b/crates/et-bin/tests/terminal_runtime_support/mod.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{Read, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixListener;
 use std::process::{Command, Stdio};
@@ -145,16 +145,6 @@ impl Drop for Fixture {
 pub fn write_credentials(child: &mut std::process::Child) {
     let mut stdin = child.stdin.take().unwrap();
     writeln!(stdin, "{ID}/{KEY}_xterm-256color").unwrap();
-}
-
-pub fn read_line_timeout(stdout: impl std::io::Read + Send + 'static) -> String {
-    let (sender, receiver) = mpsc::sync_channel(1);
-    std::thread::spawn(move || {
-        let mut line = String::new();
-        let result = BufReader::new(stdout).read_line(&mut line).map(|_| line);
-        let _ = sender.send(result);
-    });
-    receiver.recv_timeout(TIMEOUT).unwrap().unwrap()
 }
 
 pub fn contains(output: &[u8], marker: &[u8]) -> bool {

--- a/crates/et-bin/tests/terminal_runtime_support/mod.rs
+++ b/crates/et-bin/tests/terminal_runtime_support/mod.rs
@@ -3,6 +3,7 @@ use std::io::{Read, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixListener;
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
 use std::time::Duration;
 
@@ -13,6 +14,7 @@ use prost::Message;
 const ID: &str = "abcdefghijklmnop";
 const KEY: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef";
 const TIMEOUT: Duration = Duration::from_secs(5);
+static FIXTURE_GENERATION: AtomicUsize = AtomicUsize::new(0);
 
 pub const LOGIN_COLOR_MARKER: &[u8] = b"\x1b[31mET-LOGIN-COLOR\x1b[0m";
 pub const NON_LOGIN_MARKER: &[u8] = b"ET-NON-LOGIN";
@@ -34,18 +36,19 @@ impl Fixture {
         Self::new_with_ack(label, false)
     }
 
-    fn new_with_ack(label: &str, registration_ack: bool) -> Self {
+    fn new_with_ack(_label: &str, registration_ack: bool) -> Self {
+        let generation = FIXTURE_GENERATION.fetch_add(1, Ordering::Relaxed);
         let directory =
-            std::env::temp_dir().join(format!("et-rs-terminal-{label}-{}", std::process::id()));
+            std::env::temp_dir().join(format!("etr{:x}{generation:x}", std::process::id()));
         let _ = fs::remove_dir_all(&directory);
         fs::create_dir(&directory).unwrap();
         fs::set_permissions(&directory, fs::Permissions::from_mode(0o700)).unwrap();
-        let socket = directory.join("router.sock");
+        let socket = directory.join("r");
         let listener = UnixListener::bind(&socket).unwrap();
         if registration_ack {
             et_net::local::write_registration_ack_capability(&socket).unwrap();
         }
-        let ready_socket = directory.join("ready.sock");
+        let ready_socket = directory.join("a");
         let ready_listener = UnixListener::bind(&ready_socket).unwrap();
         Self {
             directory,

--- a/crates/et-bin/tests/terminal_runtime_support/mod.rs
+++ b/crates/et-bin/tests/terminal_runtime_support/mod.rs
@@ -27,6 +27,14 @@ pub struct Fixture {
 
 impl Fixture {
     pub fn new(label: &str) -> Self {
+        Self::new_with_ack(label, true)
+    }
+
+    pub fn new_legacy(label: &str) -> Self {
+        Self::new_with_ack(label, false)
+    }
+
+    fn new_with_ack(label: &str, registration_ack: bool) -> Self {
         let directory =
             std::env::temp_dir().join(format!("et-rs-terminal-{label}-{}", std::process::id()));
         let _ = fs::remove_dir_all(&directory);
@@ -34,6 +42,9 @@ impl Fixture {
         fs::set_permissions(&directory, fs::Permissions::from_mode(0o700)).unwrap();
         let socket = directory.join("router.sock");
         let listener = UnixListener::bind(&socket).unwrap();
+        if registration_ack {
+            et_net::local::write_registration_ack_capability(&socket).unwrap();
+        }
         let ready_socket = directory.join("ready.sock");
         let ready_listener = UnixListener::bind(&ready_socket).unwrap();
         Self {
@@ -43,6 +54,21 @@ impl Fixture {
             ready_socket,
             ready_listener,
         }
+    }
+
+    pub fn accept(&self) -> std::os::unix::net::UnixStream {
+        let listener = self.listener.try_clone().unwrap();
+        let (sender, receiver) = mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            let _ = sender.send(listener.accept().map(|(stream, _)| stream));
+        });
+        let stream = receiver
+            .recv_timeout(TIMEOUT)
+            .expect("timed out waiting for terminal router connection")
+            .unwrap();
+        stream.set_read_timeout(Some(TIMEOUT)).unwrap();
+        stream.set_write_timeout(Some(TIMEOUT)).unwrap();
+        stream
     }
 
     pub fn spawn(&self) -> std::process::Child {

--- a/crates/et-bin/tests/terminal_signal_resilience.rs
+++ b/crates/et-bin/tests/terminal_signal_resilience.rs
@@ -1,28 +1,35 @@
 //! Regression test: signals delivered while the client blocks in poll() must
-//! not kill the session.
-//!
-//! The client installs a process-wide SIGWINCH handler for terminal resizes.
-//! poll() is never auto-restarted by SA_RESTART, so any SIGWINCH landing on
-//! the thread blocked in poll() makes it fail with EINTR. The client used to
-//! treat that as fatal and died with:
-//!
-//!   et: polling terminal streams: Interrupted system call (os error 4)
+//! not kill or strand the session.
 #![forbid(unsafe_code)]
 #![cfg(unix)]
 
-use std::fs;
-use std::io::{BufRead, BufReader, Read};
+use std::fs::{self, OpenOptions};
+use std::io::{self, BufRead, BufReader, Read, Write};
 use std::net::{Ipv4Addr, TcpListener};
 use std::os::unix::fs::{symlink, PermissionsExt};
-use std::process::{Command, Stdio};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::mpsc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use nix::sys::signal::{kill, Signal};
 use nix::unistd::Pid;
 use wait_timeout::ChildExt;
 
-const TIMEOUT: Duration = Duration::from_secs(20);
+const WATCHDOG: Duration = Duration::from_secs(20);
+const SIGNAL_COUNT: usize = 128;
+const MARKER: &str = "SIGWINCH-SURVIVED";
+
+enum OutputEvent {
+    Line(String),
+    Done(io::Result<String>),
+}
+
+struct ClientObservation {
+    status: ExitStatus,
+    stdout: String,
+    stderr: String,
+}
 
 #[test]
 fn client_survives_sigwinch_storm_while_polling() {
@@ -33,7 +40,19 @@ fn client_survives_sigwinch_storm_while_polling() {
     fs::set_permissions(&directory, fs::Permissions::from_mode(0o700)).unwrap();
     let router = directory.join("router.sock");
     let config = directory.join("et.cfg");
-    let ready = directory.join("session-ready");
+    let pump_probe = directory.join("pump-probe.sock");
+    let release = directory.join("remote-release");
+    let remote_ready = directory.join("remote-ready");
+    let probe_listener = UnixListener::bind(&pump_probe).unwrap();
+    for fifo in [&release, &remote_ready] {
+        assert!(Command::new("mkfifo").arg(fifo).status().unwrap().success());
+    }
+    let remote_ready_control = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&remote_ready)
+        .unwrap();
+
     let reserved = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let port = reserved.local_addr().unwrap().port();
     drop(reserved);
@@ -71,84 +90,256 @@ fn client_survives_sigwinch_storm_while_polling() {
     symlink(env!("CARGO_BIN_EXE_et"), &terminal).unwrap();
     let existing_path = std::env::var("PATH").unwrap();
 
-    // Keep the session alive long enough for the storm, then print a marker.
-    let mut client = Command::new(env!("CARGO_BIN_EXE_et"))
+    let client = Command::new(env!("CARGO_BIN_EXE_et"))
         .env("PATH", format!("{}:{existing_path}", directory.display()))
         .env("TERM", "xterm-256color")
-        .env("ET_SSH_READY", &ready)
+        .env("ET_PUMP_PROBE", &pump_probe)
         .args(["--terminal-path"])
         .arg(&terminal)
         .args(["--serverfifo"])
         .arg(&router)
         .arg("-p")
         .arg(port.to_string())
-        .args(["-c", "sleep 2; printf 'SIGWINCH-SURVIVED\\n'", "127.0.0.1"])
+        .arg("-c")
+        .arg(format!(
+            "printf x > '{}'; read _ < '{}'; printf 'SIGWINCH-%s\\n' SURVIVED",
+            remote_ready.display(),
+            release.display()
+        ))
+        .arg("127.0.0.1")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .unwrap();
 
-    // Wait until the client's pump loop is live (it writes the gate file).
-    let gate_deadline = Instant::now() + TIMEOUT;
-    while !ready.exists() {
-        assert!(
-            Instant::now() < gate_deadline,
-            "client never reached the terminal loop"
-        );
-        std::thread::sleep(Duration::from_millis(10));
-    }
+    let result = exercise_client(client, probe_listener, remote_ready_control, release);
+    terminate_server(&mut server);
+    fs::remove_dir_all(&directory).unwrap();
 
-    // Storm the client with SIGWINCH while it blocks in poll() waiting for
-    // server output. Any one of these interrupts poll() with EINTR.
-    let client_pid = Pid::from_raw(i32::try_from(client.id()).unwrap());
-    let storm_deadline = Instant::now() + Duration::from_millis(1_500);
-    while Instant::now() < storm_deadline {
-        if kill(client_pid, Signal::SIGWINCH).is_err() {
-            break; // client already exited; the assertions below explain why
-        }
-        std::thread::sleep(Duration::from_millis(5));
-    }
-
-    let status = match client.wait_timeout(TIMEOUT).unwrap() {
-        Some(status) => status,
-        None => {
-            let _ = client.kill();
-            let _ = client.wait();
-            panic!("client did not exit after the signal storm");
-        }
-    };
-    let mut stdout_text = String::new();
-    let mut stderr_text = String::new();
-    client
-        .stdout
-        .take()
-        .unwrap()
-        .read_to_string(&mut stdout_text)
-        .unwrap();
-    client
-        .stderr
-        .take()
-        .unwrap()
-        .read_to_string(&mut stderr_text)
-        .unwrap();
+    let observation = result.unwrap_or_else(|error| panic!("{error}"));
     assert!(
-        !stderr_text.contains("Interrupted system call"),
-        "client died from EINTR: {stderr_text}"
+        !observation.stderr.contains("Interrupted system call"),
+        "client died from EINTR: {}",
+        observation.stderr
     );
-    assert!(status.success(), "{stderr_text}");
+    assert!(observation.status.success(), "{}", observation.stderr);
     assert!(
-        stdout_text.contains("SIGWINCH-SURVIVED"),
-        "{stdout_text:?} {stderr_text:?}"
+        observation.stdout.contains(MARKER),
+        "{:?} {:?}",
+        observation.stdout,
+        observation.stderr
     );
-
-    let server_pid = Pid::from_raw(i32::try_from(server.id()).unwrap());
-    kill(server_pid, Signal::SIGTERM).unwrap();
-    assert!(server.wait_timeout(TIMEOUT).unwrap().unwrap().success());
-    fs::remove_dir_all(directory).unwrap();
 }
 
-fn wait_ready(server: &mut std::process::Child, port: u16, router: &std::path::Path) {
+fn exercise_client(
+    mut client: Child,
+    probe_listener: UnixListener,
+    mut remote_ready: fs::File,
+    release_path: std::path::PathBuf,
+) -> Result<ClientObservation, String> {
+    let pid = Pid::from_raw(i32::try_from(client.id()).unwrap());
+    let stdout = client.stdout.take().unwrap();
+    let stderr = client.stderr.take().unwrap();
+    let (output_tx, output_rx) = mpsc::sync_channel(64);
+    std::thread::spawn(move || read_stdout(stdout, output_tx));
+    let (stderr_tx, stderr_rx) = mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let mut stderr = stderr;
+        let mut text = String::new();
+        let result = stderr.read_to_string(&mut text).map(|_| text);
+        let _ = stderr_tx.send(result);
+    });
+    let (exit_tx, exit_rx) = mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let _ = exit_tx.send(client.wait());
+    });
+    let (accept_tx, accept_rx) = mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let _ = accept_tx.send(probe_listener.accept().map(|(stream, _)| stream));
+    });
+
+    let mut failure = None;
+    let mut probe = match accept_rx.recv_timeout(WATCHDOG) {
+        Ok(Ok(stream)) => Some(stream),
+        Ok(Err(error)) => {
+            failure = Some(format!("client pump probe accept failed: {error}"));
+            None
+        }
+        Err(error) => {
+            failure = Some(format!("client never connected its pump probe: {error}"));
+            None
+        }
+    };
+    if let Some(stream) = probe.as_mut() {
+        stream.set_read_timeout(Some(WATCHDOG)).unwrap();
+        stream.set_write_timeout(Some(WATCHDOG)).unwrap();
+        if let Err(error) = expect_probe(stream, b'R') {
+            failure = Some(format!("client never reported pump readiness: {error}"));
+        } else if let Err(error) = stream.write_all(b"G") {
+            failure = Some(format!("could not release the armed pump gate: {error}"));
+        }
+    }
+
+    let (remote_ready_tx, remote_ready_rx) = mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let mut byte = [0_u8; 1];
+        let result = remote_ready.read_exact(&mut byte);
+        let _ = remote_ready_tx.send(result);
+    });
+    if let Err(error) = remote_ready_rx.recv_timeout(WATCHDOG) {
+        failure.get_or_insert_with(|| format!("remote command never armed its release: {error}"));
+    }
+
+    if failure.is_none() {
+        let stream = probe.as_mut().expect("probe established without failure");
+        for delivered in 0..SIGNAL_COUNT {
+            if let Err(error) = expect_probe(stream, b'A') {
+                failure = Some(format!(
+                    "client stopped arming poll after {delivered} signals: {error}"
+                ));
+                break;
+            }
+            if let Err(error) = kill(pid, Signal::SIGWINCH) {
+                failure = Some(format!(
+                    "client exited while delivering signal {delivered}: {error}"
+                ));
+                break;
+            }
+            if let Err(error) = expect_probe(stream, b'P') {
+                failure = Some(format!(
+                    "client made no pump progress after signal {delivered}: {error}"
+                ));
+                break;
+            }
+        }
+    }
+
+    // The remote command is released only after every acknowledged signal.
+    let (release_tx, release_rx) = mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let result = OpenOptions::new()
+            .write(true)
+            .open(release_path)
+            .and_then(|mut release| release.write_all(b"go\n"));
+        let _ = release_tx.send(result);
+    });
+    match release_rx.recv_timeout(WATCHDOG) {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+            failure.get_or_insert_with(|| format!("could not release remote command: {error}"));
+        }
+        Err(error) => {
+            failure.get_or_insert_with(|| format!("remote release writer stalled: {error}"));
+        }
+    }
+
+    let mut stdout_done = None;
+    let mut marker_seen = false;
+    while stdout_done.is_none() {
+        match output_rx.recv_timeout(WATCHDOG) {
+            Ok(OutputEvent::Line(line)) => marker_seen |= line.contains(MARKER),
+            Ok(OutputEvent::Done(result)) => stdout_done = Some(result),
+            Err(error) => {
+                failure.get_or_insert_with(|| format!("client output stalled: {error}"));
+                break;
+            }
+        }
+    }
+    if !marker_seen {
+        failure
+            .get_or_insert_with(|| "remote marker was not observed before client EOF".to_owned());
+    }
+
+    let status = match exit_rx.recv_timeout(WATCHDOG) {
+        Ok(Ok(status)) => Some(status),
+        Ok(Err(error)) => {
+            failure.get_or_insert_with(|| format!("waiting for client failed: {error}"));
+            None
+        }
+        Err(_) => {
+            let _ = kill(pid, Signal::SIGKILL);
+            let reaped = exit_rx.recv_timeout(WATCHDOG);
+            failure.get_or_insert_with(|| {
+                format!("client product hang after marker/exit trigger; cleanup={reaped:?}")
+            });
+            reaped.ok().and_then(Result::ok)
+        }
+    };
+    let stdout = stdout_done
+        .and_then(Result::ok)
+        .unwrap_or_else(|| "<stdout unavailable>".to_owned());
+    let stderr = stderr_rx
+        .recv_timeout(WATCHDOG)
+        .ok()
+        .and_then(Result::ok)
+        .unwrap_or_else(|| "<stderr unavailable>".to_owned());
+
+    if let Some(error) = failure {
+        return Err(format!("{error}; stdout={stdout:?}; stderr={stderr:?}"));
+    }
+    Ok(ClientObservation {
+        status: status.expect("successful observation has an exit status"),
+        stdout,
+        stderr,
+    })
+}
+
+fn read_stdout(stdout: impl Read, sender: mpsc::SyncSender<OutputEvent>) {
+    let mut reader = BufReader::new(stdout);
+    let mut complete = String::new();
+    loop {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => {
+                let _ = sender.send(OutputEvent::Done(Ok(complete)));
+                return;
+            }
+            Ok(_) => {
+                complete.push_str(&line);
+                if sender.send(OutputEvent::Line(line)).is_err() {
+                    return;
+                }
+            }
+            Err(error) => {
+                let _ = sender.send(OutputEvent::Done(Err(error)));
+                return;
+            }
+        }
+    }
+}
+
+fn expect_probe(stream: &mut UnixStream, expected: u8) -> io::Result<()> {
+    let mut observed = [0_u8; 1];
+    stream.read_exact(&mut observed)?;
+    if observed[0] == expected {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "expected pump event {:?}, received {:?}",
+                char::from(expected),
+                char::from(observed[0])
+            ),
+        ))
+    }
+}
+
+fn terminate_server(server: &mut Child) {
+    let pid = Pid::from_raw(i32::try_from(server.id()).unwrap());
+    let _ = kill(pid, Signal::SIGTERM);
+    match server.wait_timeout(WATCHDOG).unwrap() {
+        Some(status) => assert!(status.success(), "server shutdown failed: {status}"),
+        None => {
+            let _ = kill(pid, Signal::SIGKILL);
+            let _ = server.wait();
+            panic!("server did not terminate after SIGTERM");
+        }
+    }
+}
+
+fn wait_ready(server: &mut Child, port: u16, router: &std::path::Path) {
     let stdout = server.stdout.take().unwrap();
     let (sender, receiver) = mpsc::sync_channel(1);
     std::thread::spawn(move || {
@@ -157,7 +348,7 @@ fn wait_ready(server: &mut std::process::Child, port: u16, router: &std::path::P
         let _ = sender.send(result);
     });
     assert_eq!(
-        receiver.recv_timeout(TIMEOUT).unwrap().unwrap(),
+        receiver.recv_timeout(WATCHDOG).unwrap().unwrap(),
         format!(
             "ETSERVER_READY tcp=127.0.0.1:{port} router={}\n",
             router.display()

--- a/crates/et-bin/tests/tunnels_end_to_end.rs
+++ b/crates/et-bin/tests/tunnels_end_to_end.rs
@@ -66,9 +66,8 @@ fn ssh_config_local_tunnel_relays_while_remote_forward_is_omitted() {
 #[test]
 fn ssh_config_destination_host_reaches_target_not_localhost_decoy() {
     let mut stack = Stack::start();
-    let target = TcpListener::bind((std::net::Ipv4Addr::new(127, 0, 0, 2), 0)).unwrap();
+    let (target, decoy) = reserve_destination_and_decoy().unwrap();
     let target_port = target.local_addr().unwrap().port();
-    let decoy = TcpListener::bind((Ipv4Addr::LOCALHOST, target_port)).unwrap();
     decoy.set_nonblocking(true).unwrap();
     let target_echo = spawn_tcp_echo_once(target, b"configured-destination");
     let source = stack.directory.join("configured-destination.sock");
@@ -896,6 +895,24 @@ fn reserve_port() -> u16 {
         .local_addr()
         .unwrap()
         .port()
+}
+
+fn reserve_destination_and_decoy() -> std::io::Result<(TcpListener, TcpListener)> {
+    const MAX_ATTEMPTS: usize = 128;
+    let target_address = Ipv4Addr::new(127, 0, 0, 2);
+    for _ in 0..MAX_ATTEMPTS {
+        let target = TcpListener::bind((target_address, 0))?;
+        let port = target.local_addr()?.port();
+        match TcpListener::bind((Ipv4Addr::LOCALHOST, port)) {
+            Ok(decoy) => return Ok((target, decoy)),
+            Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AddrInUse,
+        format!("could not reserve paired loopback listeners after {MAX_ATTEMPTS} attempts"),
+    ))
 }
 
 fn await_fifo(path: &std::path::Path, child: &mut Child) -> String {

--- a/crates/et-bin/tests/tunnels_end_to_end.rs
+++ b/crates/et-bin/tests/tunnels_end_to_end.rs
@@ -16,7 +16,9 @@ use reconnect_stack::{mkfifo, shell_quote, Stack};
 use tunnel_support::SingleCutProxy;
 use wait_timeout::ChildExt;
 
-const TIMEOUT: Duration = Duration::from_secs(10);
+// Process creation can legitimately exceed ten seconds under the load this
+// suite exercises; every wait remains bounded by the exact FIFO/process event.
+const TIMEOUT: Duration = Duration::from_secs(30);
 
 #[test]
 fn ssh_config_local_tunnel_relays_while_remote_forward_is_omitted() {

--- a/crates/et-net/Cargo.toml
+++ b/crates/et-net/Cargo.toml
@@ -16,6 +16,7 @@ et-core = { path = "../et-core" }
 prost = "0.13"
 rustix = { version = "1.1.4", features = ["event"] }
 socket2 = "0.6.1"
+wait-timeout = "0.2"
 
 [target.'cfg(unix)'.dependencies]
 privdrop = "0.5.6"

--- a/crates/et-net/src/connection.rs
+++ b/crates/et-net/src/connection.rs
@@ -185,6 +185,10 @@ impl Connection {
         }
     }
 
+    pub fn read_packet_deadline(&mut self, deadline: Instant) -> Result<Packet, ConnError> {
+        self.read_packet_until(deadline)
+    }
+
     pub fn read_packet_until(&mut self, deadline: Instant) -> Result<Packet, ConnError> {
         loop {
             match self.reader.pop() {

--- a/crates/et-net/src/forward.rs
+++ b/crates/et-net/src/forward.rs
@@ -988,11 +988,12 @@ mod tests {
     fn shutdown_and_drop_ignore_a_full_non_emitting_command_queue() {
         for drop_only in [false, true] {
             let directory = std::env::temp_dir().join(format!(
-                "et-forward-stale-close-shutdown-{}-{drop_only}",
-                std::process::id()
+                "ef{}{}",
+                std::process::id(),
+                u8::from(drop_only)
             ));
             std::fs::create_dir_all(&directory).unwrap();
-            let path = directory.join("listener.sock");
+            let path = directory.join("s");
             let request = PortForwardSourceRequest {
                 source: Some(SocketEndpoint {
                     name: Some(path.to_string_lossy().into_owned()),

--- a/crates/et-net/src/forward.rs
+++ b/crates/et-net/src/forward.rs
@@ -127,6 +127,22 @@ impl ResolverExecutor {
         port: u16,
         deadline: Instant,
     ) -> io::Result<Vec<std::net::SocketAddr>> {
+        self.resolve_with_observers(resolver, host, port, deadline, |_| {}, |_| {})
+    }
+
+    fn resolve_with_observers<F, G>(
+        &self,
+        resolver: Arc<dyn ForwardResolver>,
+        host: String,
+        port: u16,
+        deadline: Instant,
+        observe_wait: F,
+        observe_result: G,
+    ) -> io::Result<Vec<std::net::SocketAddr>>
+    where
+        F: FnOnce(Duration),
+        G: FnOnce(&io::Result<Vec<std::net::SocketAddr>>),
+    {
         deadline
             .checked_duration_since(Instant::now())
             .ok_or_else(|| {
@@ -185,6 +201,7 @@ impl ResolverExecutor {
                     "forwarding resolution deadline elapsed",
                 )
             })?;
+        observe_wait(remaining);
         let result = match receiver.recv_timeout(remaining) {
             Ok(_) if Instant::now() >= deadline => Err(io::Error::new(
                 io::ErrorKind::TimedOut,
@@ -199,6 +216,7 @@ impl ResolverExecutor {
                 "forwarding resolver terminated unexpectedly",
             )),
         };
+        observe_result(&result);
         cancelled.store(true, Ordering::Release);
         self.queue.changed.notify_all();
         result
@@ -776,6 +794,7 @@ mod tests {
 
     struct GatedResolver {
         started: mpsc::SyncSender<()>,
+        completed: Option<mpsc::SyncSender<()>>,
         gate: Arc<(Mutex<bool>, Condvar)>,
     }
 
@@ -786,6 +805,9 @@ mod tests {
             let mut released = released.lock().unwrap();
             while !*released {
                 released = changed.wait(released).unwrap();
+            }
+            if let Some(completed) = self.completed.as_ref() {
+                completed.send(()).unwrap();
             }
             Ok(Vec::new())
         }
@@ -806,7 +828,11 @@ mod tests {
             active.push(std::thread::spawn(move || {
                 barrier.wait();
                 executor.resolve(
-                    Arc::new(GatedResolver { started, gate }),
+                    Arc::new(GatedResolver {
+                        started,
+                        completed: None,
+                        gate,
+                    }),
                     format!("active-{index}"),
                     1,
                     Instant::now() + Duration::from_secs(10),
@@ -844,20 +870,30 @@ mod tests {
         let target_deadline = target_start + Duration::from_secs(3);
         let target_gate = Arc::new((Mutex::new(false), Condvar::new()));
         let (target_started_tx, target_started_rx) = mpsc::sync_channel(1);
+        let (target_completed_tx, target_completed_rx) = mpsc::sync_channel(1);
+        let (target_wait_tx, target_wait_rx) = mpsc::sync_channel(1);
+        let (target_decision_tx, target_decision_rx) = mpsc::sync_channel(1);
         let (target_done_tx, target_done_rx) = mpsc::sync_channel(1);
         let target_executor = executor.clone();
         let target_gate_for_resolver = target_gate.clone();
         let target = std::thread::spawn(move || {
-            let result = target_executor.resolve(
+            let result = target_executor.resolve_with_observers(
                 Arc::new(GatedResolver {
                     started: target_started_tx,
+                    completed: Some(target_completed_tx),
                     gate: target_gate_for_resolver,
                 }),
                 "target".to_owned(),
                 1,
                 target_deadline,
+                |remaining| target_wait_tx.send(remaining).unwrap(),
+                |result| {
+                    target_decision_tx
+                        .send(result.as_ref().map(|_| ()).map_err(io::Error::kind))
+                        .unwrap()
+                },
             );
-            target_done_tx.send((Instant::now(), result)).unwrap();
+            target_done_tx.send(result).unwrap();
         });
 
         assert!(matches!(
@@ -870,25 +906,39 @@ mod tests {
             *released.lock().unwrap() = true;
             changed.notify_all();
         }
+        let target_wait = target_wait_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("target caller did not begin its result wait after admission");
         target_started_rx
             .recv_timeout(Duration::from_secs(1))
             .expect("target resolver did not start after delayed admission");
-        let (completed, result) = target_done_rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("target exceeded its original absolute deadline");
-        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::TimedOut);
-        assert!(completed <= target_deadline + Duration::from_millis(100));
+        let decision = target_decision_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("target caller did not make a bounded timeout decision");
 
         {
             let (released, changed) = &*target_gate;
             *released.lock().unwrap() = true;
             changed.notify_all();
         }
+        target_completed_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("late target callback did not complete after release");
+        let result = target_done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("target caller did not return its timeout decision");
         target.join().unwrap();
         for worker in active {
             worker.join().unwrap().unwrap();
         }
         drop(queued_receivers);
+
+        assert!(
+            target_wait <= target_deadline.duration_since(target_start) - admission_delay,
+            "queue admission extended the caller's result-wait budget"
+        );
+        assert_eq!(decision, Err(io::ErrorKind::TimedOut));
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::TimedOut);
     }
 
     #[cfg(unix)]

--- a/crates/et-net/src/forward.rs
+++ b/crates/et-net/src/forward.rs
@@ -15,12 +15,11 @@ use et_core::proto::{PortForwardSourceRequest, TerminalPacketType};
 use crate::forward_endpoint::{Endpoint, ResolvedEndpoint};
 use crate::forward_io::BoundSource;
 use crate::forward_worker::{run, Command};
-use crate::reverse_report::SkipReason;
 
 const CHANNEL_CAPACITY: usize = 256;
 /// Maximum reverse listeners owned by one terminal session, after DNS fanout
 /// and address deduplication.
-const MAX_SESSION_LISTENERS: usize = 32;
+pub const MAX_SESSION_LISTENERS: usize = 32;
 pub(crate) const RESOLVER_WORKERS: usize = 4;
 pub(crate) const RESOLVER_QUEUE_CAPACITY: usize = 16;
 pub const FORWARD_TIMEOUT_SENTINEL: &str = "\nET_ERR:FORWARD_TIMEOUT";
@@ -255,7 +254,6 @@ pub(crate) type Outbound = Result<Packet, ForwardError>;
 pub enum ForwardOrigin {
     Explicit,
     SshConfig { strict: bool },
-    Reported(usize),
 }
 
 pub struct ForwardSource {
@@ -282,8 +280,6 @@ impl ForwardSource {
 pub struct SkippedForward {
     pub request: PortForwardSourceRequest,
     pub error: io::Error,
-    pub reason: SkipReason,
-    pub report_index: Option<usize>,
 }
 
 pub struct Forwarder {
@@ -366,35 +362,6 @@ impl Forwarder {
         let sources = sources.into_iter().map(ForwardSource::explicit).collect();
         start_forwarder_hook(sources, owner, deadline, resolver, before_publish)
             .map(|(forwarder, environment, _)| (forwarder, environment))
-    }
-
-    pub fn start_with_user_report(
-        sources: Vec<PortForwardSourceRequest>,
-        owner: Option<(u32, u32)>,
-    ) -> Result<(Self, ForwardEnvironment, Vec<SkippedForward>), ForwardError> {
-        Self::start_with_user_report_deadline(
-            sources,
-            owner,
-            Instant::now() + Duration::from_secs(30),
-            Arc::new(SystemForwardResolver),
-        )
-    }
-
-    pub fn start_with_user_report_deadline(
-        sources: Vec<PortForwardSourceRequest>,
-        owner: Option<(u32, u32)>,
-        deadline: Instant,
-        resolver: Arc<dyn ForwardResolver>,
-    ) -> Result<(Self, ForwardEnvironment, Vec<SkippedForward>), ForwardError> {
-        let sources = sources
-            .into_iter()
-            .enumerate()
-            .map(|(index, request)| ForwardSource {
-                request,
-                origin: ForwardOrigin::Reported(index),
-            })
-            .collect();
-        start_forwarder(sources, owner, deadline, resolver)
     }
 }
 
@@ -605,17 +572,6 @@ fn bind_sources(
                     skipped.push(SkippedForward {
                         request: original,
                         error,
-                        reason: SkipReason::Resolve,
-                        report_index: None,
-                    });
-                    continue;
-                }
-                (Err(error), ForwardOrigin::Reported(index)) => {
-                    skipped.push(SkippedForward {
-                        request: original,
-                        error,
-                        reason: SkipReason::Resolve,
-                        report_index: Some(index),
                     });
                     continue;
                 }
@@ -624,20 +580,17 @@ fn bind_sources(
                     ForwardOrigin::Explicit | ForwardOrigin::SshConfig { strict: true },
                 ) => return Err(ForwardError::Io(error)),
             };
-            if owner.is_some() {
-                match &source {
+            if owner.is_some()
+                && matches!(
+                    &source,
                     ResolvedEndpoint::Tcp(addresses)
-                        if addresses.iter().any(|address| !address.ip().is_loopback()) =>
-                    {
-                        return Err(ForwardError::Io(io::Error::new(
-                            io::ErrorKind::PermissionDenied,
-                            "authenticated reverse TCP bind must resolve only to loopback addresses",
-                        )));
-                    }
-                    ResolvedEndpoint::Tcp(_) => {}
-                    #[cfg(unix)]
-                    ResolvedEndpoint::Unix(_) => {}
-                }
+                        if addresses.iter().any(|address| address.ip().is_unspecified())
+                )
+            {
+                return Err(ForwardError::Io(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "authenticated reverse TCP wildcard bind is not permitted",
+                )));
             }
             let listener_count = source.listener_count();
             (
@@ -685,16 +638,6 @@ fn bind_sources(
                     skipped.push(SkippedForward {
                         request: original,
                         error,
-                        reason: SkipReason::Bind,
-                        report_index: None,
-                    });
-                }
-                (Err(error), ForwardOrigin::Reported(index)) => {
-                    skipped.push(SkippedForward {
-                        request: original,
-                        error,
-                        reason: SkipReason::Bind,
-                        report_index: Some(index),
                     });
                 }
                 (

--- a/crates/et-net/src/forward.rs
+++ b/crates/et-net/src/forward.rs
@@ -1,9 +1,11 @@
+use std::collections::VecDeque;
 #[cfg(unix)]
 use std::io::Read;
 use std::io::{self};
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
-use std::sync::mpsc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc, Condvar, Mutex, OnceLock};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
@@ -13,11 +15,206 @@ use et_core::proto::{PortForwardSourceRequest, TerminalPacketType};
 use crate::forward_endpoint::{Endpoint, ResolvedEndpoint};
 use crate::forward_io::BoundSource;
 use crate::forward_worker::{run, Command};
+use crate::reverse_report::SkipReason;
 
 const CHANNEL_CAPACITY: usize = 256;
 /// Maximum reverse listeners owned by one terminal session, after DNS fanout
 /// and address deduplication.
-pub const MAX_SESSION_LISTENERS: usize = 32;
+const MAX_SESSION_LISTENERS: usize = 32;
+pub(crate) const RESOLVER_WORKERS: usize = 4;
+pub(crate) const RESOLVER_QUEUE_CAPACITY: usize = 16;
+pub const FORWARD_TIMEOUT_SENTINEL: &str = "\nET_ERR:FORWARD_TIMEOUT";
+
+pub fn encode_forward_timeout(message: &str) -> String {
+    format!("{message}{FORWARD_TIMEOUT_SENTINEL}")
+}
+
+pub fn decode_forward_timeout(message: &str) -> Option<&str> {
+    message.strip_suffix(FORWARD_TIMEOUT_SENTINEL)
+}
+
+pub trait ForwardResolver: Send + Sync {
+    fn resolve(&self, host: &str, port: u16) -> io::Result<Vec<std::net::SocketAddr>>;
+
+    #[cfg(unix)]
+    fn listen_tcp_as_user(
+        &self,
+        address: std::net::SocketAddr,
+        uid: u32,
+        gid: u32,
+        deadline: Instant,
+    ) -> io::Result<std::net::TcpListener> {
+        crate::user_socket_ops::listen_tcp_as_user_deadline(address, uid, gid, deadline)
+    }
+}
+
+struct ResolverRequest {
+    resolver: Arc<dyn ForwardResolver>,
+    host: String,
+    port: u16,
+    deadline: Instant,
+    cancelled: Arc<AtomicBool>,
+    result: mpsc::SyncSender<io::Result<Vec<std::net::SocketAddr>>>,
+}
+
+struct ResolverQueue {
+    requests: Mutex<VecDeque<ResolverRequest>>,
+    changed: Condvar,
+}
+
+pub(crate) struct ResolverExecutor {
+    queue: Arc<ResolverQueue>,
+    _workers: Vec<JoinHandle<()>>,
+}
+
+impl ResolverExecutor {
+    pub(crate) fn global() -> &'static Self {
+        static EXECUTOR: OnceLock<ResolverExecutor> = OnceLock::new();
+        EXECUTOR.get_or_init(Self::new)
+    }
+
+    fn new() -> Self {
+        let queue = Arc::new(ResolverQueue {
+            requests: Mutex::new(VecDeque::with_capacity(RESOLVER_QUEUE_CAPACITY)),
+            changed: Condvar::new(),
+        });
+        let mut workers = Vec::with_capacity(RESOLVER_WORKERS);
+        for index in 0..RESOLVER_WORKERS {
+            let queue = queue.clone();
+            if let Ok(worker) = std::thread::Builder::new()
+                .name(format!("et-forward-resolver-{index}"))
+                .spawn(move || loop {
+                    let request = {
+                        let mut requests = match queue.requests.lock() {
+                            Ok(requests) => requests,
+                            Err(_) => return,
+                        };
+                        while requests.is_empty() {
+                            requests = match queue.changed.wait(requests) {
+                                Ok(requests) => requests,
+                                Err(_) => return,
+                            };
+                        }
+                        let request = requests.pop_front().expect("queue is non-empty");
+                        queue.changed.notify_all();
+                        request
+                    };
+                    if request.cancelled.load(Ordering::Acquire)
+                        || Instant::now() >= request.deadline
+                    {
+                        continue;
+                    }
+                    let result = request.resolver.resolve(&request.host, request.port);
+                    if !request.cancelled.load(Ordering::Acquire)
+                        && Instant::now() < request.deadline
+                    {
+                        let _ = request.result.send(result);
+                    }
+                })
+            {
+                workers.push(worker);
+            }
+        }
+        ResolverExecutor {
+            queue,
+            _workers: workers,
+        }
+    }
+
+    pub(crate) fn resolve(
+        &self,
+        resolver: Arc<dyn ForwardResolver>,
+        host: String,
+        port: u16,
+        deadline: Instant,
+    ) -> io::Result<Vec<std::net::SocketAddr>> {
+        deadline
+            .checked_duration_since(Instant::now())
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::TimedOut, "forwarding setup deadline elapsed")
+            })?;
+        let (result, receiver) = mpsc::sync_channel(1);
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let mut request = Some(ResolverRequest {
+            resolver,
+            host,
+            port,
+            deadline,
+            cancelled: cancelled.clone(),
+            result,
+        });
+        let mut requests = self
+            .queue
+            .requests
+            .lock()
+            .map_err(|_| io::Error::other("forwarding resolver is unavailable"))?;
+        loop {
+            let now = Instant::now();
+            requests.retain(|queued| {
+                !queued.cancelled.load(Ordering::Acquire) && now < queued.deadline
+            });
+            if requests.len() < RESOLVER_QUEUE_CAPACITY {
+                requests.push_back(request.take().expect("request is admitted once"));
+                self.queue.changed.notify_one();
+                break;
+            }
+            let wait = deadline.checked_duration_since(now).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "forwarding resolution deadline elapsed",
+                )
+            })?;
+            let (next, timed) = self
+                .queue
+                .changed
+                .wait_timeout(requests, wait)
+                .map_err(|_| io::Error::other("forwarding resolver is unavailable"))?;
+            requests = next;
+            if timed.timed_out() && Instant::now() >= deadline {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "forwarding resolution deadline elapsed",
+                ));
+            }
+        }
+        drop(requests);
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "forwarding resolution deadline elapsed",
+                )
+            })?;
+        let result = match receiver.recv_timeout(remaining) {
+            Ok(_) if Instant::now() >= deadline => Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "forwarding resolution deadline elapsed",
+            )),
+            Ok(result) => result,
+            Err(mpsc::RecvTimeoutError::Timeout) => Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "forwarding resolution deadline elapsed",
+            )),
+            Err(mpsc::RecvTimeoutError::Disconnected) => Err(io::Error::other(
+                "forwarding resolver terminated unexpectedly",
+            )),
+        };
+        cancelled.store(true, Ordering::Release);
+        self.queue.changed.notify_all();
+        result
+    }
+}
+
+#[derive(Default)]
+pub struct SystemForwardResolver;
+
+impl ForwardResolver for SystemForwardResolver {
+    fn resolve(&self, host: &str, port: u16) -> io::Result<Vec<std::net::SocketAddr>> {
+        use std::net::ToSocketAddrs;
+        (host, port).to_socket_addrs().map(Iterator::collect)
+    }
+}
 
 #[derive(Debug)]
 pub enum ForwardError {
@@ -40,6 +237,12 @@ impl std::fmt::Display for ForwardError {
 
 impl std::error::Error for ForwardError {}
 
+impl ForwardError {
+    pub fn is_timeout(&self) -> bool {
+        matches!(self, Self::Io(error) if error.kind() == io::ErrorKind::TimedOut)
+    }
+}
+
 impl From<io::Error> for ForwardError {
     fn from(error: io::Error) -> Self {
         Self::Io(error)
@@ -52,6 +255,7 @@ pub(crate) type Outbound = Result<Packet, ForwardError>;
 pub enum ForwardOrigin {
     Explicit,
     SshConfig { strict: bool },
+    Reported(usize),
 }
 
 pub struct ForwardSource {
@@ -78,6 +282,8 @@ impl ForwardSource {
 pub struct SkippedForward {
     pub request: PortForwardSourceRequest,
     pub error: io::Error,
+    pub reason: SkipReason,
+    pub report_index: Option<usize>,
 }
 
 pub struct Forwarder {
@@ -89,19 +295,39 @@ pub struct Forwarder {
     /// this way is not selectable there.
     #[cfg(unix)]
     wake: UnixStream,
+    shutdown: Arc<AtomicBool>,
     worker: Option<JoinHandle<()>>,
 }
 
 impl Forwarder {
     pub fn start(sources: Vec<PortForwardSourceRequest>) -> Result<Self, ForwardError> {
         let sources = sources.into_iter().map(ForwardSource::explicit).collect();
-        start_forwarder(sources, None, None).map(|(forwarder, _, _)| forwarder)
+        start_forwarder(
+            sources,
+            None,
+            Instant::now() + Duration::from_secs(30),
+            Arc::new(SystemForwardResolver),
+        )
+        .map(|(forwarder, _, _)| forwarder)
     }
 
     pub fn start_with_origins(
         sources: Vec<ForwardSource>,
     ) -> Result<(Self, Vec<SkippedForward>), ForwardError> {
-        start_forwarder(sources, None, None).map(|(forwarder, _, skipped)| (forwarder, skipped))
+        Self::start_with_origins_deadline(
+            sources,
+            Instant::now() + Duration::from_secs(30),
+            Arc::new(SystemForwardResolver),
+        )
+    }
+
+    pub fn start_with_origins_deadline(
+        sources: Vec<ForwardSource>,
+        deadline: Instant,
+        resolver: Arc<dyn ForwardResolver>,
+    ) -> Result<(Self, Vec<SkippedForward>), ForwardError> {
+        start_forwarder(sources, None, deadline, resolver)
+            .map(|(forwarder, _, skipped)| (forwarder, skipped))
     }
 
     /// Bind all forwarding sources and return the forwarder together with the
@@ -113,28 +339,83 @@ impl Forwarder {
         sources: Vec<PortForwardSourceRequest>,
         owner: Option<(u32, u32)>,
     ) -> Result<(Self, ForwardEnvironment), ForwardError> {
+        Self::start_with_user_deadline(
+            sources,
+            owner,
+            Instant::now() + Duration::from_secs(30),
+            Arc::new(SystemForwardResolver),
+        )
+    }
+
+    pub fn start_with_user_deadline(
+        sources: Vec<PortForwardSourceRequest>,
+        owner: Option<(u32, u32)>,
+        deadline: Instant,
+        resolver: Arc<dyn ForwardResolver>,
+    ) -> Result<(Self, ForwardEnvironment), ForwardError> {
+        Self::start_with_user_deadline_hook(sources, owner, deadline, resolver, || {})
+    }
+
+    fn start_with_user_deadline_hook(
+        sources: Vec<PortForwardSourceRequest>,
+        owner: Option<(u32, u32)>,
+        deadline: Instant,
+        resolver: Arc<dyn ForwardResolver>,
+        before_publish: impl FnOnce(),
+    ) -> Result<(Self, ForwardEnvironment), ForwardError> {
         let sources = sources.into_iter().map(ForwardSource::explicit).collect();
-        start_forwarder(sources, owner, None)
+        start_forwarder_hook(sources, owner, deadline, resolver, before_publish)
             .map(|(forwarder, environment, _)| (forwarder, environment))
     }
 
-    pub fn start_with_user_until(
+    pub fn start_with_user_report(
         sources: Vec<PortForwardSourceRequest>,
-        owner: (u32, u32),
+        owner: Option<(u32, u32)>,
+    ) -> Result<(Self, ForwardEnvironment, Vec<SkippedForward>), ForwardError> {
+        Self::start_with_user_report_deadline(
+            sources,
+            owner,
+            Instant::now() + Duration::from_secs(30),
+            Arc::new(SystemForwardResolver),
+        )
+    }
+
+    pub fn start_with_user_report_deadline(
+        sources: Vec<PortForwardSourceRequest>,
+        owner: Option<(u32, u32)>,
         deadline: Instant,
-    ) -> Result<(Self, ForwardEnvironment), ForwardError> {
-        let sources = sources.into_iter().map(ForwardSource::explicit).collect();
-        start_forwarder(sources, Some(owner), Some(deadline))
-            .map(|(forwarder, environment, _)| (forwarder, environment))
+        resolver: Arc<dyn ForwardResolver>,
+    ) -> Result<(Self, ForwardEnvironment, Vec<SkippedForward>), ForwardError> {
+        let sources = sources
+            .into_iter()
+            .enumerate()
+            .map(|(index, request)| ForwardSource {
+                request,
+                origin: ForwardOrigin::Reported(index),
+            })
+            .collect();
+        start_forwarder(sources, owner, deadline, resolver)
     }
 }
 
 fn start_forwarder(
     sources: Vec<ForwardSource>,
     owner: Option<(u32, u32)>,
-    deadline: Option<Instant>,
+    deadline: Instant,
+    resolver: Arc<dyn ForwardResolver>,
 ) -> Result<(Forwarder, ForwardEnvironment, Vec<SkippedForward>), ForwardError> {
-    let (sources, environment, skipped) = bind_sources(sources, owner, deadline)?;
+    start_forwarder_hook(sources, owner, deadline, resolver, || {})
+}
+
+fn start_forwarder_hook(
+    sources: Vec<ForwardSource>,
+    owner: Option<(u32, u32)>,
+    deadline: Instant,
+    resolver: Arc<dyn ForwardResolver>,
+    before_publish: impl FnOnce(),
+) -> Result<(Forwarder, ForwardEnvironment, Vec<SkippedForward>), ForwardError> {
+    let (sources, environment, skipped) = bind_sources(sources, owner, deadline, resolver)?;
+    ensure_setup_deadline(deadline)?;
     let session_user = owner;
     let (commands_tx, commands_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
     let (outbound_tx, outbound_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
@@ -151,6 +432,8 @@ fn start_forwarder(
     #[cfg(windows)]
     let listener_stop_reader = listener_stop.clone();
     let worker_commands = commands_tx.clone();
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let worker_shutdown = shutdown.clone();
     let worker = std::thread::Builder::new()
         .name("et-forwarding".to_owned())
         .spawn(move || {
@@ -161,8 +444,7 @@ fn start_forwarder(
                 outbound_tx,
                 #[cfg(unix)]
                 wake_writer,
-                listener_stop_reader,
-                session_user,
+                (listener_stop_reader, session_user, worker_shutdown),
             );
             #[cfg(unix)]
             drop(listener_stop);
@@ -170,17 +452,17 @@ fn start_forwarder(
             listener_stop.store(true, std::sync::atomic::Ordering::Release);
         })
         .map_err(ForwardError::Io)?;
-    Ok((
-        Forwarder {
-            commands: commands_tx,
-            outbound: outbound_rx,
-            #[cfg(unix)]
-            wake,
-            worker: Some(worker),
-        },
-        environment,
-        skipped,
-    ))
+    let forwarder = Forwarder {
+        commands: commands_tx,
+        outbound: outbound_rx,
+        #[cfg(unix)]
+        wake,
+        shutdown,
+        worker: Some(worker),
+    };
+    before_publish();
+    ensure_setup_deadline(deadline)?;
+    Ok((forwarder, environment, skipped))
 }
 
 impl Forwarder {
@@ -243,7 +525,8 @@ impl Forwarder {
 
     fn stop(&mut self) -> Result<(), ForwardError> {
         if let Some(worker) = self.worker.take() {
-            let _ = self.commands.send(Command::Stop);
+            self.shutdown.store(true, Ordering::Release);
+            let _ = self.commands.try_send(Command::Stop);
             worker.join().map_err(|_| ForwardError::Unavailable)?;
         }
         Ok(())
@@ -276,12 +559,14 @@ enum PlannedSource {
 fn bind_sources(
     sources: Vec<ForwardSource>,
     owner: Option<(u32, u32)>,
-    deadline: Option<Instant>,
+    deadline: Instant,
+    resolver: Arc<dyn ForwardResolver>,
 ) -> Result<(Vec<BoundSource>, ForwardEnvironment, Vec<SkippedForward>), ForwardError> {
     let mut plans = Vec::with_capacity(sources.len());
     let mut skipped = Vec::new();
     let mut listener_count = 0usize;
     for source in sources {
+        ensure_setup_deadline(deadline)?;
         let origin = source.origin;
         let original = source.request.clone();
         let request = source.request;
@@ -313,19 +598,24 @@ fn bind_sources(
             }
         } else {
             let endpoint = Endpoint::parse(request.source).map_err(ForwardError::Io)?;
-            let resolved = match (owner, deadline) {
-                (Some(_), Some(deadline)) => endpoint.resolve_for_bind_until(
-                    deadline,
-                    MAX_SESSION_LISTENERS.saturating_sub(listener_count),
-                ),
-                _ => endpoint.resolve_for_bind(),
-            };
+            let resolved = endpoint.resolve_for_bind_deadline(deadline, resolver.clone());
             let source = match (resolved, origin) {
                 (Ok(source), _) => source,
                 (Err(error), ForwardOrigin::SshConfig { strict: false }) => {
                     skipped.push(SkippedForward {
                         request: original,
                         error,
+                        reason: SkipReason::Resolve,
+                        report_index: None,
+                    });
+                    continue;
+                }
+                (Err(error), ForwardOrigin::Reported(index)) => {
+                    skipped.push(SkippedForward {
+                        request: original,
+                        error,
+                        reason: SkipReason::Resolve,
+                        report_index: Some(index),
                     });
                     continue;
                 }
@@ -337,13 +627,11 @@ fn bind_sources(
             if owner.is_some() {
                 match &source {
                     ResolvedEndpoint::Tcp(addresses)
-                        if addresses
-                            .iter()
-                            .any(|address| address.ip().is_unspecified()) =>
+                        if addresses.iter().any(|address| !address.ip().is_loopback()) =>
                     {
                         return Err(ForwardError::Io(io::Error::new(
                             io::ErrorKind::PermissionDenied,
-                            "authenticated reverse TCP wildcard bind is not permitted",
+                            "authenticated reverse TCP bind must resolve only to loopback addresses",
                         )));
                     }
                     ResolvedEndpoint::Tcp(_) => {}
@@ -382,10 +670,7 @@ fn bind_sources(
                 original,
                 origin,
             } => match (
-                match deadline {
-                    Some(deadline) => source.bind_with_user_until(owner, deadline),
-                    None => source.bind_with_user(owner),
-                },
+                source.bind_with_user_deadline_resolver(owner, deadline, resolver.clone()),
                 origin,
             ) {
                 (Ok(listeners), _) => {
@@ -400,6 +685,16 @@ fn bind_sources(
                     skipped.push(SkippedForward {
                         request: original,
                         error,
+                        reason: SkipReason::Bind,
+                        report_index: None,
+                    });
+                }
+                (Err(error), ForwardOrigin::Reported(index)) => {
+                    skipped.push(SkippedForward {
+                        request: original,
+                        error,
+                        reason: SkipReason::Bind,
+                        report_index: Some(index),
                     });
                 }
                 (
@@ -413,11 +708,10 @@ fn bind_sources(
                 destination,
             } => {
                 let mut pipe = create_forward_pipe(owner)?;
-                let source = Endpoint::Unix(pipe.path.clone()).resolve_for_bind()?;
-                let mut listeners = match deadline {
-                    Some(deadline) => source.bind_with_user_until(owner, deadline)?,
-                    None => source.bind_with_user(owner)?,
-                };
+                let source = Endpoint::Unix(pipe.path.clone())
+                    .resolve_for_bind_deadline(deadline, resolver.clone())?;
+                let mut listeners =
+                    source.bind_with_user_deadline_resolver(owner, deadline, resolver.clone())?;
                 environment.push((variable, pipe.path.to_string_lossy().into_owned()));
                 let directory = pipe.disarm()?;
                 for mut listener in listeners.drain(..) {
@@ -430,7 +724,19 @@ fn bind_sources(
             }
         }
     }
+    ensure_setup_deadline(deadline)?;
     Ok((bound, environment, skipped))
+}
+
+fn ensure_setup_deadline(deadline: Instant) -> Result<(), ForwardError> {
+    if Instant::now() >= deadline {
+        Err(ForwardError::Io(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "forwarding setup deadline elapsed",
+        )))
+    } else {
+        Ok(())
+    }
 }
 
 /// Create the private directory for a named-pipe forward and return the
@@ -516,8 +822,222 @@ pub fn is_forward_packet(header: u8) -> bool {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+    use et_core::proto::{PortForwardDestinationRequest, SocketEndpoint};
+    use prost::Message;
     use std::cell::RefCell;
+    use std::net::{Ipv4Addr, TcpListener};
     use std::os::unix::net::UnixListener;
+    use std::sync::{Barrier, Condvar};
+
+    struct GatedResolver {
+        started: mpsc::SyncSender<()>,
+        gate: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl ForwardResolver for GatedResolver {
+        fn resolve(&self, _host: &str, _port: u16) -> io::Result<Vec<std::net::SocketAddr>> {
+            self.started.send(()).unwrap();
+            let (released, changed) = &*self.gate;
+            let mut released = released.lock().unwrap();
+            while !*released {
+                released = changed.wait(released).unwrap();
+            }
+            Ok(Vec::new())
+        }
+    }
+
+    #[test]
+    fn queue_admission_time_does_not_extend_resolution_deadline() {
+        let executor = Arc::new(ResolverExecutor::new());
+        let active_gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let (active_started_tx, active_started_rx) = mpsc::sync_channel(RESOLVER_WORKERS);
+        let start_barrier = Arc::new(Barrier::new(RESOLVER_WORKERS + 1));
+        let mut active = Vec::new();
+        for index in 0..RESOLVER_WORKERS {
+            let executor = executor.clone();
+            let gate = active_gate.clone();
+            let started = active_started_tx.clone();
+            let barrier = start_barrier.clone();
+            active.push(std::thread::spawn(move || {
+                barrier.wait();
+                executor.resolve(
+                    Arc::new(GatedResolver { started, gate }),
+                    format!("active-{index}"),
+                    1,
+                    Instant::now() + Duration::from_secs(10),
+                )
+            }));
+        }
+        start_barrier.wait();
+        for _ in 0..RESOLVER_WORKERS {
+            active_started_rx
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap();
+        }
+
+        let admission_delay = Duration::from_millis(1500);
+        let queued_deadline = Instant::now() + admission_delay;
+        let mut queued_receivers = Vec::new();
+        {
+            let mut requests = executor.queue.requests.lock().unwrap();
+            for index in 0..RESOLVER_QUEUE_CAPACITY {
+                let (result, receiver) = mpsc::sync_channel(1);
+                queued_receivers.push(receiver);
+                requests.push_back(ResolverRequest {
+                    resolver: Arc::new(SystemForwardResolver),
+                    host: format!("expired-{index}"),
+                    port: 1,
+                    deadline: queued_deadline,
+                    cancelled: Arc::new(AtomicBool::new(false)),
+                    result,
+                });
+            }
+            assert_eq!(requests.len(), RESOLVER_QUEUE_CAPACITY);
+        }
+
+        let target_start = Instant::now();
+        let target_deadline = target_start + Duration::from_secs(3);
+        let target_gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let (target_started_tx, target_started_rx) = mpsc::sync_channel(1);
+        let (target_done_tx, target_done_rx) = mpsc::sync_channel(1);
+        let target_executor = executor.clone();
+        let target_gate_for_resolver = target_gate.clone();
+        let target = std::thread::spawn(move || {
+            let result = target_executor.resolve(
+                Arc::new(GatedResolver {
+                    started: target_started_tx,
+                    gate: target_gate_for_resolver,
+                }),
+                "target".to_owned(),
+                1,
+                target_deadline,
+            );
+            target_done_tx.send((Instant::now(), result)).unwrap();
+        });
+
+        assert!(matches!(
+            target_done_rx.recv_timeout(admission_delay),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ));
+        executor.queue.changed.notify_all();
+        {
+            let (released, changed) = &*active_gate;
+            *released.lock().unwrap() = true;
+            changed.notify_all();
+        }
+        target_started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("target resolver did not start after delayed admission");
+        let (completed, result) = target_done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("target exceeded its original absolute deadline");
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::TimedOut);
+        assert!(completed <= target_deadline + Duration::from_millis(100));
+
+        {
+            let (released, changed) = &*target_gate;
+            *released.lock().unwrap() = true;
+            changed.notify_all();
+        }
+        target.join().unwrap();
+        for worker in active {
+            worker.join().unwrap().unwrap();
+        }
+        drop(queued_receivers);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn later_unix_source_failure_rolls_back_prior_tcp_listener() {
+        let probe = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let address = probe.local_addr().unwrap();
+        drop(probe);
+        let directory =
+            std::env::temp_dir().join(format!("et-forward-rollback-{}", std::process::id()));
+        std::fs::create_dir_all(&directory).unwrap();
+        let occupied = directory.join("occupied.sock");
+        std::fs::write(&occupied, b"occupied").unwrap();
+        let requests = vec![
+            PortForwardSourceRequest {
+                source: Some(SocketEndpoint {
+                    name: Some(Ipv4Addr::LOCALHOST.to_string()),
+                    port: Some(i32::from(address.port())),
+                }),
+                destination: None,
+                environmentvariable: None,
+            },
+            PortForwardSourceRequest {
+                source: Some(SocketEndpoint {
+                    name: Some(occupied.to_string_lossy().into_owned()),
+                    port: None,
+                }),
+                destination: None,
+                environmentvariable: None,
+            },
+        ];
+        assert!(Forwarder::start_with_user_deadline(
+            requests,
+            None,
+            Instant::now() + Duration::from_secs(1),
+            Arc::new(SystemForwardResolver),
+        )
+        .is_err());
+        TcpListener::bind(address).expect("later source failure retained prior listener");
+        std::fs::remove_file(occupied).unwrap();
+        std::fs::remove_dir(directory).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shutdown_completes_with_command_and_outbound_queues_saturated() {
+        let directory = std::env::temp_dir().join(format!(
+            "et-forward-saturated-shutdown-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&directory).unwrap();
+        let path = directory.join("listener.sock");
+        let request = PortForwardSourceRequest {
+            source: Some(SocketEndpoint {
+                name: Some(path.to_string_lossy().into_owned()),
+                port: None,
+            }),
+            destination: Some(SocketEndpoint {
+                name: Some("localhost".to_owned()),
+                port: Some(1),
+            }),
+            environmentvariable: None,
+        };
+        let forwarder = Forwarder::start(vec![request]).unwrap();
+        let mut fd = 1;
+        loop {
+            let packet = Packet::new(
+                TerminalPacketType::PortForwardDestinationRequest as u8,
+                PortForwardDestinationRequest {
+                    destination: None,
+                    fd: Some(fd),
+                }
+                .encode_to_vec(),
+            );
+            match forwarder.commands.try_send(Command::Packet(packet)) {
+                Ok(()) => fd += 1,
+                Err(mpsc::TrySendError::Full(_)) => break,
+                Err(mpsc::TrySendError::Disconnected(_)) => {
+                    panic!("forwarding worker stopped before saturation")
+                }
+            }
+        }
+        let (done_tx, done_rx) = mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            let result = forwarder.shutdown();
+            let _ = done_tx.send(result);
+        });
+        done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("forwarder shutdown hung with both queues saturated")
+            .unwrap();
+        assert!(!path.exists(), "owned Unix listener was not retired");
+        std::fs::remove_dir(directory).unwrap();
+    }
 
     #[test]
     fn named_pipe_failure_after_directory_creation_cleans_and_retries() {

--- a/crates/et-net/src/forward.rs
+++ b/crates/et-net/src/forward.rs
@@ -14,7 +14,7 @@ use et_core::proto::{PortForwardSourceRequest, TerminalPacketType};
 
 use crate::forward_endpoint::{Endpoint, ResolvedEndpoint};
 use crate::forward_io::BoundSource;
-use crate::forward_worker::{run, Command};
+use crate::forward_worker::{command_channel, run, Command, CommandSender, TryCommandError};
 
 const CHANNEL_CAPACITY: usize = 256;
 /// Maximum reverse listeners owned by one terminal session, after DNS fanout
@@ -283,7 +283,7 @@ pub struct SkippedForward {
 }
 
 pub struct Forwarder {
-    commands: mpsc::SyncSender<Command>,
+    commands: CommandSender,
     outbound: mpsc::Receiver<Outbound>,
     /// Readiness channel for outbound packets. Unix callers poll it exactly
     /// like upstream's `select()`; Windows callers drain [`Forwarder::try_outbound`]
@@ -360,7 +360,7 @@ impl Forwarder {
         before_publish: impl FnOnce(),
     ) -> Result<(Self, ForwardEnvironment), ForwardError> {
         let sources = sources.into_iter().map(ForwardSource::explicit).collect();
-        start_forwarder_hook(sources, owner, deadline, resolver, before_publish)
+        start_forwarder_hook(sources, owner, deadline, resolver, before_publish, || {})
             .map(|(forwarder, environment, _)| (forwarder, environment))
     }
 }
@@ -371,7 +371,7 @@ fn start_forwarder(
     deadline: Instant,
     resolver: Arc<dyn ForwardResolver>,
 ) -> Result<(Forwarder, ForwardEnvironment, Vec<SkippedForward>), ForwardError> {
-    start_forwarder_hook(sources, owner, deadline, resolver, || {})
+    start_forwarder_hook(sources, owner, deadline, resolver, || {}, || {})
 }
 
 fn start_forwarder_hook(
@@ -380,11 +380,12 @@ fn start_forwarder_hook(
     deadline: Instant,
     resolver: Arc<dyn ForwardResolver>,
     before_publish: impl FnOnce(),
+    worker_start: impl FnOnce() + Send + 'static,
 ) -> Result<(Forwarder, ForwardEnvironment, Vec<SkippedForward>), ForwardError> {
     let (sources, environment, skipped) = bind_sources(sources, owner, deadline, resolver)?;
     ensure_setup_deadline(deadline)?;
     let session_user = owner;
-    let (commands_tx, commands_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
+    let (commands_tx, commands_rx) = command_channel(CHANNEL_CAPACITY);
     let (outbound_tx, outbound_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
     #[cfg(unix)]
     let (wake, wake_writer) = {
@@ -404,6 +405,7 @@ fn start_forwarder_hook(
     let worker = std::thread::Builder::new()
         .name("et-forwarding".to_owned())
         .spawn(move || {
+            worker_start();
             run(
                 sources,
                 commands_rx,
@@ -463,8 +465,8 @@ impl Forwarder {
     pub fn try_receive(&self, packet: Packet) -> Result<Option<Packet>, ForwardError> {
         match self.commands.try_send(Command::Packet(packet)) {
             Ok(()) => Ok(None),
-            Err(mpsc::TrySendError::Full(Command::Packet(packet))) => Ok(Some(packet)),
-            Err(mpsc::TrySendError::Full(_)) | Err(mpsc::TrySendError::Disconnected(_)) => {
+            Err(TryCommandError::Full(Command::Packet(packet))) => Ok(Some(packet)),
+            Err(TryCommandError::Full(_)) | Err(TryCommandError::Closed) => {
                 Err(ForwardError::Unavailable)
             }
         }
@@ -493,7 +495,7 @@ impl Forwarder {
     fn stop(&mut self) -> Result<(), ForwardError> {
         if let Some(worker) = self.worker.take() {
             self.shutdown.store(true, Ordering::Release);
-            let _ = self.commands.try_send(Command::Stop);
+            self.commands.shutdown();
             worker.join().map_err(|_| ForwardError::Unavailable)?;
         }
         Ok(())
@@ -765,7 +767,7 @@ pub fn is_forward_packet(header: u8) -> bool {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
-    use et_core::proto::{PortForwardDestinationRequest, SocketEndpoint};
+    use et_core::proto::{PortForwardData, PortForwardDestinationRequest, SocketEndpoint};
     use prost::Message;
     use std::cell::RefCell;
     use std::net::{Ipv4Addr, TcpListener};
@@ -963,8 +965,8 @@ mod tests {
             );
             match forwarder.commands.try_send(Command::Packet(packet)) {
                 Ok(()) => fd += 1,
-                Err(mpsc::TrySendError::Full(_)) => break,
-                Err(mpsc::TrySendError::Disconnected(_)) => {
+                Err(TryCommandError::Full(_)) => break,
+                Err(TryCommandError::Closed) => {
                     panic!("forwarding worker stopped before saturation")
                 }
             }
@@ -980,6 +982,108 @@ mod tests {
             .unwrap();
         assert!(!path.exists(), "owned Unix listener was not retired");
         std::fs::remove_dir(directory).unwrap();
+    }
+
+    #[test]
+    fn shutdown_and_drop_ignore_a_full_non_emitting_command_queue() {
+        for drop_only in [false, true] {
+            let directory = std::env::temp_dir().join(format!(
+                "et-forward-stale-close-shutdown-{}-{drop_only}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&directory).unwrap();
+            let path = directory.join("listener.sock");
+            let request = PortForwardSourceRequest {
+                source: Some(SocketEndpoint {
+                    name: Some(path.to_string_lossy().into_owned()),
+                    port: None,
+                }),
+                destination: Some(SocketEndpoint {
+                    name: Some("localhost".to_owned()),
+                    port: Some(1),
+                }),
+                environmentvariable: None,
+            };
+            let (worker_entered_tx, worker_entered_rx) = mpsc::sync_channel(1);
+            let (worker_release_tx, worker_release_rx) = mpsc::sync_channel(1);
+            let (forwarder, _, _) = start_forwarder_hook(
+                vec![ForwardSource::explicit(request)],
+                None,
+                Instant::now() + Duration::from_secs(3),
+                Arc::new(SystemForwardResolver),
+                || {},
+                move || {
+                    worker_entered_tx.send(()).unwrap();
+                    worker_release_rx.recv().unwrap();
+                },
+            )
+            .unwrap();
+            worker_entered_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("forwarding worker did not reach its deterministic gate");
+
+            for socket_id in 1..=CHANNEL_CAPACITY {
+                let packet = Packet::new(
+                    TerminalPacketType::PortForwardData as u8,
+                    PortForwardData {
+                        sourcetodestination: Some(false),
+                        socketid: Some(i32::try_from(socket_id).unwrap()),
+                        buffer: None,
+                        error: None,
+                        closed: Some(true),
+                    }
+                    .encode_to_vec(),
+                );
+                forwarder
+                    .commands
+                    .try_send(Command::Packet(packet))
+                    .unwrap_or_else(|_| panic!("command queue filled before capacity"));
+            }
+            let overflow = Packet::new(
+                TerminalPacketType::PortForwardData as u8,
+                PortForwardData {
+                    sourcetodestination: Some(false),
+                    socketid: Some(i32::MAX),
+                    buffer: None,
+                    error: None,
+                    closed: Some(true),
+                }
+                .encode_to_vec(),
+            );
+            assert!(matches!(
+                forwarder.commands.try_send(Command::Packet(overflow)),
+                Err(TryCommandError::Full(_))
+            ));
+
+            let shutdown_observer = forwarder.commands.clone();
+            let (done_tx, done_rx) = mpsc::sync_channel(1);
+            std::thread::spawn(move || {
+                let result = if drop_only {
+                    drop(forwarder);
+                    Ok(())
+                } else {
+                    forwarder.shutdown()
+                };
+                let _ = done_tx.send(result);
+            });
+            let shutdown_observed = shutdown_observer.wait_shutdown_timeout(Duration::from_secs(2));
+            if !shutdown_observed {
+                // Failure-only cleanup: release the worker through the queue's
+                // independent cancellation path before reporting the defect.
+                shutdown_observer.shutdown();
+            }
+            worker_release_tx.send(()).unwrap();
+            done_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("queue-independent shutdown did not join the worker")
+                .unwrap();
+            assert!(
+                shutdown_observed,
+                "Forwarder shutdown did not signal queue-independent cancellation"
+            );
+            assert!(!path.exists(), "shutdown retained the owned Unix listener");
+            std::fs::remove_dir(directory).unwrap();
+        }
     }
 
     #[test]

--- a/crates/et-net/src/forward_endpoint.rs
+++ b/crates/et-net/src/forward_endpoint.rs
@@ -6,13 +6,15 @@ use std::net::{Shutdown, TcpListener, TcpStream, ToSocketAddrs};
 use std::os::unix::fs::PermissionsExt;
 #[cfg(unix)]
 use std::os::unix::net::{UnixListener, UnixStream};
+#[cfg(unix)]
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use crate::forward::{ForwardResolver, ResolverExecutor};
-
 use et_core::proto::SocketEndpoint;
+
+use crate::forward::{ForwardResolver, ResolverExecutor};
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 
@@ -120,6 +122,11 @@ impl Endpoint {
     pub(crate) fn connect_with_user(&self, user: Option<(u32, u32)>) -> io::Result<ForwardStream> {
         match (self, user) {
             #[cfg(unix)]
+            (Self::Tcp { host, port }, Some((uid, gid))) => {
+                crate::user_socket_ops::connect_tcp_as_user(host, *port, uid, gid)
+                    .map(ForwardStream::Tcp)
+            }
+            #[cfg(unix)]
             (Self::Unix(path), Some((uid, gid))) => {
                 crate::user_socket_ops::connect_unix_as_user(path, uid, gid)
                     .map(ForwardStream::Unix)
@@ -130,32 +137,7 @@ impl Endpoint {
 
     pub(crate) fn connect(&self) -> io::Result<ForwardStream> {
         match self {
-            Self::Tcp { host, port } => {
-                // Upstream connects to localhost destinations by trying ::1
-                // first and falling back to 127.0.0.1.
-                if host.eq_ignore_ascii_case("localhost") {
-                    let v6 = std::net::SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, *port));
-                    match TcpStream::connect_timeout(&v6, CONNECT_TIMEOUT) {
-                        Ok(stream) => return Ok(ForwardStream::Tcp(stream)),
-                        Err(_) => {
-                            let v4 =
-                                std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, *port));
-                            return TcpStream::connect_timeout(&v4, CONNECT_TIMEOUT)
-                                .map(ForwardStream::Tcp);
-                        }
-                    }
-                }
-                let mut last_error = None;
-                for address in (host.as_str(), *port).to_socket_addrs()? {
-                    match TcpStream::connect_timeout(&address, CONNECT_TIMEOUT) {
-                        Ok(stream) => return Ok(ForwardStream::Tcp(stream)),
-                        Err(error) => last_error = Some(error),
-                    }
-                }
-                Err(last_error.unwrap_or_else(|| {
-                    io::Error::new(io::ErrorKind::AddrNotAvailable, "endpoint did not resolve")
-                }))
-            }
+            Self::Tcp { host, port } => connect_tcp(host, *port).map(ForwardStream::Tcp),
             #[cfg(unix)]
             Self::Unix(path) => UnixStream::connect(path).map(ForwardStream::Unix),
         }
@@ -163,10 +145,29 @@ impl Endpoint {
 
     #[cfg(test)]
     pub(crate) fn resolve_for_bind(&self) -> io::Result<ResolvedEndpoint> {
-        self.resolve_for_bind_deadline(
-            Instant::now() + Duration::from_secs(30),
-            Arc::new(crate::forward::SystemForwardResolver),
-        )
+        match self {
+            Self::Tcp { host, port } => {
+                // Mirror upstream `TcpSocketHandler::listen`: resolve the bind
+                // name with getaddrinfo semantics and bind every distinct
+                // address ("localhost" usually yields both loopback families).
+                let addresses = if host.is_empty() {
+                    vec![
+                        (std::net::Ipv6Addr::UNSPECIFIED, *port).into(),
+                        (std::net::Ipv4Addr::UNSPECIFIED, *port).into(),
+                    ]
+                } else if host == "localhost" {
+                    vec![
+                        (std::net::Ipv6Addr::LOCALHOST, *port).into(),
+                        (std::net::Ipv4Addr::LOCALHOST, *port).into(),
+                    ]
+                } else {
+                    (host.as_str(), *port).to_socket_addrs()?.collect()
+                };
+                Ok(ResolvedEndpoint::Tcp(distinct_tcp_addresses(addresses)))
+            }
+            #[cfg(unix)]
+            Self::Unix(path) => Ok(ResolvedEndpoint::Unix(path.clone())),
+        }
     }
 
     pub(crate) fn resolve_for_bind_deadline(
@@ -188,7 +189,7 @@ impl Endpoint {
                         (std::net::Ipv4Addr::LOCALHOST, *port).into(),
                     ]
                 } else {
-                    resolve_before_deadline(resolver, host.clone(), *port, deadline)?
+                    ResolverExecutor::global().resolve(resolver, host.clone(), *port, deadline)?
                 };
                 ensure_deadline(deadline)?;
                 Ok(ResolvedEndpoint::Tcp(distinct_tcp_addresses(addresses)))
@@ -201,6 +202,59 @@ impl Endpoint {
     #[cfg(test)]
     pub(crate) fn bind(&self) -> io::Result<Vec<ForwardListener>> {
         self.resolve_for_bind()?.bind_with_user(None)
+    }
+}
+
+pub(crate) fn connect_tcp(host: &str, port: u16) -> io::Result<TcpStream> {
+    // Preserve upstream's dual-stack localhost ordering while allowing
+    // explicitly configured destination names under the session identity.
+    if host.eq_ignore_ascii_case("localhost") {
+        let v6 = std::net::SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, port));
+        match TcpStream::connect_timeout(&v6, CONNECT_TIMEOUT) {
+            Ok(stream) => return Ok(stream),
+            Err(_) => {
+                let v4 = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, port));
+                return TcpStream::connect_timeout(&v4, CONNECT_TIMEOUT);
+            }
+        }
+    }
+    let mut last_error = None;
+    for address in (host, port).to_socket_addrs()? {
+        match TcpStream::connect_timeout(&address, CONNECT_TIMEOUT) {
+            Ok(stream) => return Ok(stream),
+            Err(error) => last_error = Some(error),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| {
+        io::Error::new(io::ErrorKind::AddrNotAvailable, "endpoint did not resolve")
+    }))
+}
+
+#[cfg(test)]
+fn collect_distinct_addresses(
+    addresses: io::Result<impl Iterator<Item = std::net::SocketAddr>>,
+    max_addresses: usize,
+) -> io::Result<Vec<std::net::SocketAddr>> {
+    let mut seen = HashSet::new();
+    let mut resolved = Vec::new();
+    for address in addresses? {
+        if seen.insert(address) {
+            if resolved.len() >= max_addresses {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "forward source exceeds listener limit",
+                ));
+            }
+            resolved.push(address);
+        }
+    }
+    if resolved.is_empty() {
+        Err(io::Error::new(
+            io::ErrorKind::AddrNotAvailable,
+            "endpoint did not resolve",
+        ))
+    } else {
+        Ok(resolved)
     }
 }
 
@@ -224,20 +278,34 @@ impl ResolvedEndpoint {
         &self,
         user: Option<(u32, u32)>,
     ) -> io::Result<Vec<ForwardListener>> {
-        self.bind_with_user_deadline(user, Instant::now() + Duration::from_secs(30))
-    }
-
-    #[cfg(test)]
-    pub(crate) fn bind_with_user_deadline(
-        &self,
-        user: Option<(u32, u32)>,
-        deadline: Instant,
-    ) -> io::Result<Vec<ForwardListener>> {
-        self.bind_with_user_deadline_resolver(
-            user,
-            deadline,
-            Arc::new(crate::forward::SystemForwardResolver),
-        )
+        match (self, user) {
+            #[cfg(unix)]
+            (Self::Tcp(addresses), Some((uid, gid))) => {
+                bind_tcp_addresses_with(addresses.iter().copied(), |address| {
+                    crate::user_socket_ops::listen_tcp_as_user(address, uid, gid).map(Some)
+                })
+            }
+            (Self::Tcp(addresses), _) => bind_tcp_addresses(addresses.iter().copied()),
+            #[cfg(unix)]
+            (Self::Unix(path), Some((uid, gid))) => {
+                let listener = crate::user_socket_ops::listen_unix_as_user(path, uid, gid)?;
+                let (listener, cleanup) = listener.into_parts();
+                listener.set_nonblocking(true)?;
+                let path_cleanup = cleanup.is_none().then(|| path.clone());
+                Ok(vec![ForwardListener {
+                    inner: ListenerKind::Unix(listener),
+                    cleanup: path_cleanup,
+                    user_cleanup: cleanup,
+                    cleanup_dirs: Vec::new(),
+                }])
+            }
+            #[cfg(unix)]
+            (Self::Unix(path), None) => bind_unix_locally_with(path, |listener| {
+                fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+                listener.set_nonblocking(true)
+            })
+            .map(|listener| vec![listener]),
+        }
     }
 
     pub(crate) fn bind_with_user_deadline_resolver(
@@ -252,163 +320,47 @@ impl ResolvedEndpoint {
             (Self::Tcp(addresses), Some((uid, gid))) => {
                 bind_tcp_addresses_with(addresses.iter().copied(), |address| {
                     ensure_deadline(deadline)?;
-                    let listener = _resolver.listen_tcp_as_user(address, uid, gid, deadline)?;
-                    ensure_deadline(deadline)?;
-                    Ok(Some(listener))
+                    _resolver
+                        .listen_tcp_as_user(address, uid, gid, deadline)
+                        .map(Some)
                 })
             }
             (Self::Tcp(addresses), _) => {
-                bind_tcp_addresses_deadline(addresses.iter().copied(), deadline)
+                bind_tcp_addresses_with(addresses.iter().copied(), |address| {
+                    ensure_deadline(deadline)?;
+                    let listener = bind_tcp_single_family(address)?;
+                    ensure_deadline(deadline)?;
+                    Ok(listener)
+                })
             }
             #[cfg(unix)]
-            (Self::Unix(path), user) => {
-                let listeners = bind_unix_source_deadline(
-                    path,
-                    user,
-                    deadline,
-                    || ensure_deadline(deadline),
-                    || ensure_deadline(deadline),
-                )?;
+            (Self::Unix(path), Some((uid, gid))) => {
+                let listener =
+                    crate::user_socket_ops::listen_unix_as_user_until(path, uid, gid, deadline)?;
+                let (listener, cleanup) = listener.into_parts();
+                listener.set_nonblocking(true)?;
+                let path_cleanup = cleanup.is_none().then(|| path.clone());
+                Ok(vec![ForwardListener {
+                    inner: ListenerKind::Unix(listener),
+                    cleanup: path_cleanup,
+                    user_cleanup: cleanup,
+                    cleanup_dirs: Vec::new(),
+                }])
+            }
+            #[cfg(unix)]
+            (Self::Unix(path), None) => {
                 ensure_deadline(deadline)?;
-                Ok(listeners)
+                let listener = bind_unix_locally_with(path, |listener| {
+                    fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+                    listener.set_nonblocking(true)
+                })?;
+                ensure_deadline(deadline)?;
+                Ok(vec![listener])
             }
         }?;
         ensure_deadline(deadline)?;
         Ok(listeners)
     }
-}
-
-#[cfg(unix)]
-fn bind_unix_source_deadline(
-    path: &std::path::Path,
-    user: Option<(u32, u32)>,
-    deadline: Instant,
-    after_directory: impl FnOnce() -> io::Result<()>,
-    after_bind: impl FnOnce() -> io::Result<()>,
-) -> io::Result<Vec<ForwardListener>> {
-    if path.exists() {
-        return Err(io::Error::new(
-            io::ErrorKind::AddrInUse,
-            "Unix source socket already exists",
-        ));
-    }
-    let mut directory_guard = None;
-    if user.is_none() {
-        if let Some(parent) = path.parent().filter(|parent| !parent.exists()) {
-            fs::create_dir_all(parent)?;
-            directory_guard = Some(PathCleanup::directory(parent.to_path_buf()));
-            after_directory()?;
-            fs::set_permissions(parent, fs::Permissions::from_mode(0o700))?;
-        }
-    }
-    let (listener, identity) = match user {
-        Some((uid, gid)) => {
-            crate::user_socket_ops::listen_unix_as_user_owned_deadline(path, uid, gid, deadline)?
-        }
-        None => crate::user_socket_ops::bind_staged(path, deadline)?,
-    };
-    let setup = (|| {
-        after_bind()?;
-        if user.is_none() {
-            fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
-        }
-        listener.set_nonblocking(true)?;
-        Ok(())
-    })();
-    if let Err(error) = setup {
-        drop(listener);
-        crate::user_socket_ops::remove_socket_if_owned(path, identity);
-        return Err(error);
-    }
-    Ok(vec![ForwardListener {
-        inner: ListenerKind::Unix(listener),
-        cleanup: Some((path.to_path_buf(), identity)),
-        cleanup_dir: directory_guard.and_then(PathCleanup::disarm),
-    }])
-}
-
-#[cfg(all(test, unix))]
-fn bind_unix_source(
-    path: &std::path::Path,
-    user: Option<(u32, u32)>,
-    after_directory: impl FnOnce() -> io::Result<()>,
-    after_bind: impl FnOnce() -> io::Result<()>,
-) -> io::Result<Vec<ForwardListener>> {
-    bind_unix_source_deadline(
-        path,
-        user,
-        Instant::now() + Duration::from_secs(30),
-        after_directory,
-        after_bind,
-    )
-}
-
-#[cfg(unix)]
-struct PathCleanup {
-    path: Option<PathBuf>,
-}
-
-#[cfg(unix)]
-impl PathCleanup {
-    fn directory(path: PathBuf) -> Self {
-        Self { path: Some(path) }
-    }
-
-    fn disarm(mut self) -> Option<PathBuf> {
-        self.path.take()
-    }
-}
-
-#[cfg(unix)]
-impl Drop for PathCleanup {
-    fn drop(&mut self) {
-        if let Some(path) = self.path.as_ref() {
-            let _ = fs::remove_dir(path);
-        }
-    }
-}
-
-#[cfg(test)]
-fn bind_tcp_addresses(
-    addresses: impl IntoIterator<Item = std::net::SocketAddr>,
-) -> io::Result<Vec<ForwardListener>> {
-    bind_tcp_addresses_deadline(addresses, Instant::now() + Duration::from_secs(30))
-}
-
-fn bind_tcp_addresses_deadline(
-    addresses: impl IntoIterator<Item = std::net::SocketAddr>,
-    deadline: Instant,
-) -> io::Result<Vec<ForwardListener>> {
-    bind_tcp_addresses_with(addresses, |address| {
-        ensure_deadline(deadline)?;
-        let listener = bind_tcp_single_family(address)?;
-        ensure_deadline(deadline)?;
-        Ok(listener)
-    })
-}
-
-fn bind_tcp_addresses_with(
-    addresses: impl IntoIterator<Item = std::net::SocketAddr>,
-    mut bind: impl FnMut(std::net::SocketAddr) -> io::Result<Option<TcpListener>>,
-) -> io::Result<Vec<ForwardListener>> {
-    let mut listeners = Vec::new();
-    for address in addresses {
-        if let Some(listener) = bind(address)? {
-            listeners.push(ForwardListener {
-                inner: ListenerKind::Tcp(listener),
-                #[cfg(unix)]
-                cleanup: None,
-                cleanup_dir: None,
-            });
-        }
-    }
-    if listeners.is_empty() {
-        return Err(io::Error::new(
-            io::ErrorKind::AddrNotAvailable,
-            "endpoint did not resolve",
-        ));
-    }
-    Ok(listeners)
 }
 
 fn ensure_deadline(deadline: Instant) -> io::Result<()> {
@@ -422,13 +374,158 @@ fn ensure_deadline(deadline: Instant) -> io::Result<()> {
     }
 }
 
-fn resolve_before_deadline(
-    resolver: Arc<dyn ForwardResolver>,
-    host: String,
-    port: u16,
-    deadline: Instant,
-) -> io::Result<Vec<std::net::SocketAddr>> {
-    ResolverExecutor::global().resolve(resolver, host, port, deadline)
+#[cfg(unix)]
+fn bind_unix_locally_with(
+    path: &Path,
+    configure: impl FnOnce(&UnixListener) -> io::Result<()>,
+) -> io::Result<ForwardListener> {
+    if path.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::AddrInUse,
+            "Unix source socket already exists",
+        ));
+    }
+    let mut parent_cleanup = None;
+    if let Some(parent) = path.parent() {
+        if !parent.exists() {
+            parent_cleanup = Some(create_missing_directories_with(parent, |directory| {
+                fs::create_dir(directory)
+            })?);
+            fs::set_permissions(parent, fs::Permissions::from_mode(0o700))?;
+        }
+    }
+    let listener = UnixListener::bind(path)?;
+    finish_unix_listener_with(listener, path, parent_cleanup, configure)
+}
+
+#[cfg(unix)]
+fn finish_unix_listener_with(
+    listener: UnixListener,
+    path: &Path,
+    mut cleanup_dirs: Option<PendingDirectories>,
+    configure: impl FnOnce(&UnixListener) -> io::Result<()>,
+) -> io::Result<ForwardListener> {
+    let mut socket_cleanup = PendingPath::socket(path.to_path_buf());
+    configure(&listener)?;
+    Ok(ForwardListener {
+        inner: ListenerKind::Unix(listener),
+        cleanup: socket_cleanup.disarm(),
+        user_cleanup: None,
+        cleanup_dirs: cleanup_dirs
+            .as_mut()
+            .and_then(PendingDirectories::disarm)
+            .unwrap_or_default(),
+    })
+}
+
+#[cfg(unix)]
+struct PendingPath {
+    path: Option<PathBuf>,
+}
+
+#[cfg(unix)]
+impl PendingPath {
+    fn socket(path: PathBuf) -> Self {
+        Self { path: Some(path) }
+    }
+
+    fn disarm(&mut self) -> Option<PathBuf> {
+        self.path.take()
+    }
+}
+
+#[cfg(unix)]
+impl Drop for PendingPath {
+    fn drop(&mut self) {
+        if let Some(path) = self.path.as_ref() {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn missing_directories(parent: &Path) -> Vec<PathBuf> {
+    let mut directories = Vec::new();
+    let mut current = Some(parent);
+    while let Some(path) = current {
+        if path.exists() {
+            break;
+        }
+        directories.push(path.to_path_buf());
+        current = path.parent();
+    }
+    directories
+}
+
+#[cfg(unix)]
+fn create_missing_directories_with(
+    parent: &Path,
+    mut create: impl FnMut(&Path) -> io::Result<()>,
+) -> io::Result<PendingDirectories> {
+    let directories = missing_directories(parent);
+    let mut cleanup = PendingDirectories(Some(Vec::with_capacity(directories.len())));
+    for directory in directories.iter().rev() {
+        create(directory)?;
+        cleanup
+            .0
+            .as_mut()
+            .expect("pending directory cleanup")
+            .insert(0, directory.clone());
+    }
+    Ok(cleanup)
+}
+
+#[cfg(unix)]
+struct PendingDirectories(Option<Vec<PathBuf>>);
+
+#[cfg(unix)]
+impl PendingDirectories {
+    fn disarm(&mut self) -> Option<Vec<PathBuf>> {
+        self.0.take()
+    }
+}
+
+#[cfg(unix)]
+impl Drop for PendingDirectories {
+    fn drop(&mut self) {
+        if let Some(paths) = self.0.take() {
+            for path in paths {
+                let _ = fs::remove_dir(path);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+fn bind_tcp_addresses(
+    addresses: impl IntoIterator<Item = std::net::SocketAddr>,
+) -> io::Result<Vec<ForwardListener>> {
+    bind_tcp_addresses_with(addresses, bind_tcp_single_family)
+}
+
+fn bind_tcp_addresses_with(
+    addresses: impl IntoIterator<Item = std::net::SocketAddr>,
+    mut bind: impl FnMut(std::net::SocketAddr) -> io::Result<Option<TcpListener>>,
+) -> io::Result<Vec<ForwardListener>> {
+    let mut listeners = Vec::new();
+    for address in addresses {
+        if let Some(listener) = bind(address)? {
+            listeners.push(ForwardListener {
+                inner: ListenerKind::Tcp(listener),
+                cleanup: None,
+                #[cfg(unix)]
+                user_cleanup: None,
+                cleanup_dirs: Vec::new(),
+            });
+        }
+    }
+    if listeners.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::AddrNotAvailable,
+            "endpoint did not resolve",
+        ));
+    }
+    Ok(listeners)
 }
 
 fn distinct_tcp_addresses(
@@ -552,14 +649,12 @@ enum ListenerKind {
     Unix(UnixListener),
 }
 
-#[cfg(unix)]
-type ListenerCleanup = (PathBuf, crate::user_socket_ops::UnixSocketIdentity);
-
 pub(crate) struct ForwardListener {
     inner: ListenerKind,
+    cleanup: Option<PathBuf>,
     #[cfg(unix)]
-    cleanup: Option<ListenerCleanup>,
-    cleanup_dir: Option<PathBuf>,
+    user_cleanup: Option<crate::user_socket_ops::UserSocketCleanup>,
+    cleanup_dirs: Vec<PathBuf>,
 }
 
 impl ForwardListener {
@@ -567,7 +662,7 @@ impl ForwardListener {
     /// private named-pipe directories created for environment forwards).
     #[cfg(unix)]
     pub(crate) fn also_remove_dir(&mut self, directory: PathBuf) {
-        self.cleanup_dir = Some(directory);
+        self.cleanup_dirs.push(directory);
     }
 
     pub(crate) fn accept(&self) -> io::Result<ForwardStream> {
@@ -599,10 +694,11 @@ impl std::os::fd::AsFd for ForwardListener {
 impl Drop for ForwardListener {
     fn drop(&mut self) {
         #[cfg(unix)]
-        if let Some((path, identity)) = self.cleanup.as_ref() {
-            crate::user_socket_ops::remove_socket_if_owned(path, *identity);
+        drop(self.user_cleanup.take());
+        if let Some(path) = self.cleanup.as_ref() {
+            let _ = fs::remove_file(path);
         }
-        if let Some(path) = self.cleanup_dir.as_ref() {
+        for path in &self.cleanup_dirs {
             let _ = fs::remove_dir(path);
         }
     }
@@ -660,70 +756,9 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn unix_source_failure_after_directory_creation_cleans_and_retries() {
-        // Given
-        let root = std::env::temp_dir().join(format!("et-fwd-dir-{}", std::process::id()));
-        let path = root.join("created").join("source.sock");
-        let created = path.parent().unwrap().to_path_buf();
-
-        // When
-        let error = match bind_unix_source(
-            &path,
-            None,
-            || Err(io::Error::other("injected after directory creation")),
-            || Ok(()),
-        ) {
-            Ok(_) => panic!("injected directory failure succeeded"),
-            Err(error) => error,
-        };
-
-        // Then
-        assert_eq!(error.kind(), io::ErrorKind::Other);
-        assert!(!created.exists());
-        let listeners = bind_unix_source(&path, None, || Ok(()), || Ok(())).unwrap();
-        assert!(path.exists());
-        drop(listeners);
-        assert!(!path.exists());
-        assert!(!created.exists());
-        let _ = fs::remove_dir(root);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn unix_source_failure_after_bind_cleans_socket_and_directory_then_retries() {
-        // Given
-        let root = std::env::temp_dir().join(format!("et-fwd-bind-{}", std::process::id()));
-        let path = root.join("created").join("source.sock");
-        let created = path.parent().unwrap().to_path_buf();
-
-        // When
-        let error = match bind_unix_source(
-            &path,
-            None,
-            || Ok(()),
-            || Err(io::Error::other("injected before final configuration")),
-        ) {
-            Ok(_) => panic!("injected post-bind failure succeeded"),
-            Err(error) => error,
-        };
-
-        // Then
-        assert_eq!(error.kind(), io::ErrorKind::Other);
-        assert!(!path.exists());
-        assert!(!created.exists());
-        let listeners = bind_unix_source(&path, None, || Ok(()), || Ok(())).unwrap();
-        assert!(path.exists());
-        drop(listeners);
-        assert!(!path.exists());
-        assert!(!created.exists());
-        let _ = fs::remove_dir(root);
-    }
-
-    #[cfg(unix)]
-    #[test]
     fn unix_source_bind_uses_openssh_default_owner_only_mode() {
         // Given
-        let path = std::env::temp_dir().join(format!("et-forward-mode-{}", std::process::id()));
+        let path = PathBuf::from(format!("/tmp/et-forward-mode-{}", std::process::id()));
         let endpoint = ResolvedEndpoint::Unix(path.clone());
 
         // When
@@ -737,153 +772,70 @@ mod tests {
         drop(listeners);
     }
 
-    struct BlockingResolver {
-        started: std::sync::mpsc::Sender<String>,
-        released: Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>,
-    }
-
-    impl ForwardResolver for BlockingResolver {
-        fn resolve(&self, host: &str, _port: u16) -> io::Result<Vec<std::net::SocketAddr>> {
-            let _ = self.started.send(host.to_owned());
-            if host.starts_with("active-") {
-                let (released, changed) = &*self.released;
-                let mut released = released.lock().unwrap();
-                while !*released {
-                    released = changed.wait(released).unwrap();
-                }
-            }
-            Ok(Vec::new())
-        }
-    }
-
+    #[cfg(unix)]
     #[test]
-    fn expired_queued_resolutions_are_skipped_and_fresh_work_starts() {
-        let (started_tx, started_rx) = std::sync::mpsc::channel();
-        let released = Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new()));
-        let resolver: Arc<dyn ForwardResolver> = Arc::new(BlockingResolver {
-            started: started_tx,
-            released: released.clone(),
-        });
-        let mut active = Vec::new();
-        for index in 0..crate::forward::RESOLVER_WORKERS {
-            let resolver = resolver.clone();
-            active.push(std::thread::spawn(move || {
-                ResolverExecutor::global().resolve(
-                    resolver,
-                    format!("active-{index}.test"),
-                    1,
-                    Instant::now() + Duration::from_secs(5),
-                )
-            }));
-        }
-        for _ in 0..crate::forward::RESOLVER_WORKERS {
-            assert!(started_rx
-                .recv_timeout(Duration::from_secs(1))
-                .unwrap()
-                .starts_with("active-"));
-        }
+    fn failed_unix_listener_setup_removes_socket_and_created_parent() {
+        let base = PathBuf::from(format!(
+            "/tmp/et-forward-rollback-{}",
+            et_core::keys::gen_id_passkey().0
+        ));
+        fs::create_dir(&base).unwrap();
+        let created_parent = base.join("created");
+        let path = created_parent.join("source.sock");
 
-        let mut queued = Vec::new();
-        for index in 0..crate::forward::RESOLVER_QUEUE_CAPACITY {
-            let resolver = resolver.clone();
-            queued.push(std::thread::spawn(move || {
-                ResolverExecutor::global().resolve(
-                    resolver,
-                    format!("expired-{index}.test"),
-                    1,
-                    Instant::now() + Duration::from_millis(100),
-                )
-            }));
-        }
-        for caller in queued {
-            assert_eq!(
-                caller.join().unwrap().unwrap_err().kind(),
-                io::ErrorKind::TimedOut
-            );
-        }
-        assert!(
-            started_rx.try_recv().is_err(),
-            "queued callback ran before release"
-        );
-
-        let fresh_resolver = resolver.clone();
-        let fresh = std::thread::spawn(move || {
-            ResolverExecutor::global().resolve(
-                fresh_resolver,
-                "fresh.test".to_owned(),
-                1,
-                Instant::now() + Duration::from_secs(1),
-            )
-        });
-        assert!(
-            started_rx.try_recv().is_err(),
-            "fresh callback ran while all workers were active"
-        );
-        let (is_released, changed) = &*released;
-        *is_released.lock().unwrap() = true;
-        changed.notify_all();
-        assert_eq!(
-            started_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
-            "fresh.test"
-        );
-        for caller in active {
-            caller.join().unwrap().unwrap();
-        }
-        fresh.join().unwrap().unwrap();
-        assert!(
-            started_rx.try_recv().is_err(),
-            "expired queued resolver callback was invoked"
-        );
-    }
-
-    struct DelayedResolver(std::net::SocketAddr);
-
-    impl ForwardResolver for DelayedResolver {
-        fn resolve(&self, _host: &str, _port: u16) -> io::Result<Vec<std::net::SocketAddr>> {
-            std::thread::sleep(Duration::from_millis(200));
-            Ok(vec![self.0])
-        }
-    }
-
-    #[test]
-    fn delayed_resolution_times_out_without_late_listener_creation() {
-        let probe = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
-        let address = probe.local_addr().unwrap();
-        drop(probe);
-        let endpoint = Endpoint::Tcp {
-            host: "delayed.valid.test".to_owned(),
-            port: address.port(),
-        };
-        let error = match endpoint.resolve_for_bind_deadline(
-            Instant::now() + Duration::from_millis(50),
-            Arc::new(DelayedResolver(address)),
-        ) {
-            Ok(_) => panic!("delayed resolution exceeded its deadline"),
+        let error = match bind_unix_locally_with(&path, |_| {
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "injected post-bind setup failure",
+            ))
+        }) {
+            Ok(_) => panic!("injected listener setup failure unexpectedly succeeded"),
             Err(error) => error,
         };
-        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
-        std::thread::sleep(Duration::from_millis(250));
-        TcpListener::bind(address).expect("cancelled resolver created a late listener");
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(!path.exists());
+        assert!(!created_parent.exists());
+        fs::remove_dir(base).unwrap();
     }
 
     #[cfg(unix)]
     #[test]
-    fn old_listener_drop_does_not_unlink_replacement_generation() {
-        let directory =
-            std::env::temp_dir().join(format!("et-forward-generation-{}", std::process::id()));
-        std::fs::create_dir_all(&directory).unwrap();
-        let path = directory.join("source.sock");
-        let endpoint = Endpoint::Unix(path.clone());
-        let old = endpoint.bind().unwrap();
-        std::fs::remove_file(&path).unwrap();
-        let replacement = UnixListener::bind(&path).unwrap();
-        drop(old);
-        let client = UnixStream::connect(&path).expect("old listener unlinked replacement path");
-        replacement.accept().unwrap();
-        drop(client);
-        drop(replacement);
-        std::fs::remove_file(path).unwrap();
-        std::fs::remove_dir(directory).unwrap();
+    fn failed_directory_creation_removes_created_ancestors() {
+        struct RemoveDirectory(PathBuf);
+
+        impl Drop for RemoveDirectory {
+            fn drop(&mut self) {
+                let _ = fs::remove_dir_all(&self.0);
+            }
+        }
+
+        let base = PathBuf::from(format!(
+            "/tmp/et-forward-directory-rollback-{}",
+            et_core::keys::gen_id_passkey().0
+        ));
+        fs::create_dir(&base).unwrap();
+        let _cleanup = RemoveDirectory(base.clone());
+        let created = base.join("created");
+        let parent = created.join("nested");
+        let mut calls = 0;
+
+        let error = match create_missing_directories_with(&parent, |directory| {
+            calls += 1;
+            if calls == 2 {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "injected directory creation failure",
+                ));
+            }
+            fs::create_dir(directory)
+        }) {
+            Ok(_) => panic!("injected directory creation failure unexpectedly succeeded"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(!created.exists());
     }
 
     #[test]
@@ -935,6 +887,19 @@ mod tests {
         let addresses = distinct_tcp_addresses([address, address]);
 
         assert_eq!(bind_tcp_addresses(addresses).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn bounded_resolution_counts_only_distinct_addresses() {
+        let first = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 1));
+        let second = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 2));
+        let error =
+            collect_distinct_addresses(Ok(vec![first, first, second].into_iter()), 1).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(
+            collect_distinct_addresses(Ok(vec![first, first].into_iter()), 1).unwrap(),
+            [first]
+        );
     }
 
     #[test]

--- a/crates/et-net/src/forward_endpoint.rs
+++ b/crates/et-net/src/forward_endpoint.rs
@@ -6,18 +6,15 @@ use std::net::{Shutdown, TcpListener, TcpStream, ToSocketAddrs};
 use std::os::unix::fs::PermissionsExt;
 #[cfg(unix)]
 use std::os::unix::net::{UnixListener, UnixStream};
-#[cfg(unix)]
-use std::path::Path;
 use std::path::PathBuf;
-use std::sync::mpsc::{sync_channel, SyncSender, TrySendError};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+use crate::forward::{ForwardResolver, ResolverExecutor};
 
 use et_core::proto::SocketEndpoint;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
-const RESOLVER_WORKERS: usize = 4;
-const RESOLVER_QUEUE: usize = 32;
 
 #[derive(Clone, Debug)]
 pub(crate) enum Endpoint {
@@ -123,11 +120,6 @@ impl Endpoint {
     pub(crate) fn connect_with_user(&self, user: Option<(u32, u32)>) -> io::Result<ForwardStream> {
         match (self, user) {
             #[cfg(unix)]
-            (Self::Tcp { host, port }, Some((uid, gid))) => {
-                crate::user_socket_ops::connect_tcp_as_user(host, *port, uid, gid)
-                    .map(ForwardStream::Tcp)
-            }
-            #[cfg(unix)]
             (Self::Unix(path), Some((uid, gid))) => {
                 crate::user_socket_ops::connect_unix_as_user(path, uid, gid)
                     .map(ForwardStream::Unix)
@@ -138,18 +130,53 @@ impl Endpoint {
 
     pub(crate) fn connect(&self) -> io::Result<ForwardStream> {
         match self {
-            Self::Tcp { host, port } => connect_tcp(host, *port).map(ForwardStream::Tcp),
+            Self::Tcp { host, port } => {
+                // Upstream connects to localhost destinations by trying ::1
+                // first and falling back to 127.0.0.1.
+                if host.eq_ignore_ascii_case("localhost") {
+                    let v6 = std::net::SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, *port));
+                    match TcpStream::connect_timeout(&v6, CONNECT_TIMEOUT) {
+                        Ok(stream) => return Ok(ForwardStream::Tcp(stream)),
+                        Err(_) => {
+                            let v4 =
+                                std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, *port));
+                            return TcpStream::connect_timeout(&v4, CONNECT_TIMEOUT)
+                                .map(ForwardStream::Tcp);
+                        }
+                    }
+                }
+                let mut last_error = None;
+                for address in (host.as_str(), *port).to_socket_addrs()? {
+                    match TcpStream::connect_timeout(&address, CONNECT_TIMEOUT) {
+                        Ok(stream) => return Ok(ForwardStream::Tcp(stream)),
+                        Err(error) => last_error = Some(error),
+                    }
+                }
+                Err(last_error.unwrap_or_else(|| {
+                    io::Error::new(io::ErrorKind::AddrNotAvailable, "endpoint did not resolve")
+                }))
+            }
             #[cfg(unix)]
             Self::Unix(path) => UnixStream::connect(path).map(ForwardStream::Unix),
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn resolve_for_bind(&self) -> io::Result<ResolvedEndpoint> {
+        self.resolve_for_bind_deadline(
+            Instant::now() + Duration::from_secs(30),
+            Arc::new(crate::forward::SystemForwardResolver),
+        )
+    }
+
+    pub(crate) fn resolve_for_bind_deadline(
+        &self,
+        deadline: Instant,
+        resolver: Arc<dyn ForwardResolver>,
+    ) -> io::Result<ResolvedEndpoint> {
+        ensure_deadline(deadline)?;
         match self {
             Self::Tcp { host, port } => {
-                // Mirror upstream `TcpSocketHandler::listen`: resolve the bind
-                // name with getaddrinfo semantics and bind every distinct
-                // address ("localhost" usually yields both loopback families).
                 let addresses = if host.is_empty() {
                     vec![
                         (std::net::Ipv6Addr::UNSPECIFIED, *port).into(),
@@ -161,28 +188,10 @@ impl Endpoint {
                         (std::net::Ipv4Addr::LOCALHOST, *port).into(),
                     ]
                 } else {
-                    (host.as_str(), *port).to_socket_addrs()?.collect()
+                    resolve_before_deadline(resolver, host.clone(), *port, deadline)?
                 };
+                ensure_deadline(deadline)?;
                 Ok(ResolvedEndpoint::Tcp(distinct_tcp_addresses(addresses)))
-            }
-            #[cfg(unix)]
-            Self::Unix(path) => Ok(ResolvedEndpoint::Unix(path.clone())),
-        }
-    }
-
-    pub(crate) fn resolve_for_bind_until(
-        &self,
-        deadline: Instant,
-        max_addresses: usize,
-    ) -> io::Result<ResolvedEndpoint> {
-        match self {
-            Self::Tcp { host, port } if host.is_empty() => Ok(ResolvedEndpoint::Tcp(vec![
-                (std::net::Ipv6Addr::UNSPECIFIED, *port).into(),
-                (std::net::Ipv4Addr::UNSPECIFIED, *port).into(),
-            ])),
-            Self::Tcp { host, port } => {
-                resolve_tcp_bounded(host.clone(), *port, deadline, max_addresses)
-                    .map(ResolvedEndpoint::Tcp)
             }
             #[cfg(unix)]
             Self::Unix(path) => Ok(ResolvedEndpoint::Unix(path.clone())),
@@ -192,147 +201,6 @@ impl Endpoint {
     #[cfg(test)]
     pub(crate) fn bind(&self) -> io::Result<Vec<ForwardListener>> {
         self.resolve_for_bind()?.bind_with_user(None)
-    }
-}
-
-pub(crate) fn connect_tcp(host: &str, port: u16) -> io::Result<TcpStream> {
-    // Preserve upstream's dual-stack localhost ordering while allowing
-    // explicitly configured destination names under the session identity.
-    if host.eq_ignore_ascii_case("localhost") {
-        let v6 = std::net::SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, port));
-        match TcpStream::connect_timeout(&v6, CONNECT_TIMEOUT) {
-            Ok(stream) => return Ok(stream),
-            Err(_) => {
-                let v4 = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, port));
-                return TcpStream::connect_timeout(&v4, CONNECT_TIMEOUT);
-            }
-        }
-    }
-    let mut last_error = None;
-    for address in (host, port).to_socket_addrs()? {
-        match TcpStream::connect_timeout(&address, CONNECT_TIMEOUT) {
-            Ok(stream) => return Ok(stream),
-            Err(error) => last_error = Some(error),
-        }
-    }
-    Err(last_error.unwrap_or_else(|| {
-        io::Error::new(io::ErrorKind::AddrNotAvailable, "endpoint did not resolve")
-    }))
-}
-
-struct ResolveJob {
-    host: String,
-    port: u16,
-    deadline: Instant,
-    max_addresses: usize,
-    reply: SyncSender<io::Result<Vec<std::net::SocketAddr>>>,
-}
-
-fn resolve_tcp_bounded(
-    host: String,
-    port: u16,
-    deadline: Instant,
-    max_addresses: usize,
-) -> io::Result<Vec<std::net::SocketAddr>> {
-    let remaining = deadline
-        .checked_duration_since(Instant::now())
-        .filter(|remaining| !remaining.is_zero())
-        .ok_or_else(|| io::Error::from(io::ErrorKind::TimedOut))?;
-    let (reply, result) = sync_channel(1);
-    let job = ResolveJob {
-        host,
-        port,
-        deadline,
-        max_addresses,
-        reply,
-    };
-    match resolver_pool().try_send(job) {
-        Ok(()) => {}
-        Err(TrySendError::Full(_)) => {
-            return Err(io::Error::new(
-                io::ErrorKind::WouldBlock,
-                "forward resolver queue is full",
-            ));
-        }
-        Err(TrySendError::Disconnected(_)) => {
-            return Err(io::Error::new(
-                io::ErrorKind::BrokenPipe,
-                "forward resolver pool stopped",
-            ));
-        }
-    }
-    result
-        .recv_timeout(remaining)
-        .map_err(|error| match error {
-            std::sync::mpsc::RecvTimeoutError::Timeout => io::Error::from(io::ErrorKind::TimedOut),
-            std::sync::mpsc::RecvTimeoutError::Disconnected => {
-                io::Error::new(io::ErrorKind::BrokenPipe, "forward resolver worker stopped")
-            }
-        })?
-}
-
-fn resolver_pool() -> &'static SyncSender<ResolveJob> {
-    static POOL: OnceLock<SyncSender<ResolveJob>> = OnceLock::new();
-    POOL.get_or_init(|| {
-        let (sender, receiver) = sync_channel::<ResolveJob>(RESOLVER_QUEUE);
-        let receiver = Arc::new(Mutex::new(receiver));
-        for index in 0..RESOLVER_WORKERS {
-            let receiver = receiver.clone();
-            let _ = std::thread::Builder::new()
-                .name(format!("et-forward-resolver-{index}"))
-                .spawn(move || resolver_worker(&receiver));
-        }
-        sender
-    })
-}
-
-fn resolver_worker(receiver: &Mutex<std::sync::mpsc::Receiver<ResolveJob>>) {
-    loop {
-        let job = {
-            let Ok(receiver) = receiver.lock() else {
-                return;
-            };
-            let Ok(job) = receiver.recv() else {
-                return;
-            };
-            job
-        };
-        let result = if Instant::now() >= job.deadline {
-            Err(io::Error::from(io::ErrorKind::TimedOut))
-        } else {
-            collect_distinct_addresses(
-                (job.host.as_str(), job.port).to_socket_addrs(),
-                job.max_addresses,
-            )
-        };
-        let _ = job.reply.send(result);
-    }
-}
-
-fn collect_distinct_addresses(
-    addresses: io::Result<impl Iterator<Item = std::net::SocketAddr>>,
-    max_addresses: usize,
-) -> io::Result<Vec<std::net::SocketAddr>> {
-    let mut seen = HashSet::new();
-    let mut resolved = Vec::new();
-    for address in addresses? {
-        if seen.insert(address) {
-            if resolved.len() >= max_addresses {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "forward source exceeds listener limit",
-                ));
-            }
-            resolved.push(address);
-        }
-    }
-    if resolved.is_empty() {
-        Err(io::Error::new(
-            io::ErrorKind::AddrNotAvailable,
-            "endpoint did not resolve",
-        ))
-    } else {
-        Ok(resolved)
     }
 }
 
@@ -351,198 +219,172 @@ impl ResolvedEndpoint {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn bind_with_user(
         &self,
         user: Option<(u32, u32)>,
     ) -> io::Result<Vec<ForwardListener>> {
-        match (self, user) {
-            #[cfg(unix)]
-            (Self::Tcp(addresses), Some((uid, gid))) => {
-                bind_tcp_addresses_with(addresses.iter().copied(), |address| {
-                    crate::user_socket_ops::listen_tcp_as_user(address, uid, gid).map(Some)
-                })
-            }
-            (Self::Tcp(addresses), _) => bind_tcp_addresses(addresses.iter().copied()),
-            #[cfg(unix)]
-            (Self::Unix(path), Some((uid, gid))) => {
-                let listener = crate::user_socket_ops::listen_unix_as_user(path, uid, gid)?;
-                let (listener, cleanup) = listener.into_parts();
-                listener.set_nonblocking(true)?;
-                let path_cleanup = cleanup.is_none().then(|| path.clone());
-                Ok(vec![ForwardListener {
-                    inner: ListenerKind::Unix(listener),
-                    cleanup: path_cleanup,
-                    user_cleanup: cleanup,
-                    cleanup_dirs: Vec::new(),
-                }])
-            }
-            #[cfg(unix)]
-            (Self::Unix(path), None) => bind_unix_locally_with(path, |listener| {
-                fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
-                listener.set_nonblocking(true)
-            })
-            .map(|listener| vec![listener]),
-        }
+        self.bind_with_user_deadline(user, Instant::now() + Duration::from_secs(30))
     }
 
-    pub(crate) fn bind_with_user_until(
+    #[cfg(test)]
+    pub(crate) fn bind_with_user_deadline(
         &self,
         user: Option<(u32, u32)>,
-        #[cfg_attr(windows, allow(unused_variables))] deadline: Instant,
+        deadline: Instant,
     ) -> io::Result<Vec<ForwardListener>> {
-        match (self, user) {
+        self.bind_with_user_deadline_resolver(
+            user,
+            deadline,
+            Arc::new(crate::forward::SystemForwardResolver),
+        )
+    }
+
+    pub(crate) fn bind_with_user_deadline_resolver(
+        &self,
+        user: Option<(u32, u32)>,
+        deadline: Instant,
+        _resolver: Arc<dyn ForwardResolver>,
+    ) -> io::Result<Vec<ForwardListener>> {
+        ensure_deadline(deadline)?;
+        let listeners = match (self, user) {
             #[cfg(unix)]
             (Self::Tcp(addresses), Some((uid, gid))) => {
                 bind_tcp_addresses_with(addresses.iter().copied(), |address| {
-                    crate::user_socket_ops::listen_tcp_as_user_until(address, uid, gid, deadline)
-                        .map(Some)
+                    ensure_deadline(deadline)?;
+                    let listener = _resolver.listen_tcp_as_user(address, uid, gid, deadline)?;
+                    ensure_deadline(deadline)?;
+                    Ok(Some(listener))
                 })
             }
-            #[cfg(unix)]
-            (Self::Unix(path), Some((uid, gid))) => {
-                let listener =
-                    crate::user_socket_ops::listen_unix_as_user_until(path, uid, gid, deadline)?;
-                let (listener, cleanup) = listener.into_parts();
-                listener.set_nonblocking(true)?;
-                let path_cleanup = cleanup.is_none().then(|| path.clone());
-                Ok(vec![ForwardListener {
-                    inner: ListenerKind::Unix(listener),
-                    cleanup: path_cleanup,
-                    user_cleanup: cleanup,
-                    cleanup_dirs: Vec::new(),
-                }])
+            (Self::Tcp(addresses), _) => {
+                bind_tcp_addresses_deadline(addresses.iter().copied(), deadline)
             }
-            _ => self.bind_with_user(user),
-        }
+            #[cfg(unix)]
+            (Self::Unix(path), user) => {
+                let listeners = bind_unix_source_deadline(
+                    path,
+                    user,
+                    deadline,
+                    || ensure_deadline(deadline),
+                    || ensure_deadline(deadline),
+                )?;
+                ensure_deadline(deadline)?;
+                Ok(listeners)
+            }
+        }?;
+        ensure_deadline(deadline)?;
+        Ok(listeners)
     }
 }
 
 #[cfg(unix)]
-fn bind_unix_locally_with(
-    path: &Path,
-    configure: impl FnOnce(&UnixListener) -> io::Result<()>,
-) -> io::Result<ForwardListener> {
+fn bind_unix_source_deadline(
+    path: &std::path::Path,
+    user: Option<(u32, u32)>,
+    deadline: Instant,
+    after_directory: impl FnOnce() -> io::Result<()>,
+    after_bind: impl FnOnce() -> io::Result<()>,
+) -> io::Result<Vec<ForwardListener>> {
     if path.exists() {
         return Err(io::Error::new(
             io::ErrorKind::AddrInUse,
             "Unix source socket already exists",
         ));
     }
-    let mut parent_cleanup = None;
-    if let Some(parent) = path.parent() {
-        if !parent.exists() {
-            parent_cleanup = Some(create_missing_directories_with(parent, |directory| {
-                fs::create_dir(directory)
-            })?);
+    let mut directory_guard = None;
+    if user.is_none() {
+        if let Some(parent) = path.parent().filter(|parent| !parent.exists()) {
+            fs::create_dir_all(parent)?;
+            directory_guard = Some(PathCleanup::directory(parent.to_path_buf()));
+            after_directory()?;
             fs::set_permissions(parent, fs::Permissions::from_mode(0o700))?;
         }
     }
-    let listener = UnixListener::bind(path)?;
-    finish_unix_listener_with(listener, path, parent_cleanup, configure)
-}
-
-#[cfg(unix)]
-fn finish_unix_listener_with(
-    listener: UnixListener,
-    path: &Path,
-    mut cleanup_dirs: Option<PendingDirectories>,
-    configure: impl FnOnce(&UnixListener) -> io::Result<()>,
-) -> io::Result<ForwardListener> {
-    let mut socket_cleanup = PendingPath::socket(path.to_path_buf());
-    configure(&listener)?;
-    Ok(ForwardListener {
+    let (listener, identity) = match user {
+        Some((uid, gid)) => {
+            crate::user_socket_ops::listen_unix_as_user_owned_deadline(path, uid, gid, deadline)?
+        }
+        None => crate::user_socket_ops::bind_staged(path, deadline)?,
+    };
+    let setup = (|| {
+        after_bind()?;
+        if user.is_none() {
+            fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+        }
+        listener.set_nonblocking(true)?;
+        Ok(())
+    })();
+    if let Err(error) = setup {
+        drop(listener);
+        crate::user_socket_ops::remove_socket_if_owned(path, identity);
+        return Err(error);
+    }
+    Ok(vec![ForwardListener {
         inner: ListenerKind::Unix(listener),
-        cleanup: socket_cleanup.disarm(),
-        user_cleanup: None,
-        cleanup_dirs: cleanup_dirs
-            .as_mut()
-            .and_then(PendingDirectories::disarm)
-            .unwrap_or_default(),
-    })
+        cleanup: Some((path.to_path_buf(), identity)),
+        cleanup_dir: directory_guard.and_then(PathCleanup::disarm),
+    }])
+}
+
+#[cfg(all(test, unix))]
+fn bind_unix_source(
+    path: &std::path::Path,
+    user: Option<(u32, u32)>,
+    after_directory: impl FnOnce() -> io::Result<()>,
+    after_bind: impl FnOnce() -> io::Result<()>,
+) -> io::Result<Vec<ForwardListener>> {
+    bind_unix_source_deadline(
+        path,
+        user,
+        Instant::now() + Duration::from_secs(30),
+        after_directory,
+        after_bind,
+    )
 }
 
 #[cfg(unix)]
-struct PendingPath {
+struct PathCleanup {
     path: Option<PathBuf>,
 }
 
 #[cfg(unix)]
-impl PendingPath {
-    fn socket(path: PathBuf) -> Self {
+impl PathCleanup {
+    fn directory(path: PathBuf) -> Self {
         Self { path: Some(path) }
     }
 
-    fn disarm(&mut self) -> Option<PathBuf> {
+    fn disarm(mut self) -> Option<PathBuf> {
         self.path.take()
     }
 }
 
 #[cfg(unix)]
-impl Drop for PendingPath {
+impl Drop for PathCleanup {
     fn drop(&mut self) {
         if let Some(path) = self.path.as_ref() {
-            let _ = fs::remove_file(path);
+            let _ = fs::remove_dir(path);
         }
     }
 }
 
-#[cfg(unix)]
-fn missing_directories(parent: &Path) -> Vec<PathBuf> {
-    let mut directories = Vec::new();
-    let mut current = Some(parent);
-    while let Some(path) = current {
-        if path.exists() {
-            break;
-        }
-        directories.push(path.to_path_buf());
-        current = path.parent();
-    }
-    directories
-}
-
-#[cfg(unix)]
-fn create_missing_directories_with(
-    parent: &Path,
-    mut create: impl FnMut(&Path) -> io::Result<()>,
-) -> io::Result<PendingDirectories> {
-    let directories = missing_directories(parent);
-    let mut cleanup = PendingDirectories(Some(Vec::with_capacity(directories.len())));
-    for directory in directories.iter().rev() {
-        create(directory)?;
-        cleanup
-            .0
-            .as_mut()
-            .expect("pending directory cleanup")
-            .insert(0, directory.clone());
-    }
-    Ok(cleanup)
-}
-
-#[cfg(unix)]
-struct PendingDirectories(Option<Vec<PathBuf>>);
-
-#[cfg(unix)]
-impl PendingDirectories {
-    fn disarm(&mut self) -> Option<Vec<PathBuf>> {
-        self.0.take()
-    }
-}
-
-#[cfg(unix)]
-impl Drop for PendingDirectories {
-    fn drop(&mut self) {
-        if let Some(paths) = self.0.take() {
-            for path in paths {
-                let _ = fs::remove_dir(path);
-            }
-        }
-    }
-}
-
+#[cfg(test)]
 fn bind_tcp_addresses(
     addresses: impl IntoIterator<Item = std::net::SocketAddr>,
 ) -> io::Result<Vec<ForwardListener>> {
-    bind_tcp_addresses_with(addresses, bind_tcp_single_family)
+    bind_tcp_addresses_deadline(addresses, Instant::now() + Duration::from_secs(30))
+}
+
+fn bind_tcp_addresses_deadline(
+    addresses: impl IntoIterator<Item = std::net::SocketAddr>,
+    deadline: Instant,
+) -> io::Result<Vec<ForwardListener>> {
+    bind_tcp_addresses_with(addresses, |address| {
+        ensure_deadline(deadline)?;
+        let listener = bind_tcp_single_family(address)?;
+        ensure_deadline(deadline)?;
+        Ok(listener)
+    })
 }
 
 fn bind_tcp_addresses_with(
@@ -554,10 +396,9 @@ fn bind_tcp_addresses_with(
         if let Some(listener) = bind(address)? {
             listeners.push(ForwardListener {
                 inner: ListenerKind::Tcp(listener),
-                cleanup: None,
                 #[cfg(unix)]
-                user_cleanup: None,
-                cleanup_dirs: Vec::new(),
+                cleanup: None,
+                cleanup_dir: None,
             });
         }
     }
@@ -568,6 +409,26 @@ fn bind_tcp_addresses_with(
         ));
     }
     Ok(listeners)
+}
+
+fn ensure_deadline(deadline: Instant) -> io::Result<()> {
+    if Instant::now() >= deadline {
+        Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "forwarding setup deadline elapsed",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn resolve_before_deadline(
+    resolver: Arc<dyn ForwardResolver>,
+    host: String,
+    port: u16,
+    deadline: Instant,
+) -> io::Result<Vec<std::net::SocketAddr>> {
+    ResolverExecutor::global().resolve(resolver, host, port, deadline)
 }
 
 fn distinct_tcp_addresses(
@@ -691,12 +552,14 @@ enum ListenerKind {
     Unix(UnixListener),
 }
 
+#[cfg(unix)]
+type ListenerCleanup = (PathBuf, crate::user_socket_ops::UnixSocketIdentity);
+
 pub(crate) struct ForwardListener {
     inner: ListenerKind,
-    cleanup: Option<PathBuf>,
     #[cfg(unix)]
-    user_cleanup: Option<crate::user_socket_ops::UserSocketCleanup>,
-    cleanup_dirs: Vec<PathBuf>,
+    cleanup: Option<ListenerCleanup>,
+    cleanup_dir: Option<PathBuf>,
 }
 
 impl ForwardListener {
@@ -704,7 +567,7 @@ impl ForwardListener {
     /// private named-pipe directories created for environment forwards).
     #[cfg(unix)]
     pub(crate) fn also_remove_dir(&mut self, directory: PathBuf) {
-        self.cleanup_dirs.push(directory);
+        self.cleanup_dir = Some(directory);
     }
 
     pub(crate) fn accept(&self) -> io::Result<ForwardStream> {
@@ -736,11 +599,10 @@ impl std::os::fd::AsFd for ForwardListener {
 impl Drop for ForwardListener {
     fn drop(&mut self) {
         #[cfg(unix)]
-        drop(self.user_cleanup.take());
-        if let Some(path) = self.cleanup.as_ref() {
-            let _ = fs::remove_file(path);
+        if let Some((path, identity)) = self.cleanup.as_ref() {
+            crate::user_socket_ops::remove_socket_if_owned(path, *identity);
         }
-        for path in &self.cleanup_dirs {
+        if let Some(path) = self.cleanup_dir.as_ref() {
             let _ = fs::remove_dir(path);
         }
     }
@@ -798,9 +660,70 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn unix_source_failure_after_directory_creation_cleans_and_retries() {
+        // Given
+        let root = std::env::temp_dir().join(format!("et-fwd-dir-{}", std::process::id()));
+        let path = root.join("created").join("source.sock");
+        let created = path.parent().unwrap().to_path_buf();
+
+        // When
+        let error = match bind_unix_source(
+            &path,
+            None,
+            || Err(io::Error::other("injected after directory creation")),
+            || Ok(()),
+        ) {
+            Ok(_) => panic!("injected directory failure succeeded"),
+            Err(error) => error,
+        };
+
+        // Then
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert!(!created.exists());
+        let listeners = bind_unix_source(&path, None, || Ok(()), || Ok(())).unwrap();
+        assert!(path.exists());
+        drop(listeners);
+        assert!(!path.exists());
+        assert!(!created.exists());
+        let _ = fs::remove_dir(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_source_failure_after_bind_cleans_socket_and_directory_then_retries() {
+        // Given
+        let root = std::env::temp_dir().join(format!("et-fwd-bind-{}", std::process::id()));
+        let path = root.join("created").join("source.sock");
+        let created = path.parent().unwrap().to_path_buf();
+
+        // When
+        let error = match bind_unix_source(
+            &path,
+            None,
+            || Ok(()),
+            || Err(io::Error::other("injected before final configuration")),
+        ) {
+            Ok(_) => panic!("injected post-bind failure succeeded"),
+            Err(error) => error,
+        };
+
+        // Then
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert!(!path.exists());
+        assert!(!created.exists());
+        let listeners = bind_unix_source(&path, None, || Ok(()), || Ok(())).unwrap();
+        assert!(path.exists());
+        drop(listeners);
+        assert!(!path.exists());
+        assert!(!created.exists());
+        let _ = fs::remove_dir(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn unix_source_bind_uses_openssh_default_owner_only_mode() {
         // Given
-        let path = PathBuf::from(format!("/tmp/et-forward-mode-{}", std::process::id()));
+        let path = std::env::temp_dir().join(format!("et-forward-mode-{}", std::process::id()));
         let endpoint = ResolvedEndpoint::Unix(path.clone());
 
         // When
@@ -814,70 +737,153 @@ mod tests {
         drop(listeners);
     }
 
-    #[cfg(unix)]
-    #[test]
-    fn failed_unix_listener_setup_removes_socket_and_created_parent() {
-        let base = PathBuf::from(format!(
-            "/tmp/et-forward-rollback-{}",
-            et_core::keys::gen_id_passkey().0
-        ));
-        fs::create_dir(&base).unwrap();
-        let created_parent = base.join("created");
-        let path = created_parent.join("source.sock");
+    struct BlockingResolver {
+        started: std::sync::mpsc::Sender<String>,
+        released: Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>,
+    }
 
-        let error = match bind_unix_locally_with(&path, |_| {
-            Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                "injected post-bind setup failure",
-            ))
-        }) {
-            Ok(_) => panic!("injected listener setup failure unexpectedly succeeded"),
+    impl ForwardResolver for BlockingResolver {
+        fn resolve(&self, host: &str, _port: u16) -> io::Result<Vec<std::net::SocketAddr>> {
+            let _ = self.started.send(host.to_owned());
+            if host.starts_with("active-") {
+                let (released, changed) = &*self.released;
+                let mut released = released.lock().unwrap();
+                while !*released {
+                    released = changed.wait(released).unwrap();
+                }
+            }
+            Ok(Vec::new())
+        }
+    }
+
+    #[test]
+    fn expired_queued_resolutions_are_skipped_and_fresh_work_starts() {
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let released = Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new()));
+        let resolver: Arc<dyn ForwardResolver> = Arc::new(BlockingResolver {
+            started: started_tx,
+            released: released.clone(),
+        });
+        let mut active = Vec::new();
+        for index in 0..crate::forward::RESOLVER_WORKERS {
+            let resolver = resolver.clone();
+            active.push(std::thread::spawn(move || {
+                ResolverExecutor::global().resolve(
+                    resolver,
+                    format!("active-{index}.test"),
+                    1,
+                    Instant::now() + Duration::from_secs(5),
+                )
+            }));
+        }
+        for _ in 0..crate::forward::RESOLVER_WORKERS {
+            assert!(started_rx
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap()
+                .starts_with("active-"));
+        }
+
+        let mut queued = Vec::new();
+        for index in 0..crate::forward::RESOLVER_QUEUE_CAPACITY {
+            let resolver = resolver.clone();
+            queued.push(std::thread::spawn(move || {
+                ResolverExecutor::global().resolve(
+                    resolver,
+                    format!("expired-{index}.test"),
+                    1,
+                    Instant::now() + Duration::from_millis(100),
+                )
+            }));
+        }
+        for caller in queued {
+            assert_eq!(
+                caller.join().unwrap().unwrap_err().kind(),
+                io::ErrorKind::TimedOut
+            );
+        }
+        assert!(
+            started_rx.try_recv().is_err(),
+            "queued callback ran before release"
+        );
+
+        let fresh_resolver = resolver.clone();
+        let fresh = std::thread::spawn(move || {
+            ResolverExecutor::global().resolve(
+                fresh_resolver,
+                "fresh.test".to_owned(),
+                1,
+                Instant::now() + Duration::from_secs(1),
+            )
+        });
+        assert!(
+            started_rx.try_recv().is_err(),
+            "fresh callback ran while all workers were active"
+        );
+        let (is_released, changed) = &*released;
+        *is_released.lock().unwrap() = true;
+        changed.notify_all();
+        assert_eq!(
+            started_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            "fresh.test"
+        );
+        for caller in active {
+            caller.join().unwrap().unwrap();
+        }
+        fresh.join().unwrap().unwrap();
+        assert!(
+            started_rx.try_recv().is_err(),
+            "expired queued resolver callback was invoked"
+        );
+    }
+
+    struct DelayedResolver(std::net::SocketAddr);
+
+    impl ForwardResolver for DelayedResolver {
+        fn resolve(&self, _host: &str, _port: u16) -> io::Result<Vec<std::net::SocketAddr>> {
+            std::thread::sleep(Duration::from_millis(200));
+            Ok(vec![self.0])
+        }
+    }
+
+    #[test]
+    fn delayed_resolution_times_out_without_late_listener_creation() {
+        let probe = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let address = probe.local_addr().unwrap();
+        drop(probe);
+        let endpoint = Endpoint::Tcp {
+            host: "delayed.valid.test".to_owned(),
+            port: address.port(),
+        };
+        let error = match endpoint.resolve_for_bind_deadline(
+            Instant::now() + Duration::from_millis(50),
+            Arc::new(DelayedResolver(address)),
+        ) {
+            Ok(_) => panic!("delayed resolution exceeded its deadline"),
             Err(error) => error,
         };
-
-        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
-        assert!(!path.exists());
-        assert!(!created_parent.exists());
-        fs::remove_dir(base).unwrap();
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        std::thread::sleep(Duration::from_millis(250));
+        TcpListener::bind(address).expect("cancelled resolver created a late listener");
     }
 
     #[cfg(unix)]
     #[test]
-    fn failed_directory_creation_removes_created_ancestors() {
-        struct RemoveDirectory(PathBuf);
-
-        impl Drop for RemoveDirectory {
-            fn drop(&mut self) {
-                let _ = fs::remove_dir_all(&self.0);
-            }
-        }
-
-        let base = PathBuf::from(format!(
-            "/tmp/et-forward-directory-rollback-{}",
-            et_core::keys::gen_id_passkey().0
-        ));
-        fs::create_dir(&base).unwrap();
-        let _cleanup = RemoveDirectory(base.clone());
-        let created = base.join("created");
-        let parent = created.join("nested");
-        let mut calls = 0;
-
-        let error = match create_missing_directories_with(&parent, |directory| {
-            calls += 1;
-            if calls == 2 {
-                return Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    "injected directory creation failure",
-                ));
-            }
-            fs::create_dir(directory)
-        }) {
-            Ok(_) => panic!("injected directory creation failure unexpectedly succeeded"),
-            Err(error) => error,
-        };
-
-        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
-        assert!(!created.exists());
+    fn old_listener_drop_does_not_unlink_replacement_generation() {
+        let directory =
+            std::env::temp_dir().join(format!("et-forward-generation-{}", std::process::id()));
+        std::fs::create_dir_all(&directory).unwrap();
+        let path = directory.join("source.sock");
+        let endpoint = Endpoint::Unix(path.clone());
+        let old = endpoint.bind().unwrap();
+        std::fs::remove_file(&path).unwrap();
+        let replacement = UnixListener::bind(&path).unwrap();
+        drop(old);
+        let client = UnixStream::connect(&path).expect("old listener unlinked replacement path");
+        replacement.accept().unwrap();
+        drop(client);
+        drop(replacement);
+        std::fs::remove_file(path).unwrap();
+        std::fs::remove_dir(directory).unwrap();
     }
 
     #[test]
@@ -929,19 +935,6 @@ mod tests {
         let addresses = distinct_tcp_addresses([address, address]);
 
         assert_eq!(bind_tcp_addresses(addresses).unwrap().len(), 1);
-    }
-
-    #[test]
-    fn bounded_resolution_counts_only_distinct_addresses() {
-        let first = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 1));
-        let second = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 2));
-        let error =
-            collect_distinct_addresses(Ok(vec![first, first, second].into_iter()), 1).unwrap_err();
-        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
-        assert_eq!(
-            collect_distinct_addresses(Ok(vec![first, first].into_iter()), 1).unwrap(),
-            [first]
-        );
     }
 
     #[test]

--- a/crates/et-net/src/forward_io.rs
+++ b/crates/et-net/src/forward_io.rs
@@ -11,7 +11,7 @@ use rustix::event::{poll, PollFd, PollFlags};
 use crate::forward_endpoint::{Endpoint, ForwardListener, ForwardStream};
 use et_core::proto::SocketEndpoint;
 
-use super::forward_worker::{Command, Role};
+use super::forward_worker::{Command, CommandSender, Role};
 
 const READ_CHUNK: usize = 16 * 1024;
 
@@ -49,7 +49,7 @@ const ACCEPT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10
 
 pub(crate) fn spawn_listener(
     source: BoundSource,
-    commands: mpsc::SyncSender<Command>,
+    commands: CommandSender,
     stop: ListenerStop,
     next_client_fd: Arc<AtomicI32>,
 ) -> JoinHandle<()> {
@@ -125,7 +125,7 @@ pub(crate) fn spawn_connector(
     client_fd: i32,
     socket_id: i32,
     destination: Endpoint,
-    commands: mpsc::SyncSender<Command>,
+    commands: CommandSender,
     session_user: Option<(u32, u32)>,
 ) -> JoinHandle<()> {
     thread::spawn(move || {
@@ -142,7 +142,7 @@ pub(crate) fn spawn_io(
     role: Role,
     socket_id: i32,
     stream: ForwardStream,
-    commands: mpsc::SyncSender<Command>,
+    commands: CommandSender,
 ) -> io::Result<(ActiveIo, [JoinHandle<()>; 2])> {
     let mut reader = stream.try_clone()?;
     let control = stream.try_clone()?;

--- a/crates/et-net/src/forward_worker.rs
+++ b/crates/et-net/src/forward_worker.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use std::io::{self};
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
-use std::sync::atomic::AtomicI32;
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread::JoinHandle;
 
@@ -61,21 +61,24 @@ pub(crate) fn run(
     command_sender: mpsc::SyncSender<Command>,
     outbound: mpsc::SyncSender<Outbound>,
     #[cfg(unix)] mut outbound_wake: UnixStream,
-    listener_stop: ListenerStop,
-    session_user: Option<(u32, u32)>,
+    control: (ListenerStop, Option<(u32, u32)>, Arc<AtomicBool>),
 ) {
+    let (listener_stop, session_user, shutdown) = control;
     #[cfg(unix)]
     let result = Worker::new(
         command_sender,
         outbound.clone(),
         outbound_wake.try_clone().ok(),
+        shutdown.clone(),
     )
     .and_then(|mut worker| worker.run(sources, commands, listener_stop, session_user));
     #[cfg(windows)]
-    let result = Worker::new(command_sender, outbound.clone())
+    let result = Worker::new(command_sender, outbound.clone(), shutdown.clone())
         .and_then(|mut worker| worker.run(sources, commands, listener_stop, session_user));
     if let Err(error) = result {
-        let _ = outbound.send(Err(error));
+        if !shutdown.load(Ordering::Acquire) {
+            let _ = outbound.try_send(Err(error));
+        }
         #[cfg(unix)]
         let _ = outbound_wake.write(&[1]);
     }
@@ -93,6 +96,7 @@ struct Worker {
     threads: Vec<JoinHandle<()>>,
     next_socket_id: i32,
     session_user: Option<(u32, u32)>,
+    shutdown: Arc<AtomicBool>,
 }
 
 impl Worker {
@@ -100,6 +104,7 @@ impl Worker {
         commands: mpsc::SyncSender<Command>,
         outbound: mpsc::SyncSender<Outbound>,
         #[cfg(unix)] outbound_wake: Option<UnixStream>,
+        shutdown: Arc<AtomicBool>,
     ) -> Result<Self, ForwardError> {
         #[cfg(unix)]
         let outbound_wake = {
@@ -119,6 +124,7 @@ impl Worker {
             threads: Vec::new(),
             next_socket_id: 1,
             session_user: None,
+            shutdown,
         })
     }
 

--- a/crates/et-net/src/forward_worker.rs
+++ b/crates/et-net/src/forward_worker.rs
@@ -212,7 +212,8 @@ mod state;
 #[cfg(all(test, unix))]
 mod tests {
     use std::os::unix::net::UnixStream;
-    use std::sync::mpsc;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::{mpsc, Arc};
     use std::time::Duration;
 
     use et_core::packet::Packet;
@@ -235,7 +236,13 @@ mod tests {
         let (outbound, outbound_receiver) = mpsc::sync_channel(MAX_ACTIVE_SOCKETS + 1);
         let (_wake_reader, wake_writer) = UnixStream::pair().unwrap();
         (
-            Worker::new(commands, outbound, Some(wake_writer)).unwrap(),
+            Worker::new(
+                commands,
+                outbound,
+                Some(wake_writer),
+                Arc::new(AtomicBool::new(false)),
+            )
+            .unwrap(),
             command_receiver,
             outbound_receiver,
         )

--- a/crates/et-net/src/forward_worker.rs
+++ b/crates/et-net/src/forward_worker.rs
@@ -1,11 +1,11 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 #[cfg(unix)]
 use std::io::Write;
 use std::io::{self};
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
-use std::sync::{mpsc, Arc};
+use std::sync::{mpsc, Arc, Condvar, Mutex};
 use std::thread::JoinHandle;
 
 use crate::forward::{ForwardError, Outbound};
@@ -52,13 +52,181 @@ pub(crate) enum Command {
         socket_id: i32,
         error: io::Error,
     },
-    Stop,
+}
+
+struct CommandQueueState {
+    commands: VecDeque<Command>,
+    senders: usize,
+    receiver_alive: bool,
+    shutdown: bool,
+}
+
+struct CommandQueue {
+    capacity: usize,
+    state: Mutex<CommandQueueState>,
+    changed: Condvar,
+}
+
+pub(crate) struct CommandSender {
+    queue: Arc<CommandQueue>,
+}
+
+pub(crate) struct CommandReceiver {
+    queue: Arc<CommandQueue>,
+}
+
+pub(crate) enum TryCommandError {
+    Full(Command),
+    Closed,
+}
+
+pub(crate) fn command_channel(capacity: usize) -> (CommandSender, CommandReceiver) {
+    let queue = Arc::new(CommandQueue {
+        capacity,
+        state: Mutex::new(CommandQueueState {
+            commands: VecDeque::with_capacity(capacity),
+            senders: 1,
+            receiver_alive: true,
+            shutdown: false,
+        }),
+        changed: Condvar::new(),
+    });
+    (
+        CommandSender {
+            queue: queue.clone(),
+        },
+        CommandReceiver { queue },
+    )
+}
+
+impl Clone for CommandSender {
+    fn clone(&self) -> Self {
+        let mut state = self.queue.state.lock().unwrap();
+        state.senders += 1;
+        drop(state);
+        Self {
+            queue: self.queue.clone(),
+        }
+    }
+}
+
+impl Drop for CommandSender {
+    fn drop(&mut self) {
+        let mut state = self.queue.state.lock().unwrap();
+        state.senders -= 1;
+        self.queue.changed.notify_all();
+    }
+}
+
+impl CommandSender {
+    pub(crate) fn send(&self, command: Command) -> Result<(), Command> {
+        let mut state = self.queue.state.lock().unwrap();
+        while state.commands.len() >= self.queue.capacity && !state.shutdown && state.receiver_alive
+        {
+            state = self.queue.changed.wait(state).unwrap();
+        }
+        if state.shutdown || !state.receiver_alive {
+            return Err(command);
+        }
+        state.commands.push_back(command);
+        self.queue.changed.notify_all();
+        Ok(())
+    }
+
+    pub(crate) fn try_send(&self, command: Command) -> Result<(), TryCommandError> {
+        let mut state = self.queue.state.lock().unwrap();
+        if state.shutdown || !state.receiver_alive {
+            return Err(TryCommandError::Closed);
+        }
+        if state.commands.len() >= self.queue.capacity {
+            return Err(TryCommandError::Full(command));
+        }
+        state.commands.push_back(command);
+        self.queue.changed.notify_all();
+        Ok(())
+    }
+
+    pub(crate) fn shutdown(&self) {
+        let mut state = self.queue.state.lock().unwrap();
+        state.shutdown = true;
+        self.queue.changed.notify_all();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn wait_shutdown_timeout(&self, timeout: std::time::Duration) -> bool {
+        let deadline = std::time::Instant::now() + timeout;
+        let mut state = self.queue.state.lock().unwrap();
+        while !state.shutdown {
+            let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
+                return false;
+            };
+            let (next, wait) = self.queue.changed.wait_timeout(state, remaining).unwrap();
+            state = next;
+            if wait.timed_out() && !state.shutdown {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl CommandReceiver {
+    fn recv(&self) -> Option<Command> {
+        let mut state = self.queue.state.lock().unwrap();
+        loop {
+            if state.shutdown {
+                return None;
+            }
+            if let Some(command) = state.commands.pop_front() {
+                self.queue.changed.notify_all();
+                return Some(command);
+            }
+            if state.senders == 0 {
+                return None;
+            }
+            state = self.queue.changed.wait(state).unwrap();
+        }
+    }
+
+    #[cfg(test)]
+    fn recv_timeout(
+        &self,
+        timeout: std::time::Duration,
+    ) -> Result<Command, mpsc::RecvTimeoutError> {
+        let deadline = std::time::Instant::now() + timeout;
+        let mut state = self.queue.state.lock().unwrap();
+        loop {
+            if state.shutdown || state.senders == 0 {
+                return Err(mpsc::RecvTimeoutError::Disconnected);
+            }
+            if let Some(command) = state.commands.pop_front() {
+                self.queue.changed.notify_all();
+                return Ok(command);
+            }
+            let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
+                return Err(mpsc::RecvTimeoutError::Timeout);
+            };
+            let (next, wait) = self.queue.changed.wait_timeout(state, remaining).unwrap();
+            state = next;
+            if wait.timed_out() && state.commands.is_empty() {
+                return Err(mpsc::RecvTimeoutError::Timeout);
+            }
+        }
+    }
+}
+
+impl Drop for CommandReceiver {
+    fn drop(&mut self) {
+        let mut state = self.queue.state.lock().unwrap();
+        state.receiver_alive = false;
+        self.queue.changed.notify_all();
+    }
 }
 
 pub(crate) fn run(
     sources: Vec<BoundSource>,
-    commands: mpsc::Receiver<Command>,
-    command_sender: mpsc::SyncSender<Command>,
+    commands: CommandReceiver,
+    command_sender: CommandSender,
     outbound: mpsc::SyncSender<Outbound>,
     #[cfg(unix)] mut outbound_wake: UnixStream,
     control: (ListenerStop, Option<(u32, u32)>, Arc<AtomicBool>),
@@ -85,7 +253,7 @@ pub(crate) fn run(
 }
 
 struct Worker {
-    commands: mpsc::SyncSender<Command>,
+    commands: CommandSender,
     outbound: mpsc::SyncSender<Outbound>,
     #[cfg(unix)]
     outbound_wake: UnixStream,
@@ -101,7 +269,7 @@ struct Worker {
 
 impl Worker {
     fn new(
-        commands: mpsc::SyncSender<Command>,
+        commands: CommandSender,
         outbound: mpsc::SyncSender<Outbound>,
         #[cfg(unix)] outbound_wake: Option<UnixStream>,
         shutdown: Arc<AtomicBool>,
@@ -131,7 +299,7 @@ impl Worker {
     fn run(
         &mut self,
         sources: Vec<BoundSource>,
-        commands: mpsc::Receiver<Command>,
+        commands: CommandReceiver,
         listener_stop: ListenerStop,
         session_user: Option<(u32, u32)>,
     ) -> Result<(), ForwardError> {
@@ -151,8 +319,8 @@ impl Worker {
         }
         let result = loop {
             let command = match commands.recv() {
-                Ok(command) => command,
-                Err(_) => break Ok(()),
+                Some(command) => command,
+                None => break Ok(()),
             };
             let step = match command {
                 Command::Packet(packet) => self.handle_packet(packet),
@@ -183,7 +351,6 @@ impl Worker {
                     self.remove(role, socket_id);
                     self.send_data(role, socket_id, Vec::new(), true, Some(error.to_string()))
                 }
-                Command::Stop => break Ok(()),
             };
             if let Err(error) = step {
                 break Err(error);
@@ -223,16 +390,16 @@ mod tests {
     };
     use prost::Message;
 
-    use super::{Command, Worker, MAX_ACTIVE_SOCKETS};
+    use super::{command_channel, Command, CommandReceiver, Worker, MAX_ACTIVE_SOCKETS};
 
     const EVENT_TIMEOUT: Duration = Duration::from_secs(3);
 
     fn worker() -> (
         Worker,
-        mpsc::Receiver<Command>,
+        CommandReceiver,
         mpsc::Receiver<crate::forward::Outbound>,
     ) {
-        let (commands, command_receiver) = mpsc::sync_channel(MAX_ACTIVE_SOCKETS + 1);
+        let (commands, command_receiver) = command_channel(MAX_ACTIVE_SOCKETS + 1);
         let (outbound, outbound_receiver) = mpsc::sync_channel(MAX_ACTIVE_SOCKETS + 1);
         let (_wake_reader, wake_writer) = UnixStream::pair().unwrap();
         (

--- a/crates/et-net/src/forward_worker_state.rs
+++ b/crates/et-net/src/forward_worker_state.rs
@@ -252,9 +252,22 @@ impl Worker {
     }
 
     fn emit<M: Message>(&mut self, header: u8, message: M) -> Result<(), ForwardError> {
-        self.outbound
-            .send(Ok(Packet::new(header, message.encode_to_vec())))
-            .map_err(|_| ForwardError::Unavailable)?;
+        let mut outbound = Ok(Packet::new(header, message.encode_to_vec()));
+        loop {
+            if self.shutdown.load(std::sync::atomic::Ordering::Acquire) {
+                return Err(ForwardError::Unavailable);
+            }
+            match self.outbound.try_send(outbound) {
+                Ok(()) => break,
+                Err(std::sync::mpsc::TrySendError::Full(value)) => {
+                    outbound = value;
+                    std::thread::yield_now();
+                }
+                Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {
+                    return Err(ForwardError::Unavailable);
+                }
+            }
+        }
         // Unix consumers poll the wake socket; Windows consumers drain
         // `try_outbound` on the client loop's 10ms cadence.
         #[cfg(unix)]

--- a/crates/et-net/src/local.rs
+++ b/crates/et-net/src/local.rs
@@ -21,7 +21,13 @@
 //! the user's files can register a terminal.
 
 use std::io;
+#[cfg(unix)]
+use std::io::Write;
 use std::path::Path;
+#[cfg(unix)]
+use std::path::PathBuf;
+
+const REGISTRATION_ACK_CAPABILITY: &str = "et-registration-ack-v1";
 
 /// Stream type used for local server/terminal IPC.
 #[cfg(unix)]
@@ -60,6 +66,58 @@ pub fn wake_pair() -> io::Result<(LocalStream, LocalStream)> {
         writer.set_nodelay(true)?;
         Ok((reader, writer))
     }
+}
+
+/// Sidecar used to negotiate the local-only registration acknowledgement.
+/// It does not alter the protocol-v6 network wire format.
+#[cfg(unix)]
+pub fn capability_path(path: &Path) -> PathBuf {
+    let mut value = path.as_os_str().to_owned();
+    value.push(".cap");
+    PathBuf::from(value)
+}
+
+/// Whether the selected router advertises registration acknowledgements.
+pub fn supports_registration_ack(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let Ok(metadata) = std::fs::symlink_metadata(path) else {
+            return false;
+        };
+        std::fs::read_to_string(capability_path(path)).is_ok_and(|value| {
+            let mut fields = value.split_whitespace();
+            fields.next() == Some(REGISTRATION_ACK_CAPABILITY)
+                && fields.next().and_then(|value| value.parse::<u64>().ok()) == Some(metadata.dev())
+                && fields.next().and_then(|value| value.parse::<u64>().ok()) == Some(metadata.ino())
+                && fields.next().is_none()
+        })
+    }
+    #[cfg(windows)]
+    {
+        std::fs::read_to_string(path).is_ok_and(|value| {
+            value.lines().nth(2).map(str::trim) == Some(REGISTRATION_ACK_CAPABILITY)
+        })
+    }
+}
+
+#[cfg(unix)]
+pub fn write_registration_ack_capability(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+    let metadata = std::fs::symlink_metadata(path)?;
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(capability_path(path))?
+        .write_all(
+            format!(
+                "{REGISTRATION_ACK_CAPABILITY} {} {}\n",
+                metadata.dev(),
+                metadata.ino()
+            )
+            .as_bytes(),
+        )
 }
 
 /// Connect to a local endpoint described by `path`.
@@ -159,6 +217,36 @@ pub fn new_token() -> String {
         let _ = write!(token, "{byte:02x}");
     }
     token
+}
+
+#[cfg(all(test, unix))]
+mod unix_tests {
+    use super::*;
+
+    #[test]
+    fn capability_is_bound_to_current_socket_inode() {
+        let directory = std::env::temp_dir().join(format!(
+            "et-capability-test-{}-{}",
+            std::process::id(),
+            et_core::keys::gen_id_passkey().0
+        ));
+        std::fs::create_dir(&directory).unwrap();
+        let path = directory.join("router.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
+        write_registration_ack_capability(&path).unwrap();
+        assert!(supports_registration_ack(&path));
+        drop(listener);
+        std::fs::remove_file(&path).unwrap();
+        let replacement = std::os::unix::net::UnixListener::bind(&path).unwrap();
+        std::fs::write(
+            capability_path(&path),
+            format!("{REGISTRATION_ACK_CAPABILITY} 0 0\n"),
+        )
+        .unwrap();
+        assert!(!supports_registration_ack(&path));
+        drop(replacement);
+        std::fs::remove_dir_all(directory).unwrap();
+    }
 }
 
 #[cfg(all(test, windows))]

--- a/crates/et-net/src/local.rs
+++ b/crates/et-net/src/local.rs
@@ -85,13 +85,10 @@ pub fn supports_registration_ack(path: &Path) -> bool {
         let Ok(metadata) = std::fs::symlink_metadata(path) else {
             return false;
         };
-        std::fs::read_to_string(capability_path(path)).is_ok_and(|value| {
-            let mut fields = value.split_whitespace();
-            fields.next() == Some(REGISTRATION_ACK_CAPABILITY)
-                && fields.next().and_then(|value| value.parse::<u64>().ok()) == Some(metadata.dev())
-                && fields.next().and_then(|value| value.parse::<u64>().ok()) == Some(metadata.ino())
-                && fields.next().is_none()
-        })
+        std::fs::read_to_string(capability_path(path))
+            .ok()
+            .and_then(|value| parse_capability(&value))
+            == Some((metadata.dev(), metadata.ino()))
     }
     #[cfg(windows)]
     {
@@ -108,7 +105,9 @@ pub fn write_registration_ack_capability(path: &Path) -> io::Result<()> {
     std::fs::OpenOptions::new()
         .write(true)
         .create_new(true)
-        .mode(0o600)
+        // The marker is not a secret. Root-mode routers are intentionally
+        // reachable by unprivileged terminal users through a 0666 socket.
+        .mode(0o644)
         .open(capability_path(path))?
         .write_all(
             format!(
@@ -118,6 +117,43 @@ pub fn write_registration_ack_capability(path: &Path) -> io::Result<()> {
             )
             .as_bytes(),
         )
+}
+
+#[cfg(unix)]
+pub fn retire_registration_ack_capability(path: &Path, device: u64, inode: u64) -> io::Result<()> {
+    let capability = capability_path(path);
+    let mut retired = capability.as_os_str().to_owned();
+    retired.push(format!(".retired-{device}-{inode}"));
+    let retired = PathBuf::from(retired);
+    match std::fs::rename(&capability, &retired) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    }
+    let belongs_to_listener = std::fs::read_to_string(&retired)
+        .ok()
+        .and_then(|value| parse_capability(&value))
+        == Some((device, inode));
+    if belongs_to_listener {
+        std::fs::remove_file(retired)
+    } else if !capability.exists() {
+        std::fs::rename(retired, capability)
+    } else {
+        // A current generation already published its marker. Never overwrite
+        // it while retiring an unrelated generation.
+        std::fs::remove_file(retired)
+    }
+}
+
+#[cfg(unix)]
+fn parse_capability(value: &str) -> Option<(u64, u64)> {
+    let mut fields = value.split_whitespace();
+    if fields.next() != Some(REGISTRATION_ACK_CAPABILITY) {
+        return None;
+    }
+    let device = fields.next()?.parse().ok()?;
+    let inode = fields.next()?.parse().ok()?;
+    fields.next().is_none().then_some((device, inode))
 }
 
 /// Connect to a local endpoint described by `path`.
@@ -235,6 +271,15 @@ mod unix_tests {
         let listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
         write_registration_ack_capability(&path).unwrap();
         assert!(supports_registration_ack(&path));
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            std::fs::metadata(capability_path(&path))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o644
+        );
         drop(listener);
         std::fs::remove_file(&path).unwrap();
         let replacement = std::os::unix::net::UnixListener::bind(&path).unwrap();
@@ -244,6 +289,13 @@ mod unix_tests {
         )
         .unwrap();
         assert!(!supports_registration_ack(&path));
+        let metadata = std::fs::symlink_metadata(&path).unwrap();
+        use std::os::unix::fs::MetadataExt;
+        retire_registration_ack_capability(&path, metadata.dev() + 1, metadata.ino()).unwrap();
+        assert!(
+            capability_path(&path).exists(),
+            "unrelated generation marker was deleted"
+        );
         drop(replacement);
         std::fs::remove_dir_all(directory).unwrap();
     }

--- a/crates/et-net/src/local_packet.rs
+++ b/crates/et-net/src/local_packet.rs
@@ -6,6 +6,11 @@ use std::time::Duration;
 use et_core::packet::{Packet, PacketError};
 
 pub const MAX_LOCAL_PACKET_LEN: usize = 64 * 1024;
+/// Local-only control packets. These values are deliberately outside the
+/// protocol-v6 terminal enum and never cross the encrypted network transport.
+pub const REGISTRATION_STATUS: u8 = 254;
+pub const STARTUP_STATUS: u8 = 255;
+pub const MAX_STATUS_MESSAGE: usize = 8 * 1024;
 const PREFIX_LEN: usize = std::mem::size_of::<i64>();
 /// How long a writer naps before retrying a `WouldBlock` write. Matches the
 /// 10ms cadence the Windows pump loops already use.
@@ -57,6 +62,37 @@ pub fn read_local_packet<R: Read>(reader: &mut R) -> Result<Packet, LocalPacketE
     let mut serialized = vec![0u8; length];
     read_exact_classified(reader, &mut serialized, LocalPacketError::TruncatedPayload)?;
     Packet::from_serialized(&serialized).map_err(LocalPacketError::MalformedPacket)
+}
+
+pub fn status_packet(header: u8, result: Result<(), &str>) -> Packet {
+    let mut payload = Vec::new();
+    match result {
+        Ok(()) => payload.push(0),
+        Err(message) => {
+            payload.push(1);
+            payload.extend_from_slice(&message.as_bytes()[..message.len().min(MAX_STATUS_MESSAGE)]);
+        }
+    }
+    Packet::new(header, payload)
+}
+
+pub fn parse_status(packet: &Packet, expected_header: u8) -> io::Result<()> {
+    if packet.is_encrypted() || packet.header() != expected_header {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "unexpected local status packet",
+        ));
+    }
+    match packet.payload().split_first() {
+        Some((&0, [])) => Ok(()),
+        Some((&1, message)) if message.len() <= MAX_STATUS_MESSAGE => Err(io::Error::other(
+            String::from_utf8_lossy(message).into_owned(),
+        )),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "malformed local status packet",
+        )),
+    }
 }
 
 pub fn write_local_packet<W: Write>(writer: &mut W, packet: &Packet) -> io::Result<()> {

--- a/crates/et-net/src/local_packet.rs
+++ b/crates/et-net/src/local_packet.rs
@@ -114,6 +114,16 @@ pub fn write_local_packet_cancelled<W: Write>(
     })
 }
 
+/// Write one complete local frame under ordinary backpressure, stopping only
+/// when teardown explicitly requests cancellation.
+pub fn write_local_packet_until_cancelled<W: Write>(
+    writer: &mut W,
+    packet: &Packet,
+    cancelled: &AtomicBool,
+) -> io::Result<()> {
+    write_local_packet_with(writer, packet, || cancelled.load(Ordering::Acquire))
+}
+
 fn write_local_packet_with<W: Write>(
     writer: &mut W,
     packet: &Packet,

--- a/crates/et-net/src/local_packet.rs
+++ b/crates/et-net/src/local_packet.rs
@@ -1,7 +1,8 @@
 //! Native-`i64` framing for packets exchanged with local terminal processes.
 
 use std::io::{self, Read, Write};
-use std::time::Duration;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 
 use et_core::packet::{Packet, PacketError};
 
@@ -96,6 +97,28 @@ pub fn parse_status(packet: &Packet, expected_header: u8) -> io::Result<()> {
 }
 
 pub fn write_local_packet<W: Write>(writer: &mut W, packet: &Packet) -> io::Result<()> {
+    write_local_packet_with(writer, packet, || false)
+}
+
+/// Write one frame while allowing an owner to cancel blocked backpressure.
+/// Once cancellation begins the caller must close the channel because a
+/// partially written frame is intentionally abandoned during teardown.
+pub fn write_local_packet_cancelled<W: Write>(
+    writer: &mut W,
+    packet: &Packet,
+    cancelled: &AtomicBool,
+    deadline: Instant,
+) -> io::Result<()> {
+    write_local_packet_with(writer, packet, || {
+        cancelled.load(Ordering::Acquire) || Instant::now() >= deadline
+    })
+}
+
+fn write_local_packet_with<W: Write>(
+    writer: &mut W,
+    packet: &Packet,
+    cancelled: impl Fn() -> bool,
+) -> io::Result<()> {
     let serialized = packet.serialize();
     if serialized.len() > MAX_LOCAL_PACKET_LEN {
         return Err(io::Error::new(
@@ -105,9 +128,9 @@ pub fn write_local_packet<W: Write>(writer: &mut W, packet: &Packet) -> io::Resu
     }
     let length = i64::try_from(serialized.len())
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "local packet too large"))?;
-    write_all_blocking(writer, &length.to_ne_bytes())?;
-    write_all_blocking(writer, &serialized)?;
-    flush_blocking(writer)
+    write_all_blocking(writer, &length.to_ne_bytes(), &cancelled)?;
+    write_all_blocking(writer, &serialized, &cancelled)?;
+    flush_blocking(writer, &cancelled)
 }
 
 /// `write_all` that treats `WouldBlock` as backpressure instead of an error.
@@ -123,8 +146,18 @@ pub fn write_local_packet<W: Write>(writer: &mut W, packet: &Packet) -> io::Resu
 /// drain, exactly like upstream's blocking writes, rather than tearing the
 /// session down — and a bare `write_all` would also abandon a partially
 /// written frame, corrupting the stream for good.
-fn write_all_blocking<W: Write>(writer: &mut W, mut buffer: &[u8]) -> io::Result<()> {
+fn write_all_blocking<W: Write>(
+    writer: &mut W,
+    mut buffer: &[u8],
+    cancelled: &impl Fn() -> bool,
+) -> io::Result<()> {
     while !buffer.is_empty() {
+        if cancelled() {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "local packet write cancelled",
+            ));
+        }
         match writer.write(buffer) {
             Ok(0) => return Err(io::ErrorKind::WriteZero.into()),
             Ok(count) => buffer = &buffer[count..],
@@ -138,8 +171,14 @@ fn write_all_blocking<W: Write>(writer: &mut W, mut buffer: &[u8]) -> io::Result
     Ok(())
 }
 
-fn flush_blocking<W: Write>(writer: &mut W) -> io::Result<()> {
+fn flush_blocking<W: Write>(writer: &mut W, cancelled: &impl Fn() -> bool) -> io::Result<()> {
     loop {
+        if cancelled() {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "local packet flush cancelled",
+            ));
+        }
         match writer.flush() {
             Ok(()) => return Ok(()),
             Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
@@ -259,4 +298,49 @@ fn read_exact_classified<R: Read>(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{mpsc, Arc};
+
+    struct StalledWriter(Option<mpsc::Sender<()>>);
+
+    impl Write for StalledWriter {
+        fn write(&mut self, _buffer: &[u8]) -> io::Result<usize> {
+            if let Some(started) = self.0.take() {
+                let _ = started.send(());
+            }
+            Err(io::ErrorKind::WouldBlock.into())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn cancelled_local_write_finishes_while_peer_remains_stalled() {
+        let (started_tx, started_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let worker_cancelled = cancelled.clone();
+        std::thread::spawn(move || {
+            let result = write_local_packet_cancelled(
+                &mut StalledWriter(Some(started_tx)),
+                &Packet::new(1, vec![0; 1024]),
+                &worker_cancelled,
+                Instant::now() + Duration::from_secs(30),
+            );
+            let _ = done_tx.send(result);
+        });
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        cancelled.store(true, Ordering::Release);
+        let error = done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("cancelled writer did not terminate")
+            .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    }
 }

--- a/crates/et-net/src/user_socket_ops.rs
+++ b/crates/et-net/src/user_socket_ops.rs
@@ -14,40 +14,106 @@ use std::io::{self, IoSlice, IoSliceMut};
 use std::mem::MaybeUninit;
 use std::net::{SocketAddr, TcpListener};
 use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::{Condvar, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
+use wait_timeout::ChildExt;
 
 use rustix::net::{
     recvmsg, sendmsg, RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags, SendAncillaryBuffer,
     SendAncillaryMessage, SendFlags,
 };
-use wait_timeout::ChildExt;
 
 const OP_ENV: &str = "ET_RS_USER_SOCKET_OP";
 const PATH_ENV: &str = "ET_RS_USER_SOCKET_PATH";
-const PORT_ENV: &str = "ET_RS_USER_SOCKET_PORT";
+const PUBLIC_PATH_ENV: &str = "ET_RS_USER_SOCKET_PUBLIC_PATH";
 const UID_ENV: &str = "ET_RS_USER_SOCKET_UID";
 const GID_ENV: &str = "ET_RS_USER_SOCKET_GID";
 const HELPER_ENV: &str = "ET_RS_USER_SOCKET_HELPER";
+const GENERATION_ENV: &str = "ET_RS_USER_SOCKET_GENERATION";
+const GENERATION_PATH_ENV: &str = "ET_RS_USER_SOCKET_GENERATION_PATH";
 const HELPER_NAME: &str = "et-user-socket-helper";
 /// `sockaddr_un.sun_path` on Linux, including the trailing NUL.
 const UNIX_PATH_MAX: usize = 108;
-const HELPER_TIMEOUT: Duration = Duration::from_secs(5);
-const ATOMIC_SCM_RIGHTS_CLOEXEC: bool = cfg!(any(target_os = "linux", target_os = "android"));
-static HELPER_SPAWN_LOCK: HelperSpawnLock = HelperSpawnLock {
-    held: Mutex::new(false),
-    available: Condvar::new(),
-};
+static NEXT_GENERATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct UnixSocketIdentity {
+    fd_device: u64,
+    fd_inode: u64,
+    node_device: u64,
+    node_inode: u64,
+}
+
+impl UnixSocketIdentity {
+    fn from_fd_and_node(fd: BorrowedFd<'_>, node: &Path) -> io::Result<Self> {
+        let stat = rustix::fs::fstat(fd)?;
+        let metadata = fs::symlink_metadata(node)?;
+        Ok(Self {
+            fd_device: stat.st_dev as u64,
+            fd_inode: stat.st_ino as u64,
+            node_device: metadata.dev(),
+            node_inode: metadata.ino(),
+        })
+    }
+
+    fn node_matches(self, path: &Path) -> bool {
+        fs::symlink_metadata(path).is_ok_and(|metadata| {
+            metadata.dev() == self.node_device && metadata.ino() == self.node_inode
+        })
+    }
+}
+
+fn path_operations() -> &'static std::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
+pub(crate) fn remove_socket_if_owned(path: &Path, identity: UnixSocketIdentity) {
+    remove_socket_if_owned_with_hook(path, identity, || {});
+}
+
+fn remove_socket_if_owned_with_hook(
+    path: &Path,
+    identity: UnixSocketIdentity,
+    after_retire: impl FnOnce(),
+) {
+    let Ok(_guard) = path_operations().lock() else {
+        return;
+    };
+    let retired = staging_path(
+        path,
+        &format!(
+            "retired-{}",
+            NEXT_GENERATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ),
+    );
+    if fs::rename(path, &retired).is_err() {
+        return;
+    }
+    after_retire();
+    if identity.node_matches(&retired) {
+        let _ = fs::remove_file(retired);
+        return;
+    }
+    // We retired a replacement rather than our generation. Restore it only
+    // if no newer publisher has already occupied the public path.
+    let _ = rustix::fs::renameat_with(
+        rustix::fs::CWD,
+        &retired,
+        rustix::fs::CWD,
+        path,
+        rustix::fs::RenameFlags::NOREPLACE,
+    );
+}
 
 #[derive(Clone, Copy)]
 enum Op {
     Listen,
     Connect,
-    ConnectTcp,
     ListenTcp,
 }
 
@@ -56,7 +122,6 @@ impl Op {
         match self {
             Self::Listen => "listen",
             Self::Connect => "connect",
-            Self::ConnectTcp => "connect-tcp",
             Self::ListenTcp => "listen-tcp",
         }
     }
@@ -65,7 +130,6 @@ impl Op {
         match value {
             "listen" => Some(Self::Listen),
             "connect" => Some(Self::Connect),
-            "connect-tcp" => Some(Self::ConnectTcp),
             "listen-tcp" => Some(Self::ListenTcp),
             _ => None,
         }
@@ -89,33 +153,31 @@ pub fn run_helper() -> i32 {
     let op = std::env::var(OP_ENV)
         .ok()
         .and_then(|value| Op::parse(&value));
-    let argument = std::env::var(PATH_ENV).unwrap_or_default();
-    match op {
-        Some(Op::Listen) if !argument.is_empty() => {
-            match PendingUnixListener::bind_anchored(Path::new(&argument)) {
-                Ok(listener) => listener.send_and_serve(channel),
-                Err(error) => send_error(channel, &error),
-            }
-        }
-        Some(Op::Connect) if !argument.is_empty() => match connect_at_path(Path::new(&argument)) {
-            Ok(stream) => send_result(channel, Some(stream.as_fd()), 0, 0),
-            Err(error) => send_error(channel, &error),
-        },
-        Some(Op::ConnectTcp) if !argument.is_empty() => match env_u16(PORT_ENV) {
-            Ok(port) => match crate::forward_endpoint::connect_tcp(&argument, port) {
-                Ok(stream) => send_result(channel, Some(stream.as_fd()), 0, 0),
-                Err(error) => send_error(channel, &error),
+    let path = std::env::var(PATH_ENV).unwrap_or_default();
+    match (op, path.is_empty()) {
+        (Some(Op::Listen), false) => match listen_at_path(Path::new(&path)) {
+            Ok(listener) => match publish_helper_generation(&listener, Path::new(&path)) {
+                Ok(()) => send_result(channel, Some(listener.as_fd()), 0, 0),
+                Err(error) => {
+                    drop(listener);
+                    let _ = fs::remove_file(&path);
+                    send_error(channel, &error)
+                }
             },
             Err(error) => send_error(channel, &error),
         },
-        Some(Op::ListenTcp) => match argument.parse() {
+        (Some(Op::Connect), false) => match connect_at_path(Path::new(&path)) {
+            Ok(stream) => send_result(channel, Some(stream.as_fd()), 0, 0),
+            Err(error) => send_error(channel, &error),
+        },
+        (Some(Op::ListenTcp), _) => match path.parse() {
             Ok(address) => match listen_tcp_at_address(address) {
                 Ok(listener) => send_result(channel, Some(listener.as_fd()), 0, 0),
                 Err(error) => send_error(channel, &error),
             },
             Err(_) => send_result(channel, None, -1, rustix::io::Errno::INVAL.raw_os_error()),
         },
-        Some(Op::Listen | Op::Connect | Op::ConnectTcp) | None => {
+        (Some(Op::Listen | Op::Connect), true) | (None, _) => {
             send_result(channel, None, -1, rustix::io::Errno::INVAL.raw_os_error())
         }
     }
@@ -123,84 +185,31 @@ pub fn run_helper() -> i32 {
 
 /// Bind/listen a new owner-only UNIX socket path with the current credentials.
 pub fn listen_at_path(path: &Path) -> io::Result<UnixListener> {
-    PendingUnixListener::bind(path).map(PendingUnixListener::into_listener)
+    listen_at_path_with(path, || Ok(()))
 }
 
-struct PendingUnixListener {
-    listener: Option<UnixListener>,
-    cleanup: PendingSocketPath,
+fn listen_at_path_with(
+    path: &Path,
+    after_bind: impl FnOnce() -> io::Result<()>,
+) -> io::Result<UnixListener> {
+    if path_too_long(path) {
+        return Err(io::Error::from_raw_os_error(
+            rustix::io::Errno::NAMETOOLONG.raw_os_error(),
+        ));
+    }
+    let listener = UnixListener::bind(path)?;
+    let mut cleanup = SocketPathCleanup(Some(path.to_path_buf()));
+    after_bind()?;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    cleanup.0 = None;
+    Ok(listener)
 }
 
-impl PendingUnixListener {
-    fn bind(path: &Path) -> io::Result<Self> {
-        if path_too_long(path) {
-            return Err(io::Error::from_raw_os_error(
-                rustix::io::Errno::NAMETOOLONG.raw_os_error(),
-            ));
-        }
-        let listener = UnixListener::bind(path)?;
-        let cleanup = PendingSocketPath(Some(path.to_path_buf()));
-        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
-        Ok(Self {
-            listener: Some(listener),
-            cleanup,
-        })
-    }
+struct SocketPathCleanup(Option<PathBuf>);
 
-    fn into_listener(mut self) -> UnixListener {
-        self.cleanup.0.take();
-        self.listener.take().expect("bound Unix listener")
-    }
-
-    fn send_and_serve(mut self, channel: BorrowedFd<'_>) -> i32 {
-        let status = send_result(
-            channel,
-            Some(self.listener.as_ref().expect("bound Unix listener").as_fd()),
-            0,
-            0,
-        );
-        if status != 0 {
-            return status;
-        }
-        drop(self.listener.take());
-        let mut buffer = [0_u8; 1];
-        loop {
-            match rustix::io::read(channel, &mut buffer) {
-                Ok(0) => return 0,
-                Ok(_) => {}
-                Err(rustix::io::Errno::INTR) => {}
-                Err(_) => return 1,
-            }
-        }
-    }
-
-    fn bind_anchored(path: &Path) -> io::Result<Self> {
-        if path_too_long(path) {
-            return Err(io::Error::from_raw_os_error(
-                rustix::io::Errno::NAMETOOLONG.raw_os_error(),
-            ));
-        }
-        let parent = path
-            .parent()
-            .filter(|parent| !parent.as_os_str().is_empty());
-        if let Some(parent) = parent {
-            std::env::set_current_dir(parent)?;
-        }
-        let name = path.file_name().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "Unix socket path has no file name",
-            )
-        })?;
-        Self::bind(Path::new(name))
-    }
-}
-
-struct PendingSocketPath(Option<PathBuf>);
-
-impl Drop for PendingSocketPath {
+impl Drop for SocketPathCleanup {
     fn drop(&mut self) {
-        if let Some(path) = self.0.take() {
+        if let Some(path) = self.0.as_ref() {
             let _ = fs::remove_file(path);
         }
     }
@@ -217,75 +226,24 @@ pub fn connect_at_path(path: &Path) -> io::Result<UnixStream> {
 }
 
 /// Bind/listen as `uid`/`gid`, returning the listening socket.
-pub fn listen_unix_as_user(
-    path: impl AsRef<Path>,
-    uid: u32,
-    gid: u32,
-) -> io::Result<UserUnixListener> {
-    listen_unix_as_user_until(path, uid, gid, Instant::now() + HELPER_TIMEOUT)
+pub fn listen_unix_as_user(path: impl AsRef<Path>, uid: u32, gid: u32) -> io::Result<UnixListener> {
+    listen_unix_as_user_deadline(path, uid, gid, Instant::now() + Duration::from_secs(30))
 }
 
-pub(crate) fn listen_unix_as_user_until(
+pub fn listen_unix_as_user_deadline(
     path: impl AsRef<Path>,
     uid: u32,
     gid: u32,
     deadline: Instant,
-) -> io::Result<UserUnixListener> {
+) -> io::Result<UnixListener> {
     let path = path.as_ref();
-    if already_session_user(uid, gid) {
-        return listen_at_path(path).map(|listener| UserUnixListener {
-            listener,
-            cleanup: None,
-        });
+    if path_too_long(path) {
+        return Err(io::Error::from_raw_os_error(
+            rustix::io::Errno::NAMETOOLONG.raw_os_error(),
+        ));
     }
-    run_listener_as_user(path, uid, gid, deadline)
-}
-
-pub struct UserUnixListener {
-    listener: UnixListener,
-    cleanup: Option<UserSocketCleanup>,
-}
-
-impl std::fmt::Debug for UserUnixListener {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter
-            .debug_struct("UserUnixListener")
-            .finish_non_exhaustive()
-    }
-}
-
-impl std::ops::Deref for UserUnixListener {
-    type Target = UnixListener;
-
-    fn deref(&self) -> &Self::Target {
-        &self.listener
-    }
-}
-
-impl UserUnixListener {
-    pub(crate) fn into_parts(self) -> (UnixListener, Option<UserSocketCleanup>) {
-        (self.listener, self.cleanup)
-    }
-}
-
-pub(crate) struct UserSocketCleanup {
-    channel: Option<UnixStream>,
-    child: Option<std::process::Child>,
-}
-
-impl Drop for UserSocketCleanup {
-    fn drop(&mut self) {
-        drop(self.channel.take());
-        if let Some(mut child) = self.child.take() {
-            match child.wait_timeout(HELPER_TIMEOUT) {
-                Ok(Some(_)) => {}
-                Ok(None) | Err(_) => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                }
-            }
-        }
-    }
+    ensure_deadline(deadline)?;
+    Ok(listen_unix_as_user_owned_deadline(path, uid, gid, deadline)?.0)
 }
 
 /// connect() as `uid`/`gid`, returning the connected socket.
@@ -294,55 +252,68 @@ pub fn connect_unix_as_user(path: impl AsRef<Path>, uid: u32, gid: u32) -> io::R
     if already_session_user(uid, gid) {
         return connect_at_path(path);
     }
-    Ok(UnixStream::from(run_as_user(
-        Op::Connect,
-        path.as_os_str(),
-        uid,
-        gid,
-    )?))
+    if path_too_long(path) {
+        return Err(io::Error::from_raw_os_error(
+            rustix::io::Errno::NAMETOOLONG.raw_os_error(),
+        ));
+    }
+    Ok(UnixStream::from(
+        run_as_user(Op::Connect, path.as_os_str(), uid, gid)?.fd,
+    ))
 }
 
 /// Bind one TCP address as `uid`/`gid`, returning the listening socket.
 pub fn listen_tcp_as_user(address: SocketAddr, uid: u32, gid: u32) -> io::Result<TcpListener> {
-    listen_tcp_as_user_until(address, uid, gid, Instant::now() + HELPER_TIMEOUT)
+    listen_tcp_as_user_deadline(address, uid, gid, Instant::now() + Duration::from_secs(30))
 }
 
-pub(crate) fn connect_tcp_as_user(
-    host: &str,
-    port: u16,
-    uid: u32,
-    gid: u32,
-) -> io::Result<std::net::TcpStream> {
-    if already_session_user(uid, gid) {
-        return crate::forward_endpoint::connect_tcp(host, port);
-    }
-    Ok(std::net::TcpStream::from(run_as_user_until_with_port(
-        Op::ConnectTcp,
-        OsStr::new(host),
-        uid,
-        gid,
-        Instant::now() + HELPER_TIMEOUT,
-        Some(port),
-    )?))
-}
-
-pub(crate) fn listen_tcp_as_user_until(
+/// Bind one TCP address as `uid`/`gid` within the caller's absolute deadline.
+pub fn listen_tcp_as_user_deadline(
     address: SocketAddr,
     uid: u32,
     gid: u32,
     deadline: Instant,
 ) -> io::Result<TcpListener> {
+    ensure_deadline(deadline)?;
     if already_session_user(uid, gid) {
-        return listen_tcp_at_address(address);
+        let listener = listen_tcp_at_address(address)?;
+        ensure_deadline(deadline)?;
+        return Ok(listener);
     }
     let argument = address.to_string();
-    Ok(TcpListener::from(run_as_user_until(
+    let helper = helper_exe()?;
+    let received = run_as_user_deadline_argument_with_helper(
         Op::ListenTcp,
         OsStr::new(&argument),
         uid,
         gid,
         deadline,
-    )?))
+        &helper,
+    )?;
+    ensure_deadline(deadline)?;
+    Ok(TcpListener::from(received.fd))
+}
+
+#[doc(hidden)]
+pub fn listen_tcp_as_user_deadline_with_helper(
+    address: SocketAddr,
+    uid: u32,
+    gid: u32,
+    deadline: Instant,
+    helper: &Path,
+) -> io::Result<TcpListener> {
+    ensure_deadline(deadline)?;
+    let argument = address.to_string();
+    let received = run_as_user_deadline_argument_with_helper(
+        Op::ListenTcp,
+        OsStr::new(&argument),
+        uid,
+        gid,
+        deadline,
+        helper,
+    )?;
+    ensure_deadline(deadline)?;
+    Ok(TcpListener::from(received.fd))
 }
 
 fn listen_tcp_at_address(address: SocketAddr) -> io::Result<TcpListener> {
@@ -350,254 +321,423 @@ fn listen_tcp_at_address(address: SocketAddr) -> io::Result<TcpListener> {
         .ok_or_else(|| io::Error::from_raw_os_error(rustix::io::Errno::AFNOSUPPORT.raw_os_error()))
 }
 
-fn already_session_user(uid: u32, gid: u32) -> bool {
-    rustix::process::geteuid().as_raw() == uid && rustix::process::getegid().as_raw() == gid
-}
-
-fn run_as_user(op: Op, argument: &OsStr, uid: u32, gid: u32) -> io::Result<OwnedFd> {
-    run_as_user_until(op, argument, uid, gid, Instant::now() + HELPER_TIMEOUT)
-}
-
-fn run_as_user_until(
-    op: Op,
-    argument: &OsStr,
-    uid: u32,
-    gid: u32,
-    deadline: Instant,
-) -> io::Result<OwnedFd> {
-    run_as_user_until_with_port(op, argument, uid, gid, deadline, None)
-}
-
-fn run_as_user_until_with_port(
-    op: Op,
-    argument: &OsStr,
-    uid: u32,
-    gid: u32,
-    deadline: Instant,
-    port: Option<u16>,
-) -> io::Result<OwnedFd> {
-    let mut helper = spawn_helper(op, argument, uid, gid, port, deadline)?;
-    let result = recv_result_until(helper.channel(), deadline);
-    helper.release_spawn_guard();
-    finish_helper(&mut helper, result, deadline)
-}
-
-fn run_listener_as_user(
+pub(crate) fn listen_unix_as_user_owned_deadline(
     path: &Path,
     uid: u32,
     gid: u32,
     deadline: Instant,
-) -> io::Result<UserUnixListener> {
-    let mut helper = spawn_helper(Op::Listen, path.as_os_str(), uid, gid, None, deadline)?;
-    let result = recv_result_until(helper.channel(), deadline);
-    helper.release_spawn_guard();
-    match reject_success_after_deadline(result, deadline) {
-        Ok(fd) => {
-            let (channel, child) = helper.take_persistent();
-            Ok(UserUnixListener {
-                listener: UnixListener::from(fd),
-                cleanup: Some(UserSocketCleanup {
-                    channel: Some(channel),
-                    child: Some(child),
-                }),
-            })
-        }
-        Err(error) => Err(error),
+) -> io::Result<(UnixListener, UnixSocketIdentity)> {
+    ensure_deadline(deadline)?;
+    if already_session_user(uid, gid) {
+        return bind_staged(path, deadline);
     }
+    let received = run_as_user_deadline(Op::Listen, path, uid, gid, deadline)?;
+    let listener = UnixListener::from(received.fd);
+    let fd_stat = rustix::fs::fstat(&listener)?;
+    if fd_stat.st_dev as u64 != received.identity.fd_device
+        || fd_stat.st_ino as u64 != received.identity.fd_inode
+    {
+        return Err(io::Error::other("received listener identity changed"));
+    }
+    Ok((listener, received.identity))
 }
 
-trait KillAndWait {
-    fn kill_and_wait(&mut self);
+fn already_session_user(uid: u32, gid: u32) -> bool {
+    rustix::process::geteuid().as_raw() == uid && rustix::process::getegid().as_raw() == gid
 }
 
-impl KillAndWait for std::process::Child {
-    fn kill_and_wait(&mut self) {
-        let _ = self.kill();
-        let _ = self.wait();
-    }
+#[derive(Debug)]
+struct ReceivedSocket {
+    fd: OwnedFd,
+    identity: UnixSocketIdentity,
 }
 
-struct ChildLease<C: KillAndWait> {
-    child: Option<C>,
+fn run_as_user(op: Op, argument: &OsStr, uid: u32, gid: u32) -> io::Result<ReceivedSocket> {
+    let helper = helper_exe()?;
+    run_as_user_deadline_argument_with_helper(
+        op,
+        argument,
+        uid,
+        gid,
+        Instant::now() + Duration::from_secs(30),
+        &helper,
+    )
 }
 
-impl<C: KillAndWait> ChildLease<C> {
-    fn new(child: C) -> Self {
-        Self { child: Some(child) }
+fn run_as_user_deadline(
+    op: Op,
+    path: &Path,
+    uid: u32,
+    gid: u32,
+    deadline: Instant,
+) -> io::Result<ReceivedSocket> {
+    if path_too_long(path) {
+        return Err(io::Error::from_raw_os_error(
+            rustix::io::Errno::NAMETOOLONG.raw_os_error(),
+        ));
     }
-
-    fn as_mut(&mut self) -> &mut C {
-        self.child.as_mut().expect("live helper child")
-    }
-
-    fn take(&mut self) -> Option<C> {
-        self.child.take()
-    }
-
-    fn reap(&mut self) {
-        if let Some(mut child) = self.child.take() {
-            child.kill_and_wait();
-        }
-    }
+    let helper = helper_exe()?;
+    run_as_user_deadline_with_helper(op, path, uid, gid, deadline, &helper)
 }
 
-impl<C: KillAndWait> Drop for ChildLease<C> {
-    fn drop(&mut self) {
-        self.reap();
-    }
+fn run_as_user_deadline_with_helper(
+    op: Op,
+    path: &Path,
+    uid: u32,
+    gid: u32,
+    deadline: Instant,
+    helper: &Path,
+) -> io::Result<ReceivedSocket> {
+    run_as_user_deadline_with_helper_cancelled(
+        op,
+        path,
+        uid,
+        gid,
+        deadline,
+        helper,
+        &AtomicBool::new(false),
+    )
 }
 
-struct SpawnedHelper {
-    channel: Option<UnixStream>,
-    child: ChildLease<std::process::Child>,
-    spawn_guard: Option<HelperSpawnGuard>,
+fn run_as_user_deadline_with_helper_cancelled(
+    op: Op,
+    path: &Path,
+    uid: u32,
+    gid: u32,
+    deadline: Instant,
+    helper: &Path,
+    cancelled: &AtomicBool,
+) -> io::Result<ReceivedSocket> {
+    run_as_user_deadline_argument_with_helper_cancelled(
+        op,
+        path.as_os_str(),
+        uid,
+        gid,
+        deadline,
+        helper,
+        cancelled,
+    )
 }
 
-impl SpawnedHelper {
-    fn channel(&self) -> &UnixStream {
-        self.channel.as_ref().expect("live helper channel")
-    }
-
-    fn release_spawn_guard(&mut self) {
-        drop(self.spawn_guard.take());
-    }
-
-    fn take_persistent(&mut self) -> (UnixStream, std::process::Child) {
-        (
-            self.channel.take().expect("live helper channel"),
-            self.child.take().expect("live helper child"),
-        )
-    }
-}
-
-fn spawn_helper(
+fn run_as_user_deadline_argument_with_helper(
     op: Op,
     argument: &OsStr,
     uid: u32,
     gid: u32,
-    port: Option<u16>,
     deadline: Instant,
-) -> io::Result<SpawnedHelper> {
-    let helper = helper_exe()?;
+    helper: &Path,
+) -> io::Result<ReceivedSocket> {
+    run_as_user_deadline_argument_with_helper_cancelled(
+        op,
+        argument,
+        uid,
+        gid,
+        deadline,
+        helper,
+        &AtomicBool::new(false),
+    )
+}
+
+fn run_as_user_deadline_argument_with_helper_cancelled(
+    op: Op,
+    argument: &OsStr,
+    uid: u32,
+    gid: u32,
+    deadline: Instant,
+    helper: &Path,
+    cancelled: &AtomicBool,
+) -> io::Result<ReceivedSocket> {
+    let path = Path::new(argument);
     let (parent, child) = UnixStream::pair()?;
+    let generation = format!(
+        "{}-{}",
+        std::process::id(),
+        NEXT_GENERATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    );
+    let generation_path = generation_path(path, &generation);
+    let helper_path = if matches!(op, Op::Listen) {
+        staging_path(path, &generation)
+    } else {
+        path.to_path_buf()
+    };
     let mut command = Command::new(helper);
     command
         .env(OP_ENV, op.as_env())
-        .env(PATH_ENV, argument)
+        .env(PATH_ENV, &helper_path)
+        .env(PUBLIC_PATH_ENV, path)
         .env(UID_ENV, uid.to_string())
-        .env(GID_ENV, gid.to_string());
-    if let Some(port) = port {
-        command.env(PORT_ENV, port.to_string());
-    }
-    command
+        .env(GID_ENV, gid.to_string())
+        .env(GENERATION_ENV, &generation)
+        .env(GENERATION_PATH_ENV, &generation_path)
         .stdin(Stdio::from(OwnedFd::from(child)))
         .stdout(Stdio::null())
         .stderr(Stdio::null());
-    let spawn_guard = helper_spawn_guard(ATOMIC_SCM_RIGHTS_CLOEXEC, deadline)?;
-    let child = command.spawn()?;
-    Ok(SpawnedHelper {
-        channel: Some(parent),
-        child: ChildLease::new(child),
-        spawn_guard,
+    let mut child_proc = command.spawn()?;
+    let result = (|| {
+        let result = recv_result_until(&parent, deadline, cancelled).and_then(|fd| {
+            let stat = rustix::fs::fstat(&fd)?;
+            let identity = if matches!(op, Op::Listen) {
+                let (owner, identity) = read_generation_marker(&generation_path)
+                    .ok_or_else(|| io::Error::other("user-socket helper omitted its generation"))?;
+                if owner != generation
+                    || identity.fd_device != stat.st_dev as u64
+                    || identity.fd_inode != stat.st_ino as u64
+                {
+                    return Err(io::Error::other("user-socket helper identity mismatch"));
+                }
+                identity
+            } else {
+                UnixSocketIdentity {
+                    fd_device: stat.st_dev as u64,
+                    fd_inode: stat.st_ino as u64,
+                    node_device: 0,
+                    node_inode: 0,
+                }
+            };
+            Ok(ReceivedSocket { fd, identity })
+        });
+        if wait_for_helper_exit(&mut child_proc, deadline, cancelled)? {
+            ensure_deadline(deadline)?;
+            result
+        } else {
+            Err(timeout_error())
+        }
+    })();
+    let timed_out = result.as_ref().is_err_and(|error| {
+        matches!(
+            error.kind(),
+            io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+        )
+    });
+    if timed_out {
+        let _ = child_proc.kill();
+    }
+    let _ = child_proc.wait();
+    if matches!(op, Op::Listen) {
+        let _ = fs::remove_file(&helper_path);
+        if result.is_err() {
+            cleanup_helper_generation(path, &generation_path, &generation);
+        } else {
+            remove_generation_marker(&generation_path, &generation);
+        }
+    }
+    if timed_out {
+        Err(timeout_error())
+    } else {
+        result
+    }
+}
+
+fn recv_result_until(
+    channel: &UnixStream,
+    deadline: Instant,
+    cancelled: &AtomicBool,
+) -> io::Result<OwnedFd> {
+    loop {
+        if cancelled.load(Ordering::Acquire) {
+            return Err(timeout_error());
+        }
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .ok_or_else(timeout_error)?;
+        channel.set_read_timeout(Some(remaining.min(Duration::from_millis(25))))?;
+        match recv_result(channel) {
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+                ) => {}
+            result => return result,
+        }
+    }
+}
+
+fn wait_for_helper_exit(
+    child: &mut std::process::Child,
+    deadline: Instant,
+    cancelled: &AtomicBool,
+) -> io::Result<bool> {
+    loop {
+        if cancelled.load(Ordering::Acquire) {
+            return Ok(false);
+        }
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .ok_or_else(timeout_error)?;
+        if child
+            .wait_timeout(remaining.min(Duration::from_millis(25)))?
+            .is_some()
+        {
+            return Ok(true);
+        }
+    }
+}
+
+fn staging_path(path: &Path, generation: &str) -> PathBuf {
+    path.parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(format!(".et-forward-{}-{generation}", std::process::id()))
+}
+
+pub(crate) fn bind_staged(
+    public_path: &Path,
+    deadline: Instant,
+) -> io::Result<(UnixListener, UnixSocketIdentity)> {
+    bind_staged_with_hook(public_path, deadline, || {})
+}
+
+fn bind_staged_with_hook(
+    public_path: &Path,
+    deadline: Instant,
+    before_publish: impl FnOnce(),
+) -> io::Result<(UnixListener, UnixSocketIdentity)> {
+    let generation = format!(
+        "{}-{}",
+        std::process::id(),
+        NEXT_GENERATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    );
+    let staged = staging_path(public_path, &generation);
+    let listener = listen_at_path(&staged)?;
+    let identity = UnixSocketIdentity::from_fd_and_node(listener.as_fd(), &staged)?;
+    ensure_deadline(deadline)?;
+    let _guard = path_operations()
+        .lock()
+        .map_err(|_| io::Error::other("socket path lock unavailable"))?;
+    ensure_deadline(deadline)?;
+    before_publish();
+    if let Err(error) = publish_noreplace(&staged, public_path) {
+        drop(listener);
+        let _ = fs::remove_file(&staged);
+        return Err(error);
+    }
+    Ok((listener, identity))
+}
+
+fn generation_path(path: &Path, generation: &str) -> PathBuf {
+    let mut value = path.as_os_str().to_owned();
+    value.push(format!(".et-generation-{generation}"));
+    PathBuf::from(value)
+}
+
+fn publish_helper_generation(listener: &UnixListener, staged: &Path) -> io::Result<()> {
+    publish_helper_generation_with_hook(listener, staged, || {})
+}
+
+fn publish_helper_generation_with_hook(
+    listener: &UnixListener,
+    staged: &Path,
+    before_publish: impl FnOnce(),
+) -> io::Result<()> {
+    let generation = std::env::var(GENERATION_ENV)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "helper generation is missing"))?;
+    let marker = std::env::var_os(GENERATION_PATH_ENV)
+        .map(PathBuf::from)
+        .ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "helper marker path is missing")
+        })?;
+    let public = std::env::var_os(PUBLIC_PATH_ENV)
+        .map(PathBuf::from)
+        .ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "public socket path is missing")
+        })?;
+    publish_helper_generation_paths(
+        listener,
+        staged,
+        &public,
+        &marker,
+        &generation,
+        before_publish,
+    )
+}
+
+fn publish_helper_generation_paths(
+    listener: &UnixListener,
+    staged: &Path,
+    public: &Path,
+    marker: &Path,
+    generation: &str,
+    before_publish: impl FnOnce(),
+) -> io::Result<()> {
+    let identity = UnixSocketIdentity::from_fd_and_node(listener.as_fd(), staged)?;
+    fs::write(
+        marker,
+        format!(
+            "{generation} {} {} {} {}\n",
+            identity.fd_device, identity.fd_inode, identity.node_device, identity.node_inode
+        ),
+    )?;
+    before_publish();
+    publish_noreplace(staged, public)
+}
+
+fn publish_noreplace(staged: &Path, public: &Path) -> io::Result<()> {
+    rustix::fs::renameat_with(
+        rustix::fs::CWD,
+        staged,
+        rustix::fs::CWD,
+        public,
+        rustix::fs::RenameFlags::NOREPLACE,
+    )
+    .map_err(|error| {
+        if error == rustix::io::Errno::EXIST {
+            io::Error::new(
+                io::ErrorKind::AddrInUse,
+                "Unix source socket was published by another generation",
+            )
+        } else {
+            io::Error::from(error)
+        }
     })
 }
 
-struct HelperSpawnLock {
-    held: Mutex<bool>,
-    available: Condvar,
+fn read_generation_marker(path: &Path) -> Option<(String, UnixSocketIdentity)> {
+    let value = fs::read_to_string(path).ok()?;
+    let mut fields = value.split_whitespace();
+    let generation = fields.next()?.to_owned();
+    let fd_device = fields.next()?.parse().ok()?;
+    let fd_inode = fields.next()?.parse().ok()?;
+    let node_device = fields.next()?.parse().ok()?;
+    let node_inode = fields.next()?.parse().ok()?;
+    fields.next().is_none().then_some((
+        generation,
+        UnixSocketIdentity {
+            fd_device,
+            fd_inode,
+            node_device,
+            node_inode,
+        },
+    ))
 }
 
-impl HelperSpawnLock {
-    fn acquire(&'static self, deadline: Instant) -> io::Result<HelperSpawnGuard> {
-        let mut held = self
-            .held
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        loop {
-            let remaining = remaining_until(deadline)?;
-            if !*held {
-                *held = true;
-                return Ok(HelperSpawnGuard(self));
-            }
-            let (next, _) = self
-                .available
-                .wait_timeout(held, remaining)
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            held = next;
-        }
-    }
-}
-
-struct HelperSpawnGuard(&'static HelperSpawnLock);
-
-impl Drop for HelperSpawnGuard {
-    fn drop(&mut self) {
-        let mut held = self
-            .0
-            .held
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        *held = false;
-        self.0.available.notify_one();
-    }
-}
-
-fn helper_spawn_guard(
-    atomic_cloexec: bool,
-    deadline: Instant,
-) -> io::Result<Option<HelperSpawnGuard>> {
-    remaining_until(deadline)?;
-    if atomic_cloexec {
-        Ok(None)
-    } else {
-        HELPER_SPAWN_LOCK.acquire(deadline).map(Some)
-    }
-}
-
-fn finish_helper(
-    helper: &mut SpawnedHelper,
-    result: io::Result<OwnedFd>,
-    deadline: Instant,
-) -> io::Result<OwnedFd> {
-    let fd = match result {
-        Ok(fd) => fd,
-        Err(error) => {
-            helper.child.reap();
-            return Err(error);
-        }
+fn cleanup_helper_generation(path: &Path, marker: &Path, generation: &str) {
+    let Some((owner, identity)) = read_generation_marker(marker) else {
+        return;
     };
-    let remaining = remaining_until(deadline)?;
-    match helper.child.as_mut().wait_timeout(remaining) {
-        Ok(Some(_)) => {
-            helper.child.take();
-            Ok(fd)
-        }
-        Ok(None) | Err(_) => {
-            helper.child.reap();
-            Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                "socket helper timed out",
-            ))
-        }
+    if owner == generation {
+        remove_socket_if_owned(path, identity);
+        remove_generation_marker(marker, generation);
     }
 }
 
-fn remaining_until_at(deadline: Instant, now: Instant) -> io::Result<Duration> {
-    deadline
-        .checked_duration_since(now)
-        .filter(|remaining| !remaining.is_zero())
-        .ok_or_else(|| io::Error::from(io::ErrorKind::TimedOut))
-}
-
-fn remaining_until(deadline: Instant) -> io::Result<Duration> {
-    remaining_until_at(deadline, Instant::now())
-}
-
-fn reject_success_after_deadline<T>(result: io::Result<T>, deadline: Instant) -> io::Result<T> {
-    if result.is_ok() {
-        remaining_until(deadline)?;
+fn remove_generation_marker(marker: &Path, generation: &str) {
+    if read_generation_marker(marker).is_some_and(|(owner, _)| owner == generation) {
+        let _ = fs::remove_file(marker);
     }
-    result
+}
+
+fn timeout_error() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::TimedOut,
+        "user-socket helper deadline elapsed",
+    )
+}
+
+fn ensure_deadline(deadline: Instant) -> io::Result<()> {
+    if Instant::now() >= deadline {
+        Err(timeout_error())
+    } else {
+        Ok(())
+    }
 }
 
 fn drop_helper_privileges() -> io::Result<()> {
@@ -609,14 +749,10 @@ fn drop_helper_privileges() -> io::Result<()> {
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or_else(|| rustix::process::getgid().as_raw());
-    if !rustix::process::geteuid().is_root() {
-        if rustix::process::geteuid().as_raw() == uid && rustix::process::getegid().as_raw() == gid
-        {
-            // An unprivileged process cannot change its supplementary groups.
-            // It also cannot have inherited groups from a more privileged
-            // daemon identity, so retaining its own groups adds no authority.
-            return Ok(());
-        }
+    if !rustix::process::geteuid().is_root()
+        && (rustix::process::geteuid().as_raw() != uid
+            || rustix::process::getegid().as_raw() != gid)
+    {
         return Err(io::Error::from_raw_os_error(
             rustix::io::Errno::PERM.raw_os_error(),
         ));
@@ -673,13 +809,6 @@ fn helper_identity_matches(
     let mut observed = identity.groups.clone();
     observed.sort_unstable();
     identity.euid == target.0 && identity.egid == target.1 && observed == expected
-}
-
-fn env_u16(name: &str) -> io::Result<u16> {
-    std::env::var(name)
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, format!("missing {name}")))?
-        .parse()
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, format!("invalid {name}")))
 }
 
 fn helper_exe() -> io::Result<PathBuf> {
@@ -753,9 +882,7 @@ fn send_result(channel: BorrowedFd<'_>, fd: Option<BorrowedFd<'_>>, status: i32,
     if status == 0 {
         if let Some(fd) = fd {
             rights = [fd];
-            if !control.push(SendAncillaryMessage::ScmRights(&rights)) {
-                return 1;
-            }
+            let _ = control.push(SendAncillaryMessage::ScmRights(&rights));
         }
     }
     match sendmsg(
@@ -764,63 +891,20 @@ fn send_result(channel: BorrowedFd<'_>, fd: Option<BorrowedFd<'_>>, status: i32,
         &mut control,
         SendFlags::empty(),
     ) {
-        Ok(sent) if sent == header.len() => i32::from(status != 0),
-        Ok(_) => 1,
+        Ok(_) => i32::from(status != 0),
         Err(_) => 1,
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
-fn recv_cloexec_flags() -> RecvFlags {
-    RecvFlags::CMSG_CLOEXEC
-}
-
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
-fn recv_cloexec_flags() -> RecvFlags {
-    RecvFlags::empty()
-}
-
-fn ensure_cloexec(fd: &OwnedFd) -> io::Result<()> {
-    let flags = rustix::io::fcntl_getfd(fd)?;
-    if !flags.contains(rustix::io::FdFlags::CLOEXEC) {
-        rustix::io::fcntl_setfd(fd, flags | rustix::io::FdFlags::CLOEXEC)?;
-    }
-    Ok(())
-}
-
-fn retry_on_intr_until<T>(
-    deadline: Instant,
-    mut now: impl FnMut() -> Instant,
-    mut before_attempt: impl FnMut(Duration) -> io::Result<()>,
-    mut operation: impl FnMut() -> Result<T, rustix::io::Errno>,
-) -> io::Result<T> {
-    loop {
-        let remaining = remaining_until_at(deadline, now())?;
-        before_attempt(remaining)?;
-        match operation() {
-            Err(rustix::io::Errno::INTR) => {}
-            Err(error) => return Err(error.into()),
-            Ok(value) => return Ok(value),
-        }
-    }
-}
-
-fn recv_result_until(channel: &UnixStream, deadline: Instant) -> io::Result<OwnedFd> {
+fn recv_result(channel: &UnixStream) -> io::Result<OwnedFd> {
     let mut header = [0u8; 8];
     let mut space = [MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(1))];
     let mut control = RecvAncillaryBuffer::new(&mut space);
-    let received = retry_on_intr_until(
-        deadline,
-        Instant::now,
-        |remaining| channel.set_read_timeout(Some(remaining)),
-        || {
-            recvmsg(
-                channel,
-                &mut [IoSliceMut::new(&mut header)],
-                &mut control,
-                recv_cloexec_flags(),
-            )
-        },
+    let received = recvmsg(
+        channel,
+        &mut [IoSliceMut::new(&mut header)],
+        &mut control,
+        RecvFlags::empty(),
     )?;
     if received.bytes != header.len() {
         return Err(io::Error::other(
@@ -839,7 +923,6 @@ fn recv_result_until(channel: &UnixStream, deadline: Instant) -> io::Result<Owne
     for message in control.drain() {
         if let RecvAncillaryMessage::ScmRights(mut rights) = message {
             if let Some(fd) = rights.next() {
-                ensure_cloexec(&fd)?;
                 return Ok(fd);
             }
         }
@@ -850,11 +933,10 @@ fn recv_result_until(channel: &UnixStream, deadline: Instant) -> io::Result<Owne
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs::OpenOptions;
     use std::io::{Read, Write};
-    #[cfg(target_os = "linux")]
-    use std::os::fd::AsRawFd;
-    use std::os::unix::fs::FileTypeExt;
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+    use std::sync::atomic::AtomicU64;
 
     fn temp_dir() -> PathBuf {
         static NEXT: AtomicU64 = AtomicU64::new(0);
@@ -871,6 +953,27 @@ mod tests {
 
     fn long_unix_path() -> PathBuf {
         PathBuf::from("x".repeat(UNIX_PATH_MAX + 8))
+    }
+
+    fn socket_helper(directory: &Path, behavior: &str) -> PathBuf {
+        let helper = directory.join(format!("helper-{behavior}.py"));
+        let tail = match behavior {
+            "block" => "open(public + '.event', 'wb').write(b'x')\nos.read(0, 1)\n",
+            "short" => "os.write(0, b'x')\n",
+            "missing" => "os.write(0, struct.pack('ii', 0, 0))\n",
+            "error" => "os.write(0, struct.pack('ii', -1, 5))\n",
+            "handoff" => "channel=socket.socket(fileno=0)\nfds=array.array('i', [s.fileno()])\nchannel.sendmsg([struct.pack('ii', 0, 0)], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds)])\nopen(public + '.event', 'wb').write(b'x')\nopen(public + '.release', 'rb').read(1)\n",
+            _ => unreachable!(),
+        };
+        fs::write(
+            &helper,
+            format!(
+                "#!/usr/bin/python3\nimport array, os, socket, struct\npath=os.environ['{PATH_ENV}']\npublic=os.environ['{PUBLIC_PATH_ENV}']\nmarker=os.environ['{GENERATION_PATH_ENV}']\ngeneration=os.environ['{GENERATION_ENV}']\ntry: os.unlink(path)\nexcept FileNotFoundError: pass\ns=socket.socket(socket.AF_UNIX)\ns.bind(path)\nfdst=os.fstat(s.fileno())\nnodest=os.stat(path)\nopen(marker, 'w').write(f'{{generation}} {{fdst.st_dev}} {{fdst.st_ino}} {{nodest.st_dev}} {{nodest.st_ino}}\\n')\nos.link(path, public)\nos.unlink(path)\n{tail}"
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&helper, fs::Permissions::from_mode(0o700)).unwrap();
+        helper
     }
 
     #[test]
@@ -906,71 +1009,23 @@ mod tests {
     }
 
     #[test]
-    fn interrupted_descriptor_receive_does_not_extend_deadline() {
-        let start = Instant::now();
-        let deadline = start + Duration::from_secs(1);
-        let mut times = [start, deadline].into_iter();
-        let attempts = std::cell::Cell::new(0);
-        let configured = std::cell::RefCell::new(Vec::new());
-        let result = retry_on_intr_until(
-            deadline,
-            || times.next().expect("one clock read per attempt"),
-            |remaining| {
-                configured.borrow_mut().push(remaining);
-                Ok(())
-            },
-            || {
-                attempts.set(attempts.get() + 1);
-                Err::<(), _>(rustix::io::Errno::INTR)
-            },
-        );
+    fn listen_failure_after_bind_cleans_socket_and_immediate_retry_succeeds() {
+        // Given
+        let dir = temp_dir();
+        let path = dir.join("post-bind-failure.sock");
 
-        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::TimedOut);
-        assert_eq!(attempts.get(), 1);
-        assert_eq!(&*configured.borrow(), &[Duration::from_secs(1)]);
-    }
+        // When
+        let error = listen_at_path_with(&path, || Err(io::Error::other("injected before chmod")))
+            .unwrap_err();
 
-    #[test]
-    fn fallback_helper_spawn_lock_obeys_deadline() {
-        let first =
-            helper_spawn_guard(false, Instant::now().checked_add(HELPER_TIMEOUT).unwrap()).unwrap();
-        assert!(first.is_some());
-
-        let error = match helper_spawn_guard(false, Instant::now()) {
-            Ok(_) => panic!("contended fallback lock succeeded after deadline"),
-            Err(error) => error,
-        };
-        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
-        assert!(helper_spawn_guard(true, Instant::now()).is_err());
-
-        drop(first);
-    }
-
-    #[test]
-    fn late_listener_result_is_rejected() {
-        let error = reject_success_after_deadline(Ok("listener"), Instant::now()).unwrap_err();
-        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
-    }
-
-    #[test]
-    fn child_lease_reaps_on_error_and_transfers_on_success() {
-        struct MockChild(std::rc::Rc<std::cell::Cell<usize>>);
-        impl KillAndWait for MockChild {
-            fn kill_and_wait(&mut self) {
-                self.0.set(self.0.get() + 1);
-            }
-        }
-
-        let reaped = std::rc::Rc::new(std::cell::Cell::new(0));
-        drop(ChildLease::new(MockChild(reaped.clone())));
-        assert_eq!(reaped.get(), 1);
-
-        let mut lease = ChildLease::new(MockChild(reaped.clone()));
-        let child = lease.take().unwrap();
-        drop(lease);
-        assert_eq!(reaped.get(), 1);
-        drop(child);
-        assert_eq!(reaped.get(), 1);
+        // Then
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert!(!path.exists());
+        let listener = listen_at_path(&path).unwrap();
+        assert!(path.exists());
+        drop(listener);
+        fs::remove_file(&path).unwrap();
+        fs::remove_dir(&dir).unwrap();
     }
 
     #[test]
@@ -1029,6 +1084,440 @@ mod tests {
     }
 
     #[test]
+    fn helper_no_reply_is_killed_reaped_and_socket_path_rolled_back() {
+        let dir = temp_dir();
+        let path = dir.join("listener.sock");
+        let event = PathBuf::from(format!("{}.event", path.display()));
+        assert!(Command::new("mkfifo")
+            .arg(&event)
+            .status()
+            .unwrap()
+            .success());
+        let event_control = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&event)
+            .unwrap();
+        let helper = dir.join("helper.sh");
+        fs::write(
+            &helper,
+            "#!/bin/sh\nprintf x > \"${ET_RS_USER_SOCKET_PUBLIC_PATH}.event\"\nexec cat\n",
+        )
+        .unwrap();
+        fs::set_permissions(&helper, fs::Permissions::from_mode(0o700)).unwrap();
+        let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+        let worker_path = path.clone();
+        std::thread::spawn(move || {
+            let result = run_as_user_deadline_with_helper(
+                Op::Listen,
+                &worker_path,
+                rustix::process::geteuid().as_raw(),
+                rustix::process::getegid().as_raw(),
+                Instant::now() + Duration::from_millis(100),
+                &helper,
+            );
+            let _ = done_tx.send(result);
+        });
+        let (event_tx, event_rx) = std::sync::mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            let mut event_control = event_control;
+            let mut byte = [0];
+            let result = event_control.read_exact(&mut byte);
+            let _ = event_tx.send(result);
+        });
+        event_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("helper did not enter its no-reply state")
+            .unwrap();
+        let error = done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("timed-out helper was not killed and reaped")
+            .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(!path.exists());
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn stalled_tcp_helper_honors_caller_deadline_and_is_killed_reaped() {
+        let dir = temp_dir();
+        let event = dir.join("tcp-helper.event");
+        assert!(Command::new("mkfifo")
+            .arg(&event)
+            .status()
+            .unwrap()
+            .success());
+        let event_control = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&event)
+            .unwrap();
+        let pid_path = dir.join("tcp-helper.pid");
+        let helper = dir.join("tcp-helper.py");
+        fs::write(
+            &helper,
+            format!(
+                "#!/usr/bin/python3\nimport os, socket\nhost, port = os.environ['{PATH_ENV}'].rsplit(':', 1)\ns = socket.socket(socket.AF_INET)\ns.bind((host, int(port)))\ns.listen(1)\nopen(r'{}', 'w').write(str(os.getpid()))\nopen(r'{}', 'wb').write(b'x')\nos.read(0, 1)\n",
+                pid_path.display(),
+                event.display()
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&helper, fs::Permissions::from_mode(0o700)).unwrap();
+        let probe = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let address = probe.local_addr().unwrap();
+        drop(probe);
+        let started = Instant::now();
+        let deadline = started + Duration::from_secs(1);
+        let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            let argument = address.to_string();
+            let result = run_as_user_deadline_argument_with_helper(
+                Op::ListenTcp,
+                OsStr::new(&argument),
+                rustix::process::geteuid().as_raw(),
+                rustix::process::getegid().as_raw(),
+                deadline,
+                &helper,
+            );
+            let _ = done_tx.send((Instant::now(), result));
+        });
+        let (event_tx, event_rx) = std::sync::mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            let mut event_control = event_control;
+            let mut byte = [0];
+            let result = event_control.read_exact(&mut byte);
+            let _ = event_tx.send(result);
+        });
+        event_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("TCP helper did not bind and enter its no-reply state")
+            .unwrap();
+        let (completed, result) = done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("TCP helper exceeded the caller deadline without being reaped");
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::TimedOut);
+        assert!(completed <= deadline + Duration::from_millis(100));
+        let pid = fs::read_to_string(&pid_path)
+            .unwrap()
+            .trim()
+            .parse()
+            .ok()
+            .and_then(rustix::process::Pid::from_raw)
+            .unwrap();
+        assert_eq!(
+            rustix::process::waitpid(Some(pid), rustix::process::WaitOptions::NOHANG).unwrap_err(),
+            rustix::io::Errno::CHILD,
+            "timed-out TCP helper was not killed and reaped"
+        );
+        TcpListener::bind(address).expect("timed-out TCP helper left its listener behind");
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn older_helper_timeout_does_not_unlink_replacement_generation() {
+        let dir = temp_dir();
+        let path = dir.join("overlap.sock");
+        let event = PathBuf::from(format!("{}.event", path.display()));
+        assert!(Command::new("mkfifo")
+            .arg(&event)
+            .status()
+            .unwrap()
+            .success());
+        let event_control = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&event)
+            .unwrap();
+        let helper = socket_helper(&dir, "block");
+        enum HelperLifecycle {
+            Published(io::Result<()>),
+            Done(io::Result<ReceivedSocket>),
+        }
+        let (lifecycle_tx, lifecycle_rx) = std::sync::mpsc::sync_channel(2);
+        let cancelled = std::sync::Arc::new(AtomicBool::new(false));
+        let worker_cancelled = cancelled.clone();
+        let worker_tx = lifecycle_tx.clone();
+        let old_path = path.clone();
+        std::thread::spawn(move || {
+            let result = run_as_user_deadline_with_helper_cancelled(
+                Op::Listen,
+                &old_path,
+                rustix::process::geteuid().as_raw(),
+                rustix::process::getegid().as_raw(),
+                Instant::now() + Duration::from_secs(30),
+                &helper,
+                &worker_cancelled,
+            );
+            let _ = worker_tx.send(HelperLifecycle::Done(result));
+        });
+        std::thread::spawn(move || {
+            let mut event_control = event_control;
+            let mut byte = [0];
+            let result = event_control.read_exact(&mut byte);
+            let _ = lifecycle_tx.send(HelperLifecycle::Published(result));
+        });
+        match lifecycle_rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(HelperLifecycle::Published(Ok(()))) => {}
+            Ok(HelperLifecycle::Published(Err(error))) => {
+                panic!("helper publication event failed: {error}")
+            }
+            Ok(HelperLifecycle::Done(Ok(_))) => {
+                panic!("helper returned a listener before entering no-reply")
+            }
+            Ok(HelperLifecycle::Done(Err(error))) => {
+                panic!("helper failed before publishing its generation: {error}")
+            }
+            Err(error) => panic!("helper lifecycle produced no event: {error}"),
+        }
+        assert!(fs::metadata(&path).unwrap().file_type().is_socket());
+        let marker = fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .find(|candidate| candidate.to_string_lossy().contains(".et-generation-"))
+            .expect("published helper generation has no ownership marker");
+        let (_, identity) = read_generation_marker(&marker)
+            .expect("published helper generation marker is malformed");
+        assert!(identity.node_matches(&path));
+
+        fs::remove_file(&path).unwrap();
+        let replacement = listen_at_path(&path).unwrap();
+        cancelled.store(true, Ordering::Release);
+        let error = match lifecycle_rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(HelperLifecycle::Done(result)) => result.unwrap_err(),
+            Ok(HelperLifecycle::Published(_)) => panic!("duplicate helper publication event"),
+            Err(error) => panic!("cancelled helper was not killed and reaped: {error}"),
+        };
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        let client = UnixStream::connect(&path)
+            .expect("older helper timeout unlinked replacement generation");
+        replacement.accept().unwrap();
+        drop(client);
+        drop(replacement);
+        let _ = fs::remove_file(&path);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn successful_handoff_does_not_adopt_replacement_before_helper_exit() {
+        let dir = temp_dir();
+        let path = dir.join("handoff.sock");
+        for suffix in ["event", "release"] {
+            assert!(Command::new("mkfifo")
+                .arg(format!("{}.{}", path.display(), suffix))
+                .status()
+                .unwrap()
+                .success());
+        }
+        let event = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(format!("{}.event", path.display()))
+            .unwrap();
+        let mut release = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(format!("{}.release", path.display()))
+            .unwrap();
+        let helper = socket_helper(&dir, "handoff");
+        let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+        let worker_path = path.clone();
+        std::thread::spawn(move || {
+            let result = run_as_user_deadline_with_helper(
+                Op::Listen,
+                &worker_path,
+                rustix::process::geteuid().as_raw(),
+                rustix::process::getegid().as_raw(),
+                Instant::now() + Duration::from_secs(2),
+                &helper,
+            );
+            let _ = done_tx.send(result);
+        });
+        let (event_tx, event_rx) = std::sync::mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            let mut event = event;
+            let mut byte = [0];
+            let _ = event_tx.send(event.read_exact(&mut byte));
+        });
+        event_rx
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap()
+            .unwrap();
+        fs::remove_file(&path).unwrap();
+        let replacement = listen_at_path(&path).unwrap();
+        release.write_all(b"x").unwrap();
+        let received = done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap()
+            .unwrap();
+        assert!(!received.identity.node_matches(&path));
+        remove_socket_if_owned(&path, received.identity);
+        drop(received);
+        let client = UnixStream::connect(&path)
+            .expect("successful older handoff adopted replacement identity");
+        replacement.accept().unwrap();
+        drop(client);
+        drop(replacement);
+        let _ = fs::remove_file(&path);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn premarker_short_reply_leaves_no_public_or_staged_socket() {
+        let dir = temp_dir();
+        let path = dir.join("premarker.sock");
+        let helper = dir.join("premarker.py");
+        fs::write(
+            &helper,
+            format!(
+                "#!/usr/bin/python3\nimport os,socket\np=os.environ['{PATH_ENV}']\ns=socket.socket(socket.AF_UNIX)\ns.bind(p)\nos.write(0,b'x')\n"
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&helper, fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(run_as_user_deadline_with_helper(
+            Op::Listen,
+            &path,
+            rustix::process::geteuid().as_raw(),
+            rustix::process::getegid().as_raw(),
+            Instant::now() + Duration::from_secs(1),
+            &helper,
+        )
+        .is_err());
+        assert!(!path.exists());
+        assert!(fs::read_dir(&dir).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".et-forward-")
+        }));
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn missing_fd_and_explicit_helper_error_remove_owned_generation() {
+        for behavior in ["missing", "error"] {
+            let dir = temp_dir();
+            let path = dir.join(format!("{behavior}.sock"));
+            let helper = socket_helper(&dir, behavior);
+            assert!(run_as_user_deadline_with_helper(
+                Op::Listen,
+                &path,
+                rustix::process::geteuid().as_raw(),
+                rustix::process::getegid().as_raw(),
+                Instant::now() + Duration::from_secs(1),
+                &helper,
+            )
+            .is_err());
+            assert!(!path.exists(), "{behavior} left the public socket");
+            fs::remove_dir_all(dir).unwrap();
+        }
+    }
+
+    #[test]
+    fn malformed_helper_reply_reaps_helper_and_removes_owned_stale_path() {
+        let dir = temp_dir();
+        let path = dir.join("malformed.sock");
+        let helper = socket_helper(&dir, "short");
+        let error = run_as_user_deadline_with_helper(
+            Op::Listen,
+            &path,
+            rustix::process::geteuid().as_raw(),
+            rustix::process::getegid().as_raw(),
+            Instant::now() + Duration::from_secs(1),
+            &helper,
+        )
+        .unwrap_err();
+        assert_ne!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(!path.exists(), "malformed helper left a stale socket path");
+        assert!(
+            fs::read_dir(&dir).unwrap().all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .contains("et-generation")),
+            "malformed helper left a generation marker"
+        );
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn replacement_published_after_retirement_is_never_unlinked() {
+        let dir = temp_dir();
+        let path = dir.join("retire-race.sock");
+        let (old, identity) = bind_staged(&path, Instant::now() + Duration::from_secs(1)).unwrap();
+        fs::remove_file(&path).unwrap();
+        let displaced = UnixListener::bind(&path).unwrap();
+        let mut newest = None;
+        remove_socket_if_owned_with_hook(&path, identity, || {
+            newest = Some(UnixListener::bind(&path).unwrap());
+        });
+        let client = UnixStream::connect(&path)
+            .expect("retirement cleanup unlinked newly published generation");
+        newest.as_ref().unwrap().accept().unwrap();
+        drop(client);
+        drop(old);
+        drop(displaced);
+        drop(newest);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn helper_publication_loses_atomically_to_final_window_replacement() {
+        let dir = temp_dir();
+        let public = dir.join("helper-race.sock");
+        let staged = dir.join("helper-race.staged");
+        let marker = dir.join("helper-race.marker");
+        let generation = "test-generation";
+        let listener = listen_at_path(&staged).unwrap();
+        let mut replacement = None;
+        let error = publish_helper_generation_paths(
+            &listener,
+            &staged,
+            &public,
+            &marker,
+            generation,
+            || replacement = Some(listen_at_path(&public).unwrap()),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::AddrInUse);
+        drop(listener);
+        let _ = fs::remove_file(&staged);
+        cleanup_helper_generation(&public, &marker, generation);
+        assert!(!staged.exists());
+        assert!(!marker.exists());
+        let client = UnixStream::connect(&public).unwrap();
+        replacement.as_ref().unwrap().accept().unwrap();
+        drop(client);
+        drop(replacement);
+        fs::remove_file(public).unwrap();
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn direct_bind_replacement_during_identity_capture_is_preserved() {
+        let dir = temp_dir();
+        let path = dir.join("direct-race.sock");
+        let mut replacement = None;
+        let error =
+            match bind_staged_with_hook(&path, Instant::now() + Duration::from_secs(1), || {
+                replacement = Some(UnixListener::bind(&path).unwrap())
+            }) {
+                Ok(_) => panic!("older direct bind overwrote replacement generation"),
+                Err(error) => error,
+            };
+        assert_eq!(error.kind(), io::ErrorKind::AddrInUse);
+        let client = UnixStream::connect(&path).unwrap();
+        replacement.as_ref().unwrap().accept().unwrap();
+        drop(client);
+        drop(replacement);
+        fs::remove_file(path).unwrap();
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
     fn listen_unix_as_user_rejects_oversized_path() {
         let uid = rustix::process::getuid().as_raw();
         let gid = rustix::process::getgid().as_raw();
@@ -1083,123 +1572,6 @@ mod tests {
         let _ = fs::remove_dir(&dir);
     }
 
-    #[test]
-    fn failed_listener_descriptor_transfer_removes_socket_path() {
-        let dir = temp_dir();
-        let path = dir.join("sock");
-        let listener = PendingUnixListener::bind(&path).unwrap();
-        let (channel, peer) = UnixStream::pair().unwrap();
-        drop(peer);
-
-        assert_eq!(listener.send_and_serve(channel.as_fd()), 1);
-        assert!(!path.exists());
-
-        fs::remove_dir(dir).unwrap();
-    }
-
-    #[test]
-    fn listener_cleanup_is_anchored_to_the_bound_parent() {
-        if helper_exe().is_err() {
-            eprintln!("skipping helper-dependent test: et-user-socket-helper is unavailable");
-            return;
-        }
-        let base = temp_dir();
-        let live = base.join("live");
-        let parked = base.join("parked");
-        let target = base.join("target");
-        fs::create_dir(&live).unwrap();
-        fs::create_dir(&target).unwrap();
-        let socket = live.join("victim");
-        let uid = rustix::process::geteuid().as_raw();
-        let gid = rustix::process::getegid().as_raw();
-        let listener =
-            run_listener_as_user(&socket, uid, gid, Instant::now() + HELPER_TIMEOUT).unwrap();
-
-        fs::rename(&live, &parked).unwrap();
-        let sentinel = target.join("victim");
-        fs::write(&sentinel, b"keep").unwrap();
-        std::os::unix::fs::symlink(&target, &live).unwrap();
-        drop(listener);
-
-        assert_eq!(fs::read(&sentinel).unwrap(), b"keep");
-        assert!(!parked.join("victim").exists());
-        fs::remove_file(&live).unwrap();
-        fs::remove_file(&sentinel).unwrap();
-        fs::remove_dir(&target).unwrap();
-        fs::remove_dir(&parked).unwrap();
-        fs::remove_dir(&base).unwrap();
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn descriptor_received_from_helper_is_not_inherited_by_next_helper() {
-        let dir = temp_dir();
-        let uid = rustix::process::geteuid().as_raw();
-        let gid = rustix::process::getegid().as_raw();
-        let first = run_listener_as_user(
-            &dir.join("first"),
-            uid,
-            gid,
-            Instant::now() + HELPER_TIMEOUT,
-        )
-        .unwrap();
-        let received_socket =
-            fs::read_link(format!("/proc/self/fd/{}", first.listener.as_raw_fd(),)).unwrap();
-
-        let second = run_listener_as_user(
-            &dir.join("second"),
-            uid,
-            gid,
-            Instant::now() + HELPER_TIMEOUT,
-        )
-        .unwrap();
-        let second_helper = second
-            .cleanup
-            .as_ref()
-            .and_then(|cleanup| cleanup.child.as_ref())
-            .expect("persistent listener helper");
-        let inherited = fs::read_dir(format!("/proc/{}/fd", second_helper.id()))
-            .unwrap()
-            .filter_map(Result::ok)
-            .filter_map(|entry| fs::read_link(entry.path()).ok())
-            .any(|target| target == received_socket);
-
-        assert!(
-            !inherited,
-            "subsequent helper inherited received fd {received_socket:?}"
-        );
-        drop(second);
-        drop(first);
-        fs::remove_dir(dir).unwrap();
-    }
-
-    #[test]
-    fn tcp_destination_connect_runs_through_the_session_helper() {
-        if helper_exe().is_err() {
-            eprintln!("skipping helper-dependent test: et-user-socket-helper is unavailable");
-            return;
-        }
-        let listener = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let uid = rustix::process::geteuid().as_raw();
-        let gid = rustix::process::getegid().as_raw();
-        let fd = run_as_user_until_with_port(
-            Op::ConnectTcp,
-            OsStr::new("127.0.0.1"),
-            uid,
-            gid,
-            Instant::now() + HELPER_TIMEOUT,
-            Some(port),
-        )
-        .unwrap();
-        let mut client = std::net::TcpStream::from(fd);
-        let (mut server, _) = listener.accept().unwrap();
-        client.write_all(b"session-user").unwrap();
-        let mut payload = [0_u8; 12];
-        server.read_exact(&mut payload).unwrap();
-        assert_eq!(&payload, b"session-user");
-    }
-
     fn unprivileged_drop_user() -> Option<(u32, u32)> {
         if rustix::process::getuid().as_raw() != 0 {
             return None;
@@ -1227,20 +1599,6 @@ mod tests {
             return Some((uid, gid));
         }
         None
-    }
-
-    #[test]
-    fn helper_command_clears_privileged_supplementary_groups() {
-        let Some((uid, gid)) = unprivileged_drop_user() else {
-            eprintln!("skipping helper group-drop test: not root or no nobody user");
-            return;
-        };
-        let identity = HelperIdentity {
-            euid: uid,
-            egid: gid,
-            groups: vec![gid],
-        };
-        assert!(helper_identity_matches((uid, gid), &[gid], &identity));
     }
 
     /// ANT-2026-AVTT7HQH: privilege-dropped listen cannot unlink a root-owned

--- a/crates/et-net/src/user_socket_ops.rs
+++ b/crates/et-net/src/user_socket_ops.rs
@@ -34,8 +34,11 @@ const UID_ENV: &str = "ET_RS_USER_SOCKET_UID";
 const GID_ENV: &str = "ET_RS_USER_SOCKET_GID";
 const HELPER_ENV: &str = "ET_RS_USER_SOCKET_HELPER";
 const HELPER_NAME: &str = "et-user-socket-helper";
-/// `sockaddr_un.sun_path` on Linux, including the trailing NUL.
+/// `sockaddr_un.sun_path`, including the trailing NUL.
+#[cfg(not(target_os = "macos"))]
 const UNIX_PATH_MAX: usize = 108;
+#[cfg(target_os = "macos")]
+const UNIX_PATH_MAX: usize = 104;
 const HELPER_TIMEOUT: Duration = Duration::from_secs(5);
 const ATOMIC_SCM_RIGHTS_CLOEXEC: bool = cfg!(any(target_os = "linux", target_os = "android"));
 static HELPER_SPAWN_LOCK: HelperSpawnLock = HelperSpawnLock {
@@ -246,6 +249,11 @@ pub(crate) fn listen_unix_as_user_until(
     deadline: Instant,
 ) -> io::Result<UserUnixListener> {
     let path = path.as_ref();
+    if path_too_long(path) {
+        return Err(io::Error::from_raw_os_error(
+            rustix::io::Errno::NAMETOOLONG.raw_os_error(),
+        ));
+    }
     run_listener_as_user(path, uid, gid, deadline)
 }
 
@@ -1088,6 +1096,8 @@ mod tests {
         let uid = rustix::process::getuid().as_raw();
         let gid = rustix::process::getgid().as_raw();
         let error = listen_unix_as_user(long_unix_path(), uid, gid).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidFilename);
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         assert_eq!(
             error.raw_os_error(),
             Some(rustix::io::Errno::NAMETOOLONG.raw_os_error())

--- a/crates/et-net/src/user_socket_ops.rs
+++ b/crates/et-net/src/user_socket_ops.rs
@@ -18,102 +18,36 @@ use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Condvar, Mutex};
 use std::time::{Duration, Instant};
-use wait_timeout::ChildExt;
 
 use rustix::net::{
     recvmsg, sendmsg, RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags, SendAncillaryBuffer,
     SendAncillaryMessage, SendFlags,
 };
+use wait_timeout::ChildExt;
 
 const OP_ENV: &str = "ET_RS_USER_SOCKET_OP";
 const PATH_ENV: &str = "ET_RS_USER_SOCKET_PATH";
-const PUBLIC_PATH_ENV: &str = "ET_RS_USER_SOCKET_PUBLIC_PATH";
+const PORT_ENV: &str = "ET_RS_USER_SOCKET_PORT";
 const UID_ENV: &str = "ET_RS_USER_SOCKET_UID";
 const GID_ENV: &str = "ET_RS_USER_SOCKET_GID";
 const HELPER_ENV: &str = "ET_RS_USER_SOCKET_HELPER";
-const GENERATION_ENV: &str = "ET_RS_USER_SOCKET_GENERATION";
-const GENERATION_PATH_ENV: &str = "ET_RS_USER_SOCKET_GENERATION_PATH";
 const HELPER_NAME: &str = "et-user-socket-helper";
 /// `sockaddr_un.sun_path` on Linux, including the trailing NUL.
 const UNIX_PATH_MAX: usize = 108;
-static NEXT_GENERATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct UnixSocketIdentity {
-    fd_device: u64,
-    fd_inode: u64,
-    node_device: u64,
-    node_inode: u64,
-}
-
-impl UnixSocketIdentity {
-    fn from_fd_and_node(fd: BorrowedFd<'_>, node: &Path) -> io::Result<Self> {
-        let stat = rustix::fs::fstat(fd)?;
-        let metadata = fs::symlink_metadata(node)?;
-        Ok(Self {
-            fd_device: stat.st_dev as u64,
-            fd_inode: stat.st_ino as u64,
-            node_device: metadata.dev(),
-            node_inode: metadata.ino(),
-        })
-    }
-
-    fn node_matches(self, path: &Path) -> bool {
-        fs::symlink_metadata(path).is_ok_and(|metadata| {
-            metadata.dev() == self.node_device && metadata.ino() == self.node_inode
-        })
-    }
-}
-
-fn path_operations() -> &'static std::sync::Mutex<()> {
-    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-    LOCK.get_or_init(|| std::sync::Mutex::new(()))
-}
-
-pub(crate) fn remove_socket_if_owned(path: &Path, identity: UnixSocketIdentity) {
-    remove_socket_if_owned_with_hook(path, identity, || {});
-}
-
-fn remove_socket_if_owned_with_hook(
-    path: &Path,
-    identity: UnixSocketIdentity,
-    after_retire: impl FnOnce(),
-) {
-    let Ok(_guard) = path_operations().lock() else {
-        return;
-    };
-    let retired = staging_path(
-        path,
-        &format!(
-            "retired-{}",
-            NEXT_GENERATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-        ),
-    );
-    if fs::rename(path, &retired).is_err() {
-        return;
-    }
-    after_retire();
-    if identity.node_matches(&retired) {
-        let _ = fs::remove_file(retired);
-        return;
-    }
-    // We retired a replacement rather than our generation. Restore it only
-    // if no newer publisher has already occupied the public path.
-    let _ = rustix::fs::renameat_with(
-        rustix::fs::CWD,
-        &retired,
-        rustix::fs::CWD,
-        path,
-        rustix::fs::RenameFlags::NOREPLACE,
-    );
-}
+const HELPER_TIMEOUT: Duration = Duration::from_secs(5);
+const ATOMIC_SCM_RIGHTS_CLOEXEC: bool = cfg!(any(target_os = "linux", target_os = "android"));
+static HELPER_SPAWN_LOCK: HelperSpawnLock = HelperSpawnLock {
+    held: Mutex::new(false),
+    available: Condvar::new(),
+};
 
 #[derive(Clone, Copy)]
 enum Op {
     Listen,
     Connect,
+    ConnectTcp,
     ListenTcp,
 }
 
@@ -122,6 +56,7 @@ impl Op {
         match self {
             Self::Listen => "listen",
             Self::Connect => "connect",
+            Self::ConnectTcp => "connect-tcp",
             Self::ListenTcp => "listen-tcp",
         }
     }
@@ -130,6 +65,7 @@ impl Op {
         match value {
             "listen" => Some(Self::Listen),
             "connect" => Some(Self::Connect),
+            "connect-tcp" => Some(Self::ConnectTcp),
             "listen-tcp" => Some(Self::ListenTcp),
             _ => None,
         }
@@ -153,31 +89,33 @@ pub fn run_helper() -> i32 {
     let op = std::env::var(OP_ENV)
         .ok()
         .and_then(|value| Op::parse(&value));
-    let path = std::env::var(PATH_ENV).unwrap_or_default();
-    match (op, path.is_empty()) {
-        (Some(Op::Listen), false) => match listen_at_path(Path::new(&path)) {
-            Ok(listener) => match publish_helper_generation(&listener, Path::new(&path)) {
-                Ok(()) => send_result(channel, Some(listener.as_fd()), 0, 0),
-                Err(error) => {
-                    drop(listener);
-                    let _ = fs::remove_file(&path);
-                    send_error(channel, &error)
-                }
-            },
-            Err(error) => send_error(channel, &error),
-        },
-        (Some(Op::Connect), false) => match connect_at_path(Path::new(&path)) {
+    let argument = std::env::var(PATH_ENV).unwrap_or_default();
+    match op {
+        Some(Op::Listen) if !argument.is_empty() => {
+            match PendingUnixListener::bind_anchored(Path::new(&argument)) {
+                Ok(listener) => listener.send_and_serve(channel),
+                Err(error) => send_error(channel, &error),
+            }
+        }
+        Some(Op::Connect) if !argument.is_empty() => match connect_at_path(Path::new(&argument)) {
             Ok(stream) => send_result(channel, Some(stream.as_fd()), 0, 0),
             Err(error) => send_error(channel, &error),
         },
-        (Some(Op::ListenTcp), _) => match path.parse() {
+        Some(Op::ConnectTcp) if !argument.is_empty() => match env_u16(PORT_ENV) {
+            Ok(port) => match crate::forward_endpoint::connect_tcp(&argument, port) {
+                Ok(stream) => send_result(channel, Some(stream.as_fd()), 0, 0),
+                Err(error) => send_error(channel, &error),
+            },
+            Err(error) => send_error(channel, &error),
+        },
+        Some(Op::ListenTcp) => match argument.parse() {
             Ok(address) => match listen_tcp_at_address(address) {
                 Ok(listener) => send_result(channel, Some(listener.as_fd()), 0, 0),
                 Err(error) => send_error(channel, &error),
             },
             Err(_) => send_result(channel, None, -1, rustix::io::Errno::INVAL.raw_os_error()),
         },
-        (Some(Op::Listen | Op::Connect), true) | (None, _) => {
+        Some(Op::Listen | Op::Connect | Op::ConnectTcp) | None => {
             send_result(channel, None, -1, rustix::io::Errno::INVAL.raw_os_error())
         }
     }
@@ -185,31 +123,98 @@ pub fn run_helper() -> i32 {
 
 /// Bind/listen a new owner-only UNIX socket path with the current credentials.
 pub fn listen_at_path(path: &Path) -> io::Result<UnixListener> {
-    listen_at_path_with(path, || Ok(()))
+    PendingUnixListener::bind(path).map(PendingUnixListener::into_listener)
 }
 
-fn listen_at_path_with(
-    path: &Path,
-    after_bind: impl FnOnce() -> io::Result<()>,
-) -> io::Result<UnixListener> {
-    if path_too_long(path) {
-        return Err(io::Error::from_raw_os_error(
-            rustix::io::Errno::NAMETOOLONG.raw_os_error(),
-        ));
+struct PendingUnixListener {
+    listener: Option<UnixListener>,
+    cleanup: PendingSocketPath,
+}
+
+impl PendingUnixListener {
+    fn bind(path: &Path) -> io::Result<Self> {
+        if path_too_long(path) {
+            return Err(io::Error::from_raw_os_error(
+                rustix::io::Errno::NAMETOOLONG.raw_os_error(),
+            ));
+        }
+        let listener = UnixListener::bind(path)?;
+        let metadata = fs::symlink_metadata(path)?;
+        let cleanup = PendingSocketPath {
+            path: Some(path.to_path_buf()),
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        };
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+        Ok(Self {
+            listener: Some(listener),
+            cleanup,
+        })
     }
-    let listener = UnixListener::bind(path)?;
-    let mut cleanup = SocketPathCleanup(Some(path.to_path_buf()));
-    after_bind()?;
-    fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
-    cleanup.0 = None;
-    Ok(listener)
+
+    fn into_listener(mut self) -> UnixListener {
+        self.cleanup.path.take();
+        self.listener.take().expect("bound Unix listener")
+    }
+
+    fn send_and_serve(mut self, channel: BorrowedFd<'_>) -> i32 {
+        let status = send_result(
+            channel,
+            Some(self.listener.as_ref().expect("bound Unix listener").as_fd()),
+            0,
+            0,
+        );
+        if status != 0 {
+            return status;
+        }
+        drop(self.listener.take());
+        let mut buffer = [0_u8; 1];
+        loop {
+            match rustix::io::read(channel, &mut buffer) {
+                Ok(0) => return 0,
+                Ok(_) => {}
+                Err(rustix::io::Errno::INTR) => {}
+                Err(_) => return 1,
+            }
+        }
+    }
+
+    fn bind_anchored(path: &Path) -> io::Result<Self> {
+        if path_too_long(path) {
+            return Err(io::Error::from_raw_os_error(
+                rustix::io::Errno::NAMETOOLONG.raw_os_error(),
+            ));
+        }
+        let parent = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty());
+        if let Some(parent) = parent {
+            std::env::set_current_dir(parent)?;
+        }
+        let name = path.file_name().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Unix socket path has no file name",
+            )
+        })?;
+        Self::bind(Path::new(name))
+    }
 }
 
-struct SocketPathCleanup(Option<PathBuf>);
+struct PendingSocketPath {
+    path: Option<PathBuf>,
+    device: u64,
+    inode: u64,
+}
 
-impl Drop for SocketPathCleanup {
+impl Drop for PendingSocketPath {
     fn drop(&mut self) {
-        if let Some(path) = self.0.as_ref() {
+        let Some(path) = self.path.take() else {
+            return;
+        };
+        if fs::symlink_metadata(&path)
+            .is_ok_and(|metadata| metadata.dev() == self.device && metadata.ino() == self.inode)
+        {
             let _ = fs::remove_file(path);
         }
     }
@@ -226,24 +231,69 @@ pub fn connect_at_path(path: &Path) -> io::Result<UnixStream> {
 }
 
 /// Bind/listen as `uid`/`gid`, returning the listening socket.
-pub fn listen_unix_as_user(path: impl AsRef<Path>, uid: u32, gid: u32) -> io::Result<UnixListener> {
-    listen_unix_as_user_deadline(path, uid, gid, Instant::now() + Duration::from_secs(30))
+pub fn listen_unix_as_user(
+    path: impl AsRef<Path>,
+    uid: u32,
+    gid: u32,
+) -> io::Result<UserUnixListener> {
+    listen_unix_as_user_until(path, uid, gid, Instant::now() + HELPER_TIMEOUT)
 }
 
-pub fn listen_unix_as_user_deadline(
+pub(crate) fn listen_unix_as_user_until(
     path: impl AsRef<Path>,
     uid: u32,
     gid: u32,
     deadline: Instant,
-) -> io::Result<UnixListener> {
+) -> io::Result<UserUnixListener> {
     let path = path.as_ref();
-    if path_too_long(path) {
-        return Err(io::Error::from_raw_os_error(
-            rustix::io::Errno::NAMETOOLONG.raw_os_error(),
-        ));
+    run_listener_as_user(path, uid, gid, deadline)
+}
+
+pub struct UserUnixListener {
+    listener: UnixListener,
+    cleanup: Option<UserSocketCleanup>,
+}
+
+impl std::fmt::Debug for UserUnixListener {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("UserUnixListener")
+            .finish_non_exhaustive()
     }
-    ensure_deadline(deadline)?;
-    Ok(listen_unix_as_user_owned_deadline(path, uid, gid, deadline)?.0)
+}
+
+impl std::ops::Deref for UserUnixListener {
+    type Target = UnixListener;
+
+    fn deref(&self) -> &Self::Target {
+        &self.listener
+    }
+}
+
+impl UserUnixListener {
+    pub(crate) fn into_parts(self) -> (UnixListener, Option<UserSocketCleanup>) {
+        (self.listener, self.cleanup)
+    }
+}
+
+pub(crate) struct UserSocketCleanup {
+    channel: Option<UnixStream>,
+    child: Option<std::process::Child>,
+}
+
+impl Drop for UserSocketCleanup {
+    fn drop(&mut self) {
+        drop(self.channel.take());
+        if let Some(mut child) = self.child.take() {
+            match child.wait_timeout(HELPER_TIMEOUT) {
+                Ok(Some(_)) => {}
+                Ok(None) | Err(_) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                }
+            }
+        }
+    }
 }
 
 /// connect() as `uid`/`gid`, returning the connected socket.
@@ -252,46 +302,45 @@ pub fn connect_unix_as_user(path: impl AsRef<Path>, uid: u32, gid: u32) -> io::R
     if already_session_user(uid, gid) {
         return connect_at_path(path);
     }
-    if path_too_long(path) {
-        return Err(io::Error::from_raw_os_error(
-            rustix::io::Errno::NAMETOOLONG.raw_os_error(),
-        ));
-    }
-    Ok(UnixStream::from(
-        run_as_user(Op::Connect, path.as_os_str(), uid, gid)?.fd,
-    ))
+    Ok(UnixStream::from(run_as_user(
+        Op::Connect,
+        path.as_os_str(),
+        uid,
+        gid,
+    )?))
 }
 
 /// Bind one TCP address as `uid`/`gid`, returning the listening socket.
 pub fn listen_tcp_as_user(address: SocketAddr, uid: u32, gid: u32) -> io::Result<TcpListener> {
-    listen_tcp_as_user_deadline(address, uid, gid, Instant::now() + Duration::from_secs(30))
+    listen_tcp_as_user_until(address, uid, gid, Instant::now() + HELPER_TIMEOUT)
 }
 
-/// Bind one TCP address as `uid`/`gid` within the caller's absolute deadline.
+pub(crate) fn connect_tcp_as_user(
+    host: &str,
+    port: u16,
+    uid: u32,
+    gid: u32,
+) -> io::Result<std::net::TcpStream> {
+    if already_session_user(uid, gid) {
+        return crate::forward_endpoint::connect_tcp(host, port);
+    }
+    Ok(std::net::TcpStream::from(run_as_user_until_with_port(
+        Op::ConnectTcp,
+        OsStr::new(host),
+        uid,
+        gid,
+        Instant::now() + HELPER_TIMEOUT,
+        Some(port),
+    )?))
+}
+
 pub fn listen_tcp_as_user_deadline(
     address: SocketAddr,
     uid: u32,
     gid: u32,
     deadline: Instant,
 ) -> io::Result<TcpListener> {
-    ensure_deadline(deadline)?;
-    if already_session_user(uid, gid) {
-        let listener = listen_tcp_at_address(address)?;
-        ensure_deadline(deadline)?;
-        return Ok(listener);
-    }
-    let argument = address.to_string();
-    let helper = helper_exe()?;
-    let received = run_as_user_deadline_argument_with_helper(
-        Op::ListenTcp,
-        OsStr::new(&argument),
-        uid,
-        gid,
-        deadline,
-        &helper,
-    )?;
-    ensure_deadline(deadline)?;
-    Ok(TcpListener::from(received.fd))
+    listen_tcp_as_user_until(address, uid, gid, deadline)
 }
 
 #[doc(hidden)]
@@ -302,18 +351,38 @@ pub fn listen_tcp_as_user_deadline_with_helper(
     deadline: Instant,
     helper: &Path,
 ) -> io::Result<TcpListener> {
-    ensure_deadline(deadline)?;
     let argument = address.to_string();
-    let received = run_as_user_deadline_argument_with_helper(
+    let mut spawned = spawn_helper_with_executable(
+        Op::ListenTcp,
+        OsStr::new(&argument),
+        uid,
+        gid,
+        None,
+        deadline,
+        helper,
+    )?;
+    let result = recv_result_until(spawned.channel(), deadline);
+    spawned.release_spawn_guard();
+    finish_helper(&mut spawned, result, deadline).map(TcpListener::from)
+}
+
+pub(crate) fn listen_tcp_as_user_until(
+    address: SocketAddr,
+    uid: u32,
+    gid: u32,
+    deadline: Instant,
+) -> io::Result<TcpListener> {
+    if already_session_user(uid, gid) {
+        return listen_tcp_at_address(address);
+    }
+    let argument = address.to_string();
+    Ok(TcpListener::from(run_as_user_until(
         Op::ListenTcp,
         OsStr::new(&argument),
         uid,
         gid,
         deadline,
-        helper,
-    )?;
-    ensure_deadline(deadline)?;
-    Ok(TcpListener::from(received.fd))
+    )?))
 }
 
 fn listen_tcp_at_address(address: SocketAddr) -> io::Result<TcpListener> {
@@ -321,423 +390,266 @@ fn listen_tcp_at_address(address: SocketAddr) -> io::Result<TcpListener> {
         .ok_or_else(|| io::Error::from_raw_os_error(rustix::io::Errno::AFNOSUPPORT.raw_os_error()))
 }
 
-pub(crate) fn listen_unix_as_user_owned_deadline(
-    path: &Path,
-    uid: u32,
-    gid: u32,
-    deadline: Instant,
-) -> io::Result<(UnixListener, UnixSocketIdentity)> {
-    ensure_deadline(deadline)?;
-    if already_session_user(uid, gid) {
-        return bind_staged(path, deadline);
-    }
-    let received = run_as_user_deadline(Op::Listen, path, uid, gid, deadline)?;
-    let listener = UnixListener::from(received.fd);
-    let fd_stat = rustix::fs::fstat(&listener)?;
-    if fd_stat.st_dev as u64 != received.identity.fd_device
-        || fd_stat.st_ino as u64 != received.identity.fd_inode
-    {
-        return Err(io::Error::other("received listener identity changed"));
-    }
-    Ok((listener, received.identity))
-}
-
 fn already_session_user(uid: u32, gid: u32) -> bool {
     rustix::process::geteuid().as_raw() == uid && rustix::process::getegid().as_raw() == gid
 }
 
-#[derive(Debug)]
-struct ReceivedSocket {
-    fd: OwnedFd,
-    identity: UnixSocketIdentity,
+fn run_as_user(op: Op, argument: &OsStr, uid: u32, gid: u32) -> io::Result<OwnedFd> {
+    run_as_user_until(op, argument, uid, gid, Instant::now() + HELPER_TIMEOUT)
 }
 
-fn run_as_user(op: Op, argument: &OsStr, uid: u32, gid: u32) -> io::Result<ReceivedSocket> {
-    let helper = helper_exe()?;
-    run_as_user_deadline_argument_with_helper(
-        op,
-        argument,
-        uid,
-        gid,
-        Instant::now() + Duration::from_secs(30),
-        &helper,
-    )
-}
-
-fn run_as_user_deadline(
+fn run_as_user_until(
     op: Op,
+    argument: &OsStr,
+    uid: u32,
+    gid: u32,
+    deadline: Instant,
+) -> io::Result<OwnedFd> {
+    run_as_user_until_with_port(op, argument, uid, gid, deadline, None)
+}
+
+fn run_as_user_until_with_port(
+    op: Op,
+    argument: &OsStr,
+    uid: u32,
+    gid: u32,
+    deadline: Instant,
+    port: Option<u16>,
+) -> io::Result<OwnedFd> {
+    let mut helper = spawn_helper(op, argument, uid, gid, port, deadline)?;
+    let result = recv_result_until(helper.channel(), deadline);
+    helper.release_spawn_guard();
+    finish_helper(&mut helper, result, deadline)
+}
+
+fn run_listener_as_user(
     path: &Path,
     uid: u32,
     gid: u32,
     deadline: Instant,
-) -> io::Result<ReceivedSocket> {
-    if path_too_long(path) {
-        return Err(io::Error::from_raw_os_error(
-            rustix::io::Errno::NAMETOOLONG.raw_os_error(),
-        ));
+) -> io::Result<UserUnixListener> {
+    let mut helper = spawn_helper(Op::Listen, path.as_os_str(), uid, gid, None, deadline)?;
+    let result = recv_result_until(helper.channel(), deadline);
+    helper.release_spawn_guard();
+    match reject_success_after_deadline(result, deadline) {
+        Ok(fd) => {
+            let (channel, child) = helper.take_persistent();
+            Ok(UserUnixListener {
+                listener: UnixListener::from(fd),
+                cleanup: Some(UserSocketCleanup {
+                    channel: Some(channel),
+                    child: Some(child),
+                }),
+            })
+        }
+        Err(error) => Err(error),
     }
+}
+
+trait KillAndWait {
+    fn kill_and_wait(&mut self);
+}
+
+impl KillAndWait for std::process::Child {
+    fn kill_and_wait(&mut self) {
+        let _ = self.kill();
+        let _ = self.wait();
+    }
+}
+
+struct ChildLease<C: KillAndWait> {
+    child: Option<C>,
+}
+
+impl<C: KillAndWait> ChildLease<C> {
+    fn new(child: C) -> Self {
+        Self { child: Some(child) }
+    }
+
+    fn as_mut(&mut self) -> &mut C {
+        self.child.as_mut().expect("live helper child")
+    }
+
+    fn take(&mut self) -> Option<C> {
+        self.child.take()
+    }
+
+    fn reap(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            child.kill_and_wait();
+        }
+    }
+}
+
+impl<C: KillAndWait> Drop for ChildLease<C> {
+    fn drop(&mut self) {
+        self.reap();
+    }
+}
+
+struct SpawnedHelper {
+    channel: Option<UnixStream>,
+    child: ChildLease<std::process::Child>,
+    spawn_guard: Option<HelperSpawnGuard>,
+}
+
+impl SpawnedHelper {
+    fn channel(&self) -> &UnixStream {
+        self.channel.as_ref().expect("live helper channel")
+    }
+
+    fn release_spawn_guard(&mut self) {
+        drop(self.spawn_guard.take());
+    }
+
+    fn take_persistent(&mut self) -> (UnixStream, std::process::Child) {
+        (
+            self.channel.take().expect("live helper channel"),
+            self.child.take().expect("live helper child"),
+        )
+    }
+}
+
+fn spawn_helper(
+    op: Op,
+    argument: &OsStr,
+    uid: u32,
+    gid: u32,
+    port: Option<u16>,
+    deadline: Instant,
+) -> io::Result<SpawnedHelper> {
     let helper = helper_exe()?;
-    run_as_user_deadline_with_helper(op, path, uid, gid, deadline, &helper)
+    spawn_helper_with_executable(op, argument, uid, gid, port, deadline, &helper)
 }
 
-fn run_as_user_deadline_with_helper(
-    op: Op,
-    path: &Path,
-    uid: u32,
-    gid: u32,
-    deadline: Instant,
-    helper: &Path,
-) -> io::Result<ReceivedSocket> {
-    run_as_user_deadline_with_helper_cancelled(
-        op,
-        path,
-        uid,
-        gid,
-        deadline,
-        helper,
-        &AtomicBool::new(false),
-    )
-}
-
-fn run_as_user_deadline_with_helper_cancelled(
-    op: Op,
-    path: &Path,
-    uid: u32,
-    gid: u32,
-    deadline: Instant,
-    helper: &Path,
-    cancelled: &AtomicBool,
-) -> io::Result<ReceivedSocket> {
-    run_as_user_deadline_argument_with_helper_cancelled(
-        op,
-        path.as_os_str(),
-        uid,
-        gid,
-        deadline,
-        helper,
-        cancelled,
-    )
-}
-
-fn run_as_user_deadline_argument_with_helper(
+fn spawn_helper_with_executable(
     op: Op,
     argument: &OsStr,
     uid: u32,
     gid: u32,
+    port: Option<u16>,
     deadline: Instant,
     helper: &Path,
-) -> io::Result<ReceivedSocket> {
-    run_as_user_deadline_argument_with_helper_cancelled(
-        op,
-        argument,
-        uid,
-        gid,
-        deadline,
-        helper,
-        &AtomicBool::new(false),
-    )
-}
-
-fn run_as_user_deadline_argument_with_helper_cancelled(
-    op: Op,
-    argument: &OsStr,
-    uid: u32,
-    gid: u32,
-    deadline: Instant,
-    helper: &Path,
-    cancelled: &AtomicBool,
-) -> io::Result<ReceivedSocket> {
-    let path = Path::new(argument);
+) -> io::Result<SpawnedHelper> {
     let (parent, child) = UnixStream::pair()?;
-    let generation = format!(
-        "{}-{}",
-        std::process::id(),
-        NEXT_GENERATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-    );
-    let generation_path = generation_path(path, &generation);
-    let helper_path = if matches!(op, Op::Listen) {
-        staging_path(path, &generation)
-    } else {
-        path.to_path_buf()
-    };
     let mut command = Command::new(helper);
     command
         .env(OP_ENV, op.as_env())
-        .env(PATH_ENV, &helper_path)
-        .env(PUBLIC_PATH_ENV, path)
+        .env(PATH_ENV, argument)
         .env(UID_ENV, uid.to_string())
-        .env(GID_ENV, gid.to_string())
-        .env(GENERATION_ENV, &generation)
-        .env(GENERATION_PATH_ENV, &generation_path)
+        .env(GID_ENV, gid.to_string());
+    if let Some(port) = port {
+        command.env(PORT_ENV, port.to_string());
+    }
+    command
         .stdin(Stdio::from(OwnedFd::from(child)))
         .stdout(Stdio::null())
         .stderr(Stdio::null());
-    let mut child_proc = command.spawn()?;
-    let result = (|| {
-        let result = recv_result_until(&parent, deadline, cancelled).and_then(|fd| {
-            let stat = rustix::fs::fstat(&fd)?;
-            let identity = if matches!(op, Op::Listen) {
-                let (owner, identity) = read_generation_marker(&generation_path)
-                    .ok_or_else(|| io::Error::other("user-socket helper omitted its generation"))?;
-                if owner != generation
-                    || identity.fd_device != stat.st_dev as u64
-                    || identity.fd_inode != stat.st_ino as u64
-                {
-                    return Err(io::Error::other("user-socket helper identity mismatch"));
-                }
-                identity
-            } else {
-                UnixSocketIdentity {
-                    fd_device: stat.st_dev as u64,
-                    fd_inode: stat.st_ino as u64,
-                    node_device: 0,
-                    node_inode: 0,
-                }
-            };
-            Ok(ReceivedSocket { fd, identity })
-        });
-        if wait_for_helper_exit(&mut child_proc, deadline, cancelled)? {
-            ensure_deadline(deadline)?;
-            result
-        } else {
-            Err(timeout_error())
-        }
-    })();
-    let timed_out = result.as_ref().is_err_and(|error| {
-        matches!(
-            error.kind(),
-            io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
-        )
-    });
-    if timed_out {
-        let _ = child_proc.kill();
-    }
-    let _ = child_proc.wait();
-    if matches!(op, Op::Listen) {
-        let _ = fs::remove_file(&helper_path);
-        if result.is_err() {
-            cleanup_helper_generation(path, &generation_path, &generation);
-        } else {
-            remove_generation_marker(&generation_path, &generation);
-        }
-    }
-    if timed_out {
-        Err(timeout_error())
-    } else {
-        result
-    }
-}
-
-fn recv_result_until(
-    channel: &UnixStream,
-    deadline: Instant,
-    cancelled: &AtomicBool,
-) -> io::Result<OwnedFd> {
-    loop {
-        if cancelled.load(Ordering::Acquire) {
-            return Err(timeout_error());
-        }
-        let remaining = deadline
-            .checked_duration_since(Instant::now())
-            .ok_or_else(timeout_error)?;
-        channel.set_read_timeout(Some(remaining.min(Duration::from_millis(25))))?;
-        match recv_result(channel) {
-            Err(error)
-                if matches!(
-                    error.kind(),
-                    io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
-                ) => {}
-            result => return result,
-        }
-    }
-}
-
-fn wait_for_helper_exit(
-    child: &mut std::process::Child,
-    deadline: Instant,
-    cancelled: &AtomicBool,
-) -> io::Result<bool> {
-    loop {
-        if cancelled.load(Ordering::Acquire) {
-            return Ok(false);
-        }
-        let remaining = deadline
-            .checked_duration_since(Instant::now())
-            .ok_or_else(timeout_error)?;
-        if child
-            .wait_timeout(remaining.min(Duration::from_millis(25)))?
-            .is_some()
-        {
-            return Ok(true);
-        }
-    }
-}
-
-fn staging_path(path: &Path, generation: &str) -> PathBuf {
-    path.parent()
-        .unwrap_or_else(|| Path::new("."))
-        .join(format!(".et-forward-{}-{generation}", std::process::id()))
-}
-
-pub(crate) fn bind_staged(
-    public_path: &Path,
-    deadline: Instant,
-) -> io::Result<(UnixListener, UnixSocketIdentity)> {
-    bind_staged_with_hook(public_path, deadline, || {})
-}
-
-fn bind_staged_with_hook(
-    public_path: &Path,
-    deadline: Instant,
-    before_publish: impl FnOnce(),
-) -> io::Result<(UnixListener, UnixSocketIdentity)> {
-    let generation = format!(
-        "{}-{}",
-        std::process::id(),
-        NEXT_GENERATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-    );
-    let staged = staging_path(public_path, &generation);
-    let listener = listen_at_path(&staged)?;
-    let identity = UnixSocketIdentity::from_fd_and_node(listener.as_fd(), &staged)?;
-    ensure_deadline(deadline)?;
-    let _guard = path_operations()
-        .lock()
-        .map_err(|_| io::Error::other("socket path lock unavailable"))?;
-    ensure_deadline(deadline)?;
-    before_publish();
-    if let Err(error) = publish_noreplace(&staged, public_path) {
-        drop(listener);
-        let _ = fs::remove_file(&staged);
-        return Err(error);
-    }
-    Ok((listener, identity))
-}
-
-fn generation_path(path: &Path, generation: &str) -> PathBuf {
-    let mut value = path.as_os_str().to_owned();
-    value.push(format!(".et-generation-{generation}"));
-    PathBuf::from(value)
-}
-
-fn publish_helper_generation(listener: &UnixListener, staged: &Path) -> io::Result<()> {
-    publish_helper_generation_with_hook(listener, staged, || {})
-}
-
-fn publish_helper_generation_with_hook(
-    listener: &UnixListener,
-    staged: &Path,
-    before_publish: impl FnOnce(),
-) -> io::Result<()> {
-    let generation = std::env::var(GENERATION_ENV)
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "helper generation is missing"))?;
-    let marker = std::env::var_os(GENERATION_PATH_ENV)
-        .map(PathBuf::from)
-        .ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidInput, "helper marker path is missing")
-        })?;
-    let public = std::env::var_os(PUBLIC_PATH_ENV)
-        .map(PathBuf::from)
-        .ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidInput, "public socket path is missing")
-        })?;
-    publish_helper_generation_paths(
-        listener,
-        staged,
-        &public,
-        &marker,
-        &generation,
-        before_publish,
-    )
-}
-
-fn publish_helper_generation_paths(
-    listener: &UnixListener,
-    staged: &Path,
-    public: &Path,
-    marker: &Path,
-    generation: &str,
-    before_publish: impl FnOnce(),
-) -> io::Result<()> {
-    let identity = UnixSocketIdentity::from_fd_and_node(listener.as_fd(), staged)?;
-    fs::write(
-        marker,
-        format!(
-            "{generation} {} {} {} {}\n",
-            identity.fd_device, identity.fd_inode, identity.node_device, identity.node_inode
-        ),
-    )?;
-    before_publish();
-    publish_noreplace(staged, public)
-}
-
-fn publish_noreplace(staged: &Path, public: &Path) -> io::Result<()> {
-    rustix::fs::renameat_with(
-        rustix::fs::CWD,
-        staged,
-        rustix::fs::CWD,
-        public,
-        rustix::fs::RenameFlags::NOREPLACE,
-    )
-    .map_err(|error| {
-        if error == rustix::io::Errno::EXIST {
-            io::Error::new(
-                io::ErrorKind::AddrInUse,
-                "Unix source socket was published by another generation",
-            )
-        } else {
-            io::Error::from(error)
-        }
+    let spawn_guard = helper_spawn_guard(ATOMIC_SCM_RIGHTS_CLOEXEC, deadline)?;
+    let child = command.spawn()?;
+    Ok(SpawnedHelper {
+        channel: Some(parent),
+        child: ChildLease::new(child),
+        spawn_guard,
     })
 }
 
-fn read_generation_marker(path: &Path) -> Option<(String, UnixSocketIdentity)> {
-    let value = fs::read_to_string(path).ok()?;
-    let mut fields = value.split_whitespace();
-    let generation = fields.next()?.to_owned();
-    let fd_device = fields.next()?.parse().ok()?;
-    let fd_inode = fields.next()?.parse().ok()?;
-    let node_device = fields.next()?.parse().ok()?;
-    let node_inode = fields.next()?.parse().ok()?;
-    fields.next().is_none().then_some((
-        generation,
-        UnixSocketIdentity {
-            fd_device,
-            fd_inode,
-            node_device,
-            node_inode,
-        },
-    ))
+struct HelperSpawnLock {
+    held: Mutex<bool>,
+    available: Condvar,
 }
 
-fn cleanup_helper_generation(path: &Path, marker: &Path, generation: &str) {
-    let Some((owner, identity)) = read_generation_marker(marker) else {
-        return;
-    };
-    if owner == generation {
-        remove_socket_if_owned(path, identity);
-        remove_generation_marker(marker, generation);
+impl HelperSpawnLock {
+    fn acquire(&'static self, deadline: Instant) -> io::Result<HelperSpawnGuard> {
+        let mut held = self
+            .held
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        loop {
+            let remaining = remaining_until(deadline)?;
+            if !*held {
+                *held = true;
+                return Ok(HelperSpawnGuard(self));
+            }
+            let (next, _) = self
+                .available
+                .wait_timeout(held, remaining)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            held = next;
+        }
     }
 }
 
-fn remove_generation_marker(marker: &Path, generation: &str) {
-    if read_generation_marker(marker).is_some_and(|(owner, _)| owner == generation) {
-        let _ = fs::remove_file(marker);
+struct HelperSpawnGuard(&'static HelperSpawnLock);
+
+impl Drop for HelperSpawnGuard {
+    fn drop(&mut self) {
+        let mut held = self
+            .0
+            .held
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *held = false;
+        self.0.available.notify_one();
     }
 }
 
-fn timeout_error() -> io::Error {
-    io::Error::new(
-        io::ErrorKind::TimedOut,
-        "user-socket helper deadline elapsed",
-    )
-}
-
-fn ensure_deadline(deadline: Instant) -> io::Result<()> {
-    if Instant::now() >= deadline {
-        Err(timeout_error())
+fn helper_spawn_guard(
+    atomic_cloexec: bool,
+    deadline: Instant,
+) -> io::Result<Option<HelperSpawnGuard>> {
+    remaining_until(deadline)?;
+    if atomic_cloexec {
+        Ok(None)
     } else {
-        Ok(())
+        HELPER_SPAWN_LOCK.acquire(deadline).map(Some)
     }
+}
+
+fn finish_helper(
+    helper: &mut SpawnedHelper,
+    result: io::Result<OwnedFd>,
+    deadline: Instant,
+) -> io::Result<OwnedFd> {
+    let fd = match result {
+        Ok(fd) => fd,
+        Err(error) => {
+            helper.child.reap();
+            return Err(error);
+        }
+    };
+    let remaining = remaining_until(deadline)?;
+    match helper.child.as_mut().wait_timeout(remaining) {
+        Ok(Some(_)) => {
+            helper.child.take();
+            Ok(fd)
+        }
+        Ok(None) | Err(_) => {
+            helper.child.reap();
+            Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "socket helper timed out",
+            ))
+        }
+    }
+}
+
+fn remaining_until_at(deadline: Instant, now: Instant) -> io::Result<Duration> {
+    deadline
+        .checked_duration_since(now)
+        .filter(|remaining| !remaining.is_zero())
+        .ok_or_else(|| io::Error::from(io::ErrorKind::TimedOut))
+}
+
+fn remaining_until(deadline: Instant) -> io::Result<Duration> {
+    remaining_until_at(deadline, Instant::now())
+}
+
+fn reject_success_after_deadline<T>(result: io::Result<T>, deadline: Instant) -> io::Result<T> {
+    if result.is_ok() {
+        remaining_until(deadline)?;
+    }
+    result
 }
 
 fn drop_helper_privileges() -> io::Result<()> {
@@ -749,10 +661,14 @@ fn drop_helper_privileges() -> io::Result<()> {
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or_else(|| rustix::process::getgid().as_raw());
-    if !rustix::process::geteuid().is_root()
-        && (rustix::process::geteuid().as_raw() != uid
-            || rustix::process::getegid().as_raw() != gid)
-    {
+    if !rustix::process::geteuid().is_root() {
+        if rustix::process::geteuid().as_raw() == uid && rustix::process::getegid().as_raw() == gid
+        {
+            // An unprivileged process cannot change its supplementary groups.
+            // It also cannot have inherited groups from a more privileged
+            // daemon identity, so retaining its own groups adds no authority.
+            return Ok(());
+        }
         return Err(io::Error::from_raw_os_error(
             rustix::io::Errno::PERM.raw_os_error(),
         ));
@@ -809,6 +725,13 @@ fn helper_identity_matches(
     let mut observed = identity.groups.clone();
     observed.sort_unstable();
     identity.euid == target.0 && identity.egid == target.1 && observed == expected
+}
+
+fn env_u16(name: &str) -> io::Result<u16> {
+    std::env::var(name)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, format!("missing {name}")))?
+        .parse()
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, format!("invalid {name}")))
 }
 
 fn helper_exe() -> io::Result<PathBuf> {
@@ -882,7 +805,9 @@ fn send_result(channel: BorrowedFd<'_>, fd: Option<BorrowedFd<'_>>, status: i32,
     if status == 0 {
         if let Some(fd) = fd {
             rights = [fd];
-            let _ = control.push(SendAncillaryMessage::ScmRights(&rights));
+            if !control.push(SendAncillaryMessage::ScmRights(&rights)) {
+                return 1;
+            }
         }
     }
     match sendmsg(
@@ -891,20 +816,66 @@ fn send_result(channel: BorrowedFd<'_>, fd: Option<BorrowedFd<'_>>, status: i32,
         &mut control,
         SendFlags::empty(),
     ) {
-        Ok(_) => i32::from(status != 0),
+        Ok(sent) if sent == header.len() => i32::from(status != 0),
+        Ok(_) => 1,
         Err(_) => 1,
     }
 }
 
-fn recv_result(channel: &UnixStream) -> io::Result<OwnedFd> {
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn recv_cloexec_flags() -> RecvFlags {
+    RecvFlags::CMSG_CLOEXEC
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn recv_cloexec_flags() -> RecvFlags {
+    RecvFlags::empty()
+}
+
+fn ensure_cloexec(fd: &OwnedFd) -> io::Result<()> {
+    let flags = rustix::io::fcntl_getfd(fd)?;
+    if !flags.contains(rustix::io::FdFlags::CLOEXEC) {
+        rustix::io::fcntl_setfd(fd, flags | rustix::io::FdFlags::CLOEXEC)?;
+    }
+    Ok(())
+}
+
+fn retry_on_intr_until<T>(
+    deadline: Instant,
+    mut now: impl FnMut() -> Instant,
+    mut before_attempt: impl FnMut(Duration) -> io::Result<()>,
+    mut operation: impl FnMut() -> Result<T, rustix::io::Errno>,
+) -> io::Result<T> {
+    loop {
+        let remaining = remaining_until_at(deadline, now())?;
+        before_attempt(remaining)?;
+        match operation() {
+            Err(rustix::io::Errno::INTR) => {}
+            Err(rustix::io::Errno::AGAIN) if now() >= deadline => {
+                return Err(io::Error::from(io::ErrorKind::TimedOut));
+            }
+            Err(error) => return Err(error.into()),
+            Ok(value) => return Ok(value),
+        }
+    }
+}
+
+fn recv_result_until(channel: &UnixStream, deadline: Instant) -> io::Result<OwnedFd> {
     let mut header = [0u8; 8];
     let mut space = [MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(1))];
     let mut control = RecvAncillaryBuffer::new(&mut space);
-    let received = recvmsg(
-        channel,
-        &mut [IoSliceMut::new(&mut header)],
-        &mut control,
-        RecvFlags::empty(),
+    let received = retry_on_intr_until(
+        deadline,
+        Instant::now,
+        |remaining| channel.set_read_timeout(Some(remaining)),
+        || {
+            recvmsg(
+                channel,
+                &mut [IoSliceMut::new(&mut header)],
+                &mut control,
+                recv_cloexec_flags(),
+            )
+        },
     )?;
     if received.bytes != header.len() {
         return Err(io::Error::other(
@@ -923,6 +894,7 @@ fn recv_result(channel: &UnixStream) -> io::Result<OwnedFd> {
     for message in control.drain() {
         if let RecvAncillaryMessage::ScmRights(mut rights) = message {
             if let Some(fd) = rights.next() {
+                ensure_cloexec(&fd)?;
                 return Ok(fd);
             }
         }
@@ -933,10 +905,11 @@ fn recv_result(channel: &UnixStream) -> io::Result<OwnedFd> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::OpenOptions;
     use std::io::{Read, Write};
-    use std::os::unix::fs::{FileTypeExt, PermissionsExt};
-    use std::sync::atomic::AtomicU64;
+    #[cfg(target_os = "linux")]
+    use std::os::fd::AsRawFd;
+    use std::os::unix::fs::FileTypeExt;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     fn temp_dir() -> PathBuf {
         static NEXT: AtomicU64 = AtomicU64::new(0);
@@ -953,27 +926,6 @@ mod tests {
 
     fn long_unix_path() -> PathBuf {
         PathBuf::from("x".repeat(UNIX_PATH_MAX + 8))
-    }
-
-    fn socket_helper(directory: &Path, behavior: &str) -> PathBuf {
-        let helper = directory.join(format!("helper-{behavior}.py"));
-        let tail = match behavior {
-            "block" => "open(public + '.event', 'wb').write(b'x')\nos.read(0, 1)\n",
-            "short" => "os.write(0, b'x')\n",
-            "missing" => "os.write(0, struct.pack('ii', 0, 0))\n",
-            "error" => "os.write(0, struct.pack('ii', -1, 5))\n",
-            "handoff" => "channel=socket.socket(fileno=0)\nfds=array.array('i', [s.fileno()])\nchannel.sendmsg([struct.pack('ii', 0, 0)], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds)])\nopen(public + '.event', 'wb').write(b'x')\nopen(public + '.release', 'rb').read(1)\n",
-            _ => unreachable!(),
-        };
-        fs::write(
-            &helper,
-            format!(
-                "#!/usr/bin/python3\nimport array, os, socket, struct\npath=os.environ['{PATH_ENV}']\npublic=os.environ['{PUBLIC_PATH_ENV}']\nmarker=os.environ['{GENERATION_PATH_ENV}']\ngeneration=os.environ['{GENERATION_ENV}']\ntry: os.unlink(path)\nexcept FileNotFoundError: pass\ns=socket.socket(socket.AF_UNIX)\ns.bind(path)\nfdst=os.fstat(s.fileno())\nnodest=os.stat(path)\nopen(marker, 'w').write(f'{{generation}} {{fdst.st_dev}} {{fdst.st_ino}} {{nodest.st_dev}} {{nodest.st_ino}}\\n')\nos.link(path, public)\nos.unlink(path)\n{tail}"
-            ),
-        )
-        .unwrap();
-        fs::set_permissions(&helper, fs::Permissions::from_mode(0o700)).unwrap();
-        helper
     }
 
     #[test]
@@ -1009,23 +961,71 @@ mod tests {
     }
 
     #[test]
-    fn listen_failure_after_bind_cleans_socket_and_immediate_retry_succeeds() {
-        // Given
-        let dir = temp_dir();
-        let path = dir.join("post-bind-failure.sock");
+    fn interrupted_descriptor_receive_does_not_extend_deadline() {
+        let start = Instant::now();
+        let deadline = start + Duration::from_secs(1);
+        let mut times = [start, deadline].into_iter();
+        let attempts = std::cell::Cell::new(0);
+        let configured = std::cell::RefCell::new(Vec::new());
+        let result = retry_on_intr_until(
+            deadline,
+            || times.next().expect("one clock read per attempt"),
+            |remaining| {
+                configured.borrow_mut().push(remaining);
+                Ok(())
+            },
+            || {
+                attempts.set(attempts.get() + 1);
+                Err::<(), _>(rustix::io::Errno::INTR)
+            },
+        );
 
-        // When
-        let error = listen_at_path_with(&path, || Err(io::Error::other("injected before chmod")))
-            .unwrap_err();
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::TimedOut);
+        assert_eq!(attempts.get(), 1);
+        assert_eq!(&*configured.borrow(), &[Duration::from_secs(1)]);
+    }
 
-        // Then
-        assert_eq!(error.kind(), io::ErrorKind::Other);
-        assert!(!path.exists());
-        let listener = listen_at_path(&path).unwrap();
-        assert!(path.exists());
-        drop(listener);
-        fs::remove_file(&path).unwrap();
-        fs::remove_dir(&dir).unwrap();
+    #[test]
+    fn fallback_helper_spawn_lock_obeys_deadline() {
+        let first =
+            helper_spawn_guard(false, Instant::now().checked_add(HELPER_TIMEOUT).unwrap()).unwrap();
+        assert!(first.is_some());
+
+        let error = match helper_spawn_guard(false, Instant::now()) {
+            Ok(_) => panic!("contended fallback lock succeeded after deadline"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(helper_spawn_guard(true, Instant::now()).is_err());
+
+        drop(first);
+    }
+
+    #[test]
+    fn late_listener_result_is_rejected() {
+        let error = reject_success_after_deadline(Ok("listener"), Instant::now()).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    }
+
+    #[test]
+    fn child_lease_reaps_on_error_and_transfers_on_success() {
+        struct MockChild(std::rc::Rc<std::cell::Cell<usize>>);
+        impl KillAndWait for MockChild {
+            fn kill_and_wait(&mut self) {
+                self.0.set(self.0.get() + 1);
+            }
+        }
+
+        let reaped = std::rc::Rc::new(std::cell::Cell::new(0));
+        drop(ChildLease::new(MockChild(reaped.clone())));
+        assert_eq!(reaped.get(), 1);
+
+        let mut lease = ChildLease::new(MockChild(reaped.clone()));
+        let child = lease.take().unwrap();
+        drop(lease);
+        assert_eq!(reaped.get(), 1);
+        drop(child);
+        assert_eq!(reaped.get(), 1);
     }
 
     #[test]
@@ -1084,440 +1084,6 @@ mod tests {
     }
 
     #[test]
-    fn helper_no_reply_is_killed_reaped_and_socket_path_rolled_back() {
-        let dir = temp_dir();
-        let path = dir.join("listener.sock");
-        let event = PathBuf::from(format!("{}.event", path.display()));
-        assert!(Command::new("mkfifo")
-            .arg(&event)
-            .status()
-            .unwrap()
-            .success());
-        let event_control = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(&event)
-            .unwrap();
-        let helper = dir.join("helper.sh");
-        fs::write(
-            &helper,
-            "#!/bin/sh\nprintf x > \"${ET_RS_USER_SOCKET_PUBLIC_PATH}.event\"\nexec cat\n",
-        )
-        .unwrap();
-        fs::set_permissions(&helper, fs::Permissions::from_mode(0o700)).unwrap();
-        let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
-        let worker_path = path.clone();
-        std::thread::spawn(move || {
-            let result = run_as_user_deadline_with_helper(
-                Op::Listen,
-                &worker_path,
-                rustix::process::geteuid().as_raw(),
-                rustix::process::getegid().as_raw(),
-                Instant::now() + Duration::from_millis(100),
-                &helper,
-            );
-            let _ = done_tx.send(result);
-        });
-        let (event_tx, event_rx) = std::sync::mpsc::sync_channel(1);
-        std::thread::spawn(move || {
-            let mut event_control = event_control;
-            let mut byte = [0];
-            let result = event_control.read_exact(&mut byte);
-            let _ = event_tx.send(result);
-        });
-        event_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("helper did not enter its no-reply state")
-            .unwrap();
-        let error = done_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("timed-out helper was not killed and reaped")
-            .unwrap_err();
-        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
-        assert!(!path.exists());
-        fs::remove_dir_all(dir).unwrap();
-    }
-
-    #[test]
-    fn stalled_tcp_helper_honors_caller_deadline_and_is_killed_reaped() {
-        let dir = temp_dir();
-        let event = dir.join("tcp-helper.event");
-        assert!(Command::new("mkfifo")
-            .arg(&event)
-            .status()
-            .unwrap()
-            .success());
-        let event_control = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(&event)
-            .unwrap();
-        let pid_path = dir.join("tcp-helper.pid");
-        let helper = dir.join("tcp-helper.py");
-        fs::write(
-            &helper,
-            format!(
-                "#!/usr/bin/python3\nimport os, socket\nhost, port = os.environ['{PATH_ENV}'].rsplit(':', 1)\ns = socket.socket(socket.AF_INET)\ns.bind((host, int(port)))\ns.listen(1)\nopen(r'{}', 'w').write(str(os.getpid()))\nopen(r'{}', 'wb').write(b'x')\nos.read(0, 1)\n",
-                pid_path.display(),
-                event.display()
-            ),
-        )
-        .unwrap();
-        fs::set_permissions(&helper, fs::Permissions::from_mode(0o700)).unwrap();
-        let probe = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
-        let address = probe.local_addr().unwrap();
-        drop(probe);
-        let started = Instant::now();
-        let deadline = started + Duration::from_secs(1);
-        let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
-        std::thread::spawn(move || {
-            let argument = address.to_string();
-            let result = run_as_user_deadline_argument_with_helper(
-                Op::ListenTcp,
-                OsStr::new(&argument),
-                rustix::process::geteuid().as_raw(),
-                rustix::process::getegid().as_raw(),
-                deadline,
-                &helper,
-            );
-            let _ = done_tx.send((Instant::now(), result));
-        });
-        let (event_tx, event_rx) = std::sync::mpsc::sync_channel(1);
-        std::thread::spawn(move || {
-            let mut event_control = event_control;
-            let mut byte = [0];
-            let result = event_control.read_exact(&mut byte);
-            let _ = event_tx.send(result);
-        });
-        event_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("TCP helper did not bind and enter its no-reply state")
-            .unwrap();
-        let (completed, result) = done_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("TCP helper exceeded the caller deadline without being reaped");
-        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::TimedOut);
-        assert!(completed <= deadline + Duration::from_millis(100));
-        let pid = fs::read_to_string(&pid_path)
-            .unwrap()
-            .trim()
-            .parse()
-            .ok()
-            .and_then(rustix::process::Pid::from_raw)
-            .unwrap();
-        assert_eq!(
-            rustix::process::waitpid(Some(pid), rustix::process::WaitOptions::NOHANG).unwrap_err(),
-            rustix::io::Errno::CHILD,
-            "timed-out TCP helper was not killed and reaped"
-        );
-        TcpListener::bind(address).expect("timed-out TCP helper left its listener behind");
-        fs::remove_dir_all(dir).unwrap();
-    }
-
-    #[test]
-    fn older_helper_timeout_does_not_unlink_replacement_generation() {
-        let dir = temp_dir();
-        let path = dir.join("overlap.sock");
-        let event = PathBuf::from(format!("{}.event", path.display()));
-        assert!(Command::new("mkfifo")
-            .arg(&event)
-            .status()
-            .unwrap()
-            .success());
-        let event_control = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(&event)
-            .unwrap();
-        let helper = socket_helper(&dir, "block");
-        enum HelperLifecycle {
-            Published(io::Result<()>),
-            Done(io::Result<ReceivedSocket>),
-        }
-        let (lifecycle_tx, lifecycle_rx) = std::sync::mpsc::sync_channel(2);
-        let cancelled = std::sync::Arc::new(AtomicBool::new(false));
-        let worker_cancelled = cancelled.clone();
-        let worker_tx = lifecycle_tx.clone();
-        let old_path = path.clone();
-        std::thread::spawn(move || {
-            let result = run_as_user_deadline_with_helper_cancelled(
-                Op::Listen,
-                &old_path,
-                rustix::process::geteuid().as_raw(),
-                rustix::process::getegid().as_raw(),
-                Instant::now() + Duration::from_secs(30),
-                &helper,
-                &worker_cancelled,
-            );
-            let _ = worker_tx.send(HelperLifecycle::Done(result));
-        });
-        std::thread::spawn(move || {
-            let mut event_control = event_control;
-            let mut byte = [0];
-            let result = event_control.read_exact(&mut byte);
-            let _ = lifecycle_tx.send(HelperLifecycle::Published(result));
-        });
-        match lifecycle_rx.recv_timeout(Duration::from_secs(5)) {
-            Ok(HelperLifecycle::Published(Ok(()))) => {}
-            Ok(HelperLifecycle::Published(Err(error))) => {
-                panic!("helper publication event failed: {error}")
-            }
-            Ok(HelperLifecycle::Done(Ok(_))) => {
-                panic!("helper returned a listener before entering no-reply")
-            }
-            Ok(HelperLifecycle::Done(Err(error))) => {
-                panic!("helper failed before publishing its generation: {error}")
-            }
-            Err(error) => panic!("helper lifecycle produced no event: {error}"),
-        }
-        assert!(fs::metadata(&path).unwrap().file_type().is_socket());
-        let marker = fs::read_dir(&dir)
-            .unwrap()
-            .filter_map(Result::ok)
-            .map(|entry| entry.path())
-            .find(|candidate| candidate.to_string_lossy().contains(".et-generation-"))
-            .expect("published helper generation has no ownership marker");
-        let (_, identity) = read_generation_marker(&marker)
-            .expect("published helper generation marker is malformed");
-        assert!(identity.node_matches(&path));
-
-        fs::remove_file(&path).unwrap();
-        let replacement = listen_at_path(&path).unwrap();
-        cancelled.store(true, Ordering::Release);
-        let error = match lifecycle_rx.recv_timeout(Duration::from_secs(5)) {
-            Ok(HelperLifecycle::Done(result)) => result.unwrap_err(),
-            Ok(HelperLifecycle::Published(_)) => panic!("duplicate helper publication event"),
-            Err(error) => panic!("cancelled helper was not killed and reaped: {error}"),
-        };
-        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
-        let client = UnixStream::connect(&path)
-            .expect("older helper timeout unlinked replacement generation");
-        replacement.accept().unwrap();
-        drop(client);
-        drop(replacement);
-        let _ = fs::remove_file(&path);
-        fs::remove_dir_all(dir).unwrap();
-    }
-
-    #[test]
-    fn successful_handoff_does_not_adopt_replacement_before_helper_exit() {
-        let dir = temp_dir();
-        let path = dir.join("handoff.sock");
-        for suffix in ["event", "release"] {
-            assert!(Command::new("mkfifo")
-                .arg(format!("{}.{}", path.display(), suffix))
-                .status()
-                .unwrap()
-                .success());
-        }
-        let event = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(format!("{}.event", path.display()))
-            .unwrap();
-        let mut release = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(format!("{}.release", path.display()))
-            .unwrap();
-        let helper = socket_helper(&dir, "handoff");
-        let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
-        let worker_path = path.clone();
-        std::thread::spawn(move || {
-            let result = run_as_user_deadline_with_helper(
-                Op::Listen,
-                &worker_path,
-                rustix::process::geteuid().as_raw(),
-                rustix::process::getegid().as_raw(),
-                Instant::now() + Duration::from_secs(2),
-                &helper,
-            );
-            let _ = done_tx.send(result);
-        });
-        let (event_tx, event_rx) = std::sync::mpsc::sync_channel(1);
-        std::thread::spawn(move || {
-            let mut event = event;
-            let mut byte = [0];
-            let _ = event_tx.send(event.read_exact(&mut byte));
-        });
-        event_rx
-            .recv_timeout(Duration::from_secs(1))
-            .unwrap()
-            .unwrap();
-        fs::remove_file(&path).unwrap();
-        let replacement = listen_at_path(&path).unwrap();
-        release.write_all(b"x").unwrap();
-        let received = done_rx
-            .recv_timeout(Duration::from_secs(1))
-            .unwrap()
-            .unwrap();
-        assert!(!received.identity.node_matches(&path));
-        remove_socket_if_owned(&path, received.identity);
-        drop(received);
-        let client = UnixStream::connect(&path)
-            .expect("successful older handoff adopted replacement identity");
-        replacement.accept().unwrap();
-        drop(client);
-        drop(replacement);
-        let _ = fs::remove_file(&path);
-        fs::remove_dir_all(dir).unwrap();
-    }
-
-    #[test]
-    fn premarker_short_reply_leaves_no_public_or_staged_socket() {
-        let dir = temp_dir();
-        let path = dir.join("premarker.sock");
-        let helper = dir.join("premarker.py");
-        fs::write(
-            &helper,
-            format!(
-                "#!/usr/bin/python3\nimport os,socket\np=os.environ['{PATH_ENV}']\ns=socket.socket(socket.AF_UNIX)\ns.bind(p)\nos.write(0,b'x')\n"
-            ),
-        )
-        .unwrap();
-        fs::set_permissions(&helper, fs::Permissions::from_mode(0o700)).unwrap();
-        assert!(run_as_user_deadline_with_helper(
-            Op::Listen,
-            &path,
-            rustix::process::geteuid().as_raw(),
-            rustix::process::getegid().as_raw(),
-            Instant::now() + Duration::from_secs(1),
-            &helper,
-        )
-        .is_err());
-        assert!(!path.exists());
-        assert!(fs::read_dir(&dir).unwrap().all(|entry| {
-            !entry
-                .unwrap()
-                .file_name()
-                .to_string_lossy()
-                .starts_with(".et-forward-")
-        }));
-        fs::remove_dir_all(dir).unwrap();
-    }
-
-    #[test]
-    fn missing_fd_and_explicit_helper_error_remove_owned_generation() {
-        for behavior in ["missing", "error"] {
-            let dir = temp_dir();
-            let path = dir.join(format!("{behavior}.sock"));
-            let helper = socket_helper(&dir, behavior);
-            assert!(run_as_user_deadline_with_helper(
-                Op::Listen,
-                &path,
-                rustix::process::geteuid().as_raw(),
-                rustix::process::getegid().as_raw(),
-                Instant::now() + Duration::from_secs(1),
-                &helper,
-            )
-            .is_err());
-            assert!(!path.exists(), "{behavior} left the public socket");
-            fs::remove_dir_all(dir).unwrap();
-        }
-    }
-
-    #[test]
-    fn malformed_helper_reply_reaps_helper_and_removes_owned_stale_path() {
-        let dir = temp_dir();
-        let path = dir.join("malformed.sock");
-        let helper = socket_helper(&dir, "short");
-        let error = run_as_user_deadline_with_helper(
-            Op::Listen,
-            &path,
-            rustix::process::geteuid().as_raw(),
-            rustix::process::getegid().as_raw(),
-            Instant::now() + Duration::from_secs(1),
-            &helper,
-        )
-        .unwrap_err();
-        assert_ne!(error.kind(), io::ErrorKind::TimedOut);
-        assert!(!path.exists(), "malformed helper left a stale socket path");
-        assert!(
-            fs::read_dir(&dir).unwrap().all(|entry| !entry
-                .unwrap()
-                .file_name()
-                .to_string_lossy()
-                .contains("et-generation")),
-            "malformed helper left a generation marker"
-        );
-        fs::remove_dir_all(dir).unwrap();
-    }
-
-    #[test]
-    fn replacement_published_after_retirement_is_never_unlinked() {
-        let dir = temp_dir();
-        let path = dir.join("retire-race.sock");
-        let (old, identity) = bind_staged(&path, Instant::now() + Duration::from_secs(1)).unwrap();
-        fs::remove_file(&path).unwrap();
-        let displaced = UnixListener::bind(&path).unwrap();
-        let mut newest = None;
-        remove_socket_if_owned_with_hook(&path, identity, || {
-            newest = Some(UnixListener::bind(&path).unwrap());
-        });
-        let client = UnixStream::connect(&path)
-            .expect("retirement cleanup unlinked newly published generation");
-        newest.as_ref().unwrap().accept().unwrap();
-        drop(client);
-        drop(old);
-        drop(displaced);
-        drop(newest);
-        fs::remove_dir_all(dir).unwrap();
-    }
-
-    #[test]
-    fn helper_publication_loses_atomically_to_final_window_replacement() {
-        let dir = temp_dir();
-        let public = dir.join("helper-race.sock");
-        let staged = dir.join("helper-race.staged");
-        let marker = dir.join("helper-race.marker");
-        let generation = "test-generation";
-        let listener = listen_at_path(&staged).unwrap();
-        let mut replacement = None;
-        let error = publish_helper_generation_paths(
-            &listener,
-            &staged,
-            &public,
-            &marker,
-            generation,
-            || replacement = Some(listen_at_path(&public).unwrap()),
-        )
-        .unwrap_err();
-        assert_eq!(error.kind(), io::ErrorKind::AddrInUse);
-        drop(listener);
-        let _ = fs::remove_file(&staged);
-        cleanup_helper_generation(&public, &marker, generation);
-        assert!(!staged.exists());
-        assert!(!marker.exists());
-        let client = UnixStream::connect(&public).unwrap();
-        replacement.as_ref().unwrap().accept().unwrap();
-        drop(client);
-        drop(replacement);
-        fs::remove_file(public).unwrap();
-        fs::remove_dir_all(dir).unwrap();
-    }
-
-    #[test]
-    fn direct_bind_replacement_during_identity_capture_is_preserved() {
-        let dir = temp_dir();
-        let path = dir.join("direct-race.sock");
-        let mut replacement = None;
-        let error =
-            match bind_staged_with_hook(&path, Instant::now() + Duration::from_secs(1), || {
-                replacement = Some(UnixListener::bind(&path).unwrap())
-            }) {
-                Ok(_) => panic!("older direct bind overwrote replacement generation"),
-                Err(error) => error,
-            };
-        assert_eq!(error.kind(), io::ErrorKind::AddrInUse);
-        let client = UnixStream::connect(&path).unwrap();
-        replacement.as_ref().unwrap().accept().unwrap();
-        drop(client);
-        drop(replacement);
-        fs::remove_file(path).unwrap();
-        fs::remove_dir_all(dir).unwrap();
-    }
-
-    #[test]
     fn listen_unix_as_user_rejects_oversized_path() {
         let uid = rustix::process::getuid().as_raw();
         let gid = rustix::process::getgid().as_raw();
@@ -1572,6 +1138,148 @@ mod tests {
         let _ = fs::remove_dir(&dir);
     }
 
+    #[test]
+    fn failed_listener_descriptor_transfer_removes_socket_path() {
+        let dir = temp_dir();
+        let path = dir.join("sock");
+        let listener = PendingUnixListener::bind(&path).unwrap();
+        let (channel, peer) = UnixStream::pair().unwrap();
+        drop(peer);
+
+        assert_eq!(listener.send_and_serve(channel.as_fd()), 1);
+        assert!(!path.exists());
+
+        fs::remove_dir(dir).unwrap();
+    }
+
+    #[test]
+    fn listener_cleanup_is_anchored_to_the_bound_parent() {
+        if helper_exe().is_err() {
+            eprintln!("skipping helper-dependent test: et-user-socket-helper is unavailable");
+            return;
+        }
+        let base = temp_dir();
+        let live = base.join("live");
+        let parked = base.join("parked");
+        let target = base.join("target");
+        fs::create_dir(&live).unwrap();
+        fs::create_dir(&target).unwrap();
+        let socket = live.join("victim");
+        let uid = rustix::process::geteuid().as_raw();
+        let gid = rustix::process::getegid().as_raw();
+        let listener =
+            run_listener_as_user(&socket, uid, gid, Instant::now() + HELPER_TIMEOUT).unwrap();
+
+        fs::rename(&live, &parked).unwrap();
+        let sentinel = target.join("victim");
+        fs::write(&sentinel, b"keep").unwrap();
+        std::os::unix::fs::symlink(&target, &live).unwrap();
+        drop(listener);
+
+        assert_eq!(fs::read(&sentinel).unwrap(), b"keep");
+        assert!(!parked.join("victim").exists());
+        fs::remove_file(&live).unwrap();
+        fs::remove_file(&sentinel).unwrap();
+        fs::remove_dir(&target).unwrap();
+        fs::remove_dir(&parked).unwrap();
+        fs::remove_dir(&base).unwrap();
+    }
+
+    #[test]
+    fn older_helper_cleanup_preserves_replacement_generation() {
+        if helper_exe().is_err() {
+            eprintln!("skipping helper-dependent test: et-user-socket-helper is unavailable");
+            return;
+        }
+        let dir = temp_dir();
+        let path = dir.join("generation.sock");
+        let uid = rustix::process::geteuid().as_raw();
+        let gid = rustix::process::getegid().as_raw();
+        let old = run_listener_as_user(&path, uid, gid, Instant::now() + HELPER_TIMEOUT).unwrap();
+
+        fs::remove_file(&path).unwrap();
+        let replacement = UnixListener::bind(&path).unwrap();
+        drop(old);
+
+        let client = UnixStream::connect(&path)
+            .expect("older helper cleanup unlinked the replacement generation");
+        replacement.accept().unwrap();
+        drop(client);
+        drop(replacement);
+        fs::remove_file(&path).unwrap();
+        fs::remove_dir(dir).unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn descriptor_received_from_helper_is_not_inherited_by_next_helper() {
+        let dir = temp_dir();
+        let uid = rustix::process::geteuid().as_raw();
+        let gid = rustix::process::getegid().as_raw();
+        let first = run_listener_as_user(
+            &dir.join("first"),
+            uid,
+            gid,
+            Instant::now() + HELPER_TIMEOUT,
+        )
+        .unwrap();
+        let received_socket =
+            fs::read_link(format!("/proc/self/fd/{}", first.listener.as_raw_fd(),)).unwrap();
+
+        let second = run_listener_as_user(
+            &dir.join("second"),
+            uid,
+            gid,
+            Instant::now() + HELPER_TIMEOUT,
+        )
+        .unwrap();
+        let second_helper = second
+            .cleanup
+            .as_ref()
+            .and_then(|cleanup| cleanup.child.as_ref())
+            .expect("persistent listener helper");
+        let inherited = fs::read_dir(format!("/proc/{}/fd", second_helper.id()))
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter_map(|entry| fs::read_link(entry.path()).ok())
+            .any(|target| target == received_socket);
+
+        assert!(
+            !inherited,
+            "subsequent helper inherited received fd {received_socket:?}"
+        );
+        drop(second);
+        drop(first);
+        fs::remove_dir(dir).unwrap();
+    }
+
+    #[test]
+    fn tcp_destination_connect_runs_through_the_session_helper() {
+        if helper_exe().is_err() {
+            eprintln!("skipping helper-dependent test: et-user-socket-helper is unavailable");
+            return;
+        }
+        let listener = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let uid = rustix::process::geteuid().as_raw();
+        let gid = rustix::process::getegid().as_raw();
+        let fd = run_as_user_until_with_port(
+            Op::ConnectTcp,
+            OsStr::new("127.0.0.1"),
+            uid,
+            gid,
+            Instant::now() + HELPER_TIMEOUT,
+            Some(port),
+        )
+        .unwrap();
+        let mut client = std::net::TcpStream::from(fd);
+        let (mut server, _) = listener.accept().unwrap();
+        client.write_all(b"session-user").unwrap();
+        let mut payload = [0_u8; 12];
+        server.read_exact(&mut payload).unwrap();
+        assert_eq!(&payload, b"session-user");
+    }
+
     fn unprivileged_drop_user() -> Option<(u32, u32)> {
         if rustix::process::getuid().as_raw() != 0 {
             return None;
@@ -1599,6 +1307,20 @@ mod tests {
             return Some((uid, gid));
         }
         None
+    }
+
+    #[test]
+    fn helper_command_clears_privileged_supplementary_groups() {
+        let Some((uid, gid)) = unprivileged_drop_user() else {
+            eprintln!("skipping helper group-drop test: not root or no nobody user");
+            return;
+        };
+        let identity = HelperIdentity {
+            euid: uid,
+            egid: gid,
+            groups: vec![gid],
+        };
+        assert!(helper_identity_matches((uid, gid), &[gid], &identity));
     }
 
     /// ANT-2026-AVTT7HQH: privilege-dropped listen cannot unlink a root-owned

--- a/crates/et-server/src/lib.rs
+++ b/crates/et-server/src/lib.rs
@@ -26,7 +26,9 @@ mod socket_path_windows;
 mod terminal_bridge;
 
 pub use registry::{Registration, RegistrationError, Registry};
-pub use router::{Router, RouterError, RouterEvent, RouterReject};
+pub use router::{
+    Router, RouterError, RouterEvent, RouterReject, MAX_PENDING_REGISTRATIONS, REGISTRATION_TIMEOUT,
+};
 pub use runtime::Runtime;
 pub use runtime_error::RuntimeError;
 pub use runtime_handle::{HandleError, RuntimeHandle};

--- a/crates/et-server/src/registry.rs
+++ b/crates/et-server/src/registry.rs
@@ -43,11 +43,20 @@ pub(crate) struct RegistrationIdentity {
 pub(crate) struct RegisteredTerminal {
     pub(crate) identity: RegistrationIdentity,
     pub(crate) watcher: LocalStream,
+    pub(crate) startup_ack: bool,
 }
 
 struct StoredRegistration {
     info: Registration,
     stream: LocalStream,
+    startup: StartupState,
+}
+
+#[derive(Clone)]
+enum StartupState {
+    Legacy,
+    Pending,
+    Complete(Result<(), String>),
 }
 
 #[derive(Default)]
@@ -119,14 +128,78 @@ impl Registry {
         let mut state = self.lock()?;
         match state.registrations.entry(registration.id.clone()) {
             Entry::Vacant(entry) => {
+                let startup_ack = registration.startup_ack;
+                let startup = if startup_ack {
+                    StartupState::Pending
+                } else {
+                    StartupState::Legacy
+                };
                 entry.insert(StoredRegistration {
                     info: registration,
                     stream,
+                    startup,
                 });
                 self.inner.changed.notify_all();
-                Ok(RegisteredTerminal { identity, watcher })
+                Ok(RegisteredTerminal {
+                    identity,
+                    watcher,
+                    startup_ack,
+                })
             }
             Entry::Occupied(_) => Err(RegistrationError::Duplicate),
+        }
+    }
+
+    pub(crate) fn report_startup(
+        &self,
+        identity: &RegistrationIdentity,
+        result: Result<(), String>,
+    ) -> Result<(), RegistrationError> {
+        let mut state = self.lock()?;
+        let stored = state
+            .registrations
+            .get_mut(identity.id())
+            .filter(|stored| identity.matches(&stored.info))
+            .ok_or(RegistrationError::Unavailable)?;
+        if !matches!(stored.startup, StartupState::Pending) {
+            return Err(RegistrationError::Invalid);
+        }
+        stored.startup = StartupState::Complete(result);
+        self.inner.changed.notify_all();
+        Ok(())
+    }
+
+    pub(crate) fn wait_for_startup(
+        &self,
+        registration: &Registration,
+        deadline: Instant,
+    ) -> Result<(), RegistrationError> {
+        let mut state = self.lock()?;
+        loop {
+            let stored = state
+                .registrations
+                .get(&registration.id)
+                .filter(|stored| stored.info.same_generation(registration))
+                .ok_or(RegistrationError::Unavailable)?;
+            match &stored.startup {
+                StartupState::Legacy | StartupState::Complete(Ok(())) => return Ok(()),
+                StartupState::Complete(Err(message)) => {
+                    return Err(RegistrationError::Io(io::Error::other(message.clone())))
+                }
+                StartupState::Pending => {}
+            }
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .ok_or(RegistrationError::Timeout)?;
+            let (next, wait) = self
+                .inner
+                .changed
+                .wait_timeout(state, remaining)
+                .map_err(|_| RegistrationError::Unavailable)?;
+            state = next;
+            if wait.timed_out() {
+                return Err(RegistrationError::Timeout);
+            }
         }
     }
 

--- a/crates/et-server/src/registry.rs
+++ b/crates/et-server/src/registry.rs
@@ -18,6 +18,7 @@ pub struct Registration {
     pub key: [u8; KEY_LEN],
     pub uid: u32,
     pub gid: u32,
+    pub(crate) startup_ack: bool,
     pub(crate) identity: Arc<()>,
 }
 
@@ -27,6 +28,7 @@ impl PartialEq for Registration {
             && self.key == other.key
             && self.uid == other.uid
             && self.gid == other.gid
+            && self.startup_ack == other.startup_ack
     }
 }
 

--- a/crates/et-server/src/registry_validation.rs
+++ b/crates/et-server/src/registry_validation.rs
@@ -84,11 +84,13 @@ pub(crate) fn validate(
         #[cfg(windows)]
         PeerIdentity::AuthenticatedWindowsToken => {}
     }
+    let startup_ack = user_info.fd == Some(-6);
     Ok(Registration {
         id,
         key,
         uid,
         gid,
+        startup_ack,
         identity: Arc::new(()),
     })
 }

--- a/crates/et-server/src/router.rs
+++ b/crates/et-server/src/router.rs
@@ -1,10 +1,13 @@
 use et_net::local::LocalStream;
 use std::io::{self, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
+
+pub const MAX_PENDING_REGISTRATIONS: usize = 64;
+pub const REGISTRATION_TIMEOUT: Duration = Duration::from_secs(5);
 
 use crate::path::{PathError, RouterPath};
 use crate::registry::Registry;
@@ -31,6 +34,9 @@ pub enum RouterReject {
     InvalidRegistration,
     Duplicate,
     RegistryUnavailable,
+    IdentityMismatch,
+    Capacity,
+    Timeout,
 }
 
 #[derive(Debug)]
@@ -83,14 +89,16 @@ impl Router {
     pub(crate) fn start_with_lifecycle(
         path: RouterPath,
         registry: Registry,
-        lifecycle: Option<Sender<LifecycleEvent>>,
+        lifecycle: Option<std::sync::mpsc::Sender<LifecycleEvent>>,
     ) -> Result<Self, RouterError> {
         let listener = OwnedRouterListener::bind(&path)?;
         let (wake_reader, wake_writer) = et_net::local::wake_pair().map_err(RouterError::Io)?;
         wake_reader.set_nonblocking(true).map_err(RouterError::Io)?;
         let shutdown = Arc::new(AtomicBool::new(false));
         let worker_shutdown = shutdown.clone();
-        let (event_sender, events) = mpsc::channel();
+        // Runtime does not consume diagnostic events; keep test/diagnostic
+        // observability without allowing malformed peers to grow memory.
+        let (event_sender, events) = mpsc::sync_channel(1024);
         let worker = thread::Builder::new()
             .name("et-router".to_owned())
             .spawn(move || {

--- a/crates/et-server/src/router_loop.rs
+++ b/crates/et-server/src/router_loop.rs
@@ -412,18 +412,13 @@ fn disconnect_watched(
 fn accept_ready(
     listener: &OwnedRouterListener,
     pending: &mut Vec<PendingConnection>,
-    events: &SyncSender<RouterEvent>,
+    _events: &SyncSender<RouterEvent>,
 ) -> Result<(), RouterError> {
-    loop {
+    while pending.len() < MAX_PENDING_REGISTRATIONS {
         match listener.accept() {
             Ok((stream, _)) => {
                 let peer = PeerIdentity::from_stream(&stream).map_err(RouterError::Io)?;
                 stream.set_nonblocking(true).map_err(RouterError::Io)?;
-                if pending.len() >= MAX_PENDING_REGISTRATIONS {
-                    emit_capacity();
-                    emit(events, RouterEvent::Rejected(RouterReject::Capacity));
-                    continue;
-                }
                 pending.push(PendingConnection {
                     stream,
                     decoder: LocalPacketDecoder::new(),
@@ -444,6 +439,7 @@ fn accept_ready(
             Err(error) => return Err(RouterError::Io(error)),
         }
     }
+    Ok(())
 }
 
 fn read_ready(connection: &mut PendingConnection) -> Result<ReadOutcome, RouterError> {
@@ -539,17 +535,6 @@ fn expire_pending(pending: &mut Vec<PendingConnection>, events: &SyncSender<Rout
 
 fn emit(events: &SyncSender<RouterEvent>, event: RouterEvent) {
     let _ = events.try_send(event);
-}
-
-fn emit_capacity() {
-    static LAST: std::sync::Mutex<Option<Instant>> = std::sync::Mutex::new(None);
-    if let Ok(mut last) = LAST.lock() {
-        let now = Instant::now();
-        if last.is_none_or(|previous| now.duration_since(previous) >= Duration::from_secs(1)) {
-            crate::diag::info("router registration capacity exhausted");
-            *last = Some(now);
-        }
-    }
 }
 
 fn emit_resource_error(error: &io::Error) {

--- a/crates/et-server/src/router_loop.rs
+++ b/crates/et-server/src/router_loop.rs
@@ -1,12 +1,15 @@
 use et_net::local::LocalStream;
 use std::io::{self, Read};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::{Sender, SyncSender};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use et_core::packet::Packet;
-use et_net::local_packet::LocalPacketDecoder;
+use et_net::local_packet::{
+    parse_status, status_packet, write_local_packet, LocalPacketDecoder, REGISTRATION_STATUS,
+    STARTUP_STATUS,
+};
 #[cfg(unix)]
 use rustix::event::{poll, PollFd, PollFlags};
 #[cfg(unix)]
@@ -14,7 +17,9 @@ use rustix::net::{recv, RecvFlags};
 
 use crate::registry::{RegistrationIdentity, Registry};
 use crate::registry_validation::PeerIdentity;
-use crate::router::{RouterError, RouterEvent, RouterReject};
+use crate::router::{
+    RouterError, RouterEvent, RouterReject, MAX_PENDING_REGISTRATIONS, REGISTRATION_TIMEOUT,
+};
 use crate::router_registration;
 use crate::runtime_lifecycle::LifecycleEvent;
 #[cfg(unix)]
@@ -25,13 +30,18 @@ use crate::socket_path_windows::OwnedRouterListener;
 struct PendingConnection {
     stream: LocalStream,
     decoder: LocalPacketDecoder,
+    accepted: Instant,
     peer: PeerIdentity,
-    deadline: Instant,
+    #[cfg(windows)]
+    token: Vec<u8>,
+    #[cfg(windows)]
+    expected_token: String,
 }
 
 struct WatchedRegistration {
     stream: LocalStream,
     identity: RegistrationIdentity,
+    startup: Option<LocalPacketDecoder>,
 }
 
 enum ReadOutcome {
@@ -40,15 +50,11 @@ enum ReadOutcome {
     Reject,
 }
 
-const MAX_PENDING_REGISTRATIONS: usize = 64;
-const REGISTRATION_TIMEOUT: Duration = Duration::from_secs(5);
-const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(100);
-
 pub(crate) fn run(
     listener: OwnedRouterListener,
     wake_reader: LocalStream,
     registry: Registry,
-    events: Sender<RouterEvent>,
+    events: SyncSender<RouterEvent>,
     lifecycle: Option<Sender<LifecycleEvent>>,
     shutdown: Arc<AtomicBool>,
 ) -> Result<(), RouterError> {
@@ -63,31 +69,22 @@ fn run_poll(
     listener: OwnedRouterListener,
     mut wake_reader: LocalStream,
     registry: Registry,
-    events: Sender<RouterEvent>,
+    events: SyncSender<RouterEvent>,
     lifecycle: Option<Sender<LifecycleEvent>>,
     shutdown: Arc<AtomicBool>,
 ) -> Result<(), RouterError> {
     let mut pending = Vec::<PendingConnection>::new();
     let mut watched = Vec::<WatchedRegistration>::new();
-    let mut accept_retry_at = None;
     let idle = rustix::time::Timespec::try_from(std::time::Duration::from_millis(100))
         .expect("100ms fits in timespec");
     loop {
-        let now = Instant::now();
-        pending.retain(|connection| connection.deadline > now);
-        let can_accept = pending.len() < MAX_PENDING_REGISTRATIONS
-            && accept_retry_at.is_none_or(|retry_at| now >= retry_at);
+        // Expire before constructing poll descriptors so readiness indices and
+        // the pending vector always describe the same generation.
+        expire_pending(&mut pending, &events);
         let pending_start = 2;
         let watched_start = pending_start + pending.len();
         let mut poll_fds = Vec::with_capacity(watched_start + watched.len());
-        poll_fds.push(PollFd::new(
-            listener.listener(),
-            if can_accept {
-                PollFlags::IN
-            } else {
-                PollFlags::empty()
-            },
-        ));
+        poll_fds.push(PollFd::new(listener.listener(), PollFlags::IN));
         poll_fds.push(PollFd::new(&wake_reader, PollFlags::IN));
         for connection in &pending {
             poll_fds.push(PollFd::new(
@@ -96,10 +93,11 @@ fn run_poll(
             ));
         }
         for registration in &watched {
-            poll_fds.push(PollFd::new(
-                &registration.stream,
-                PollFlags::HUP | PollFlags::ERR,
-            ));
+            let mut flags = PollFlags::HUP | PollFlags::ERR;
+            if registration.startup.is_some() {
+                flags |= PollFlags::IN;
+            }
+            poll_fds.push(PollFd::new(&registration.stream, flags));
         }
         match poll(&mut poll_fds, Some(&idle)) {
             Ok(_) => {}
@@ -132,7 +130,7 @@ fn run_poll(
                 Err(_) => *flags |= PollFlags::ERR,
             }
         }
-        disconnect_ready(
+        service_watched(
             &watched_readiness,
             &mut watched,
             &registry,
@@ -143,8 +141,7 @@ fn run_poll(
             .first()
             .is_some_and(|flags| flags.contains(PollFlags::IN))
         {
-            accept_retry_at = accept_ready(&listener, &mut pending, MAX_PENDING_REGISTRATIONS)?
-                .then(|| Instant::now() + ACCEPT_RETRY_DELAY);
+            accept_ready(&listener, &mut pending, &events)?;
         }
         let ready_pending: Vec<usize> = readiness[pending_start..watched_start]
             .iter()
@@ -161,6 +158,7 @@ fn run_poll(
                 ReadOutcome::Pending => {}
                 ReadOutcome::Packet(packet) => {
                     let connection = pending.swap_remove(index);
+                    let mut status = connection.stream.try_clone().map_err(RouterError::Io)?;
                     match router_registration::process(
                         packet,
                         connection.stream,
@@ -168,6 +166,16 @@ fn run_poll(
                         connection.peer,
                     ) {
                         Ok(terminal) => {
+                            if terminal.startup_ack
+                                && write_local_packet(
+                                    &mut status,
+                                    &status_packet(REGISTRATION_STATUS, Ok(())),
+                                )
+                                .is_err()
+                            {
+                                rollback_registration(&registry, &terminal.identity, &events)?;
+                                continue;
+                            }
                             let id = terminal.identity.id().to_owned();
                             terminal
                                 .watcher
@@ -176,17 +184,23 @@ fn run_poll(
                             watched.push(WatchedRegistration {
                                 stream: terminal.watcher,
                                 identity: terminal.identity,
+                                startup: terminal.startup_ack.then(LocalPacketDecoder::new),
                             });
-                            let _ = events.send(RouterEvent::Registered { id });
+                            emit(&events, RouterEvent::Registered { id });
                         }
                         Err(error) => {
-                            let _ = events.send(RouterEvent::Rejected(error));
+                            let message = format!("registration rejected: {error:?}");
+                            let _ = write_local_packet(
+                                &mut status,
+                                &status_packet(REGISTRATION_STATUS, Err(&message)),
+                            );
+                            emit(&events, RouterEvent::Rejected(error));
                         }
                     }
                 }
                 ReadOutcome::Reject => {
                     pending.swap_remove(index);
-                    let _ = events.send(RouterEvent::Rejected(RouterReject::MalformedFrame));
+                    emit(&events, RouterEvent::Rejected(RouterReject::MalformedFrame));
                 }
             }
         }
@@ -204,64 +218,72 @@ fn run_windows(
     listener: OwnedRouterListener,
     mut wake_reader: LocalStream,
     registry: Registry,
-    events: Sender<RouterEvent>,
+    events: SyncSender<RouterEvent>,
     lifecycle: Option<Sender<LifecycleEvent>>,
     shutdown: Arc<AtomicBool>,
 ) -> Result<(), RouterError> {
     const IDLE: std::time::Duration = std::time::Duration::from_millis(10);
     let mut pending = Vec::<PendingConnection>::new();
     let mut watched = Vec::<WatchedRegistration>::new();
-    let mut accept_retry_at = None;
     loop {
         if shutdown.load(Ordering::Acquire) {
             drain_waker(&mut wake_reader)?;
             return Ok(());
         }
         let mut progress = false;
-        let now = Instant::now();
-        let before_expiry = pending.len();
-        pending.retain(|connection| connection.deadline > now);
-        progress |= pending.len() != before_expiry;
 
         // Terminals that closed their connection release their registration.
         // The watcher shares the session socket, so this must never consume
         // bytes: `peek` reports EOF without stealing session data.
-        let mut disconnected = Vec::new();
-        for (index, registration) in watched.iter().enumerate() {
-            let mut probe = [0u8; 1];
-            match registration.stream.peek(&mut probe) {
-                Ok(0) => disconnected.push(index),
-                Ok(_) => {}
-                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
-                Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
-                Err(_) => disconnected.push(index),
-            }
-        }
-        for index in disconnected.into_iter().rev() {
-            progress = true;
-            let registration = watched.swap_remove(index);
-            if registry
-                .remove_if_current(&registration.identity)
-                .map_err(|error| RouterError::Io(io::Error::other(error)))?
-            {
-                let id = registration.identity.id().to_owned();
-                let _ = events.send(RouterEvent::Disconnected { id });
-                if let Some(sender) = lifecycle.as_ref() {
-                    let _ =
-                        sender.send(LifecycleEvent::TerminalDisconnected(registration.identity));
+        for index in (0..watched.len()).rev() {
+            if watched[index].startup.is_some() {
+                let outcome = {
+                    let registration = &mut watched[index];
+                    read_decoder(
+                        &mut registration.stream,
+                        registration.startup.as_mut().expect("startup checked"),
+                    )?
+                };
+                match outcome {
+                    ReadOutcome::Packet(packet) => {
+                        progress = true;
+                        let result = parse_status(&packet, STARTUP_STATUS)
+                            .map_err(|error| error.to_string());
+                        registry
+                            .report_startup(&watched[index].identity, result)
+                            .map_err(|error| RouterError::Io(io::Error::other(error)))?;
+                        watched[index].startup = None;
+                    }
+                    ReadOutcome::Reject => {
+                        progress = true;
+                        let _ = registry.report_startup(
+                            &watched[index].identity,
+                            Err("malformed terminal startup status".to_owned()),
+                        );
+                        watched[index].startup = None;
+                    }
+                    ReadOutcome::Pending => {}
                 }
+            }
+            let mut probe = [0u8; 1];
+            let disconnected = match watched[index].stream.peek(&mut probe) {
+                Ok(0) => true,
+                Ok(_) => false,
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => false,
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => false,
+                Err(_) => true,
+            };
+            if disconnected {
+                progress = true;
+                disconnect_watched(index, &mut watched, &registry, &events, lifecycle.as_ref())?;
             }
         }
 
-        if pending.len() < MAX_PENDING_REGISTRATIONS
-            && accept_retry_at.is_none_or(|retry_at| now >= retry_at)
-        {
-            let before = pending.len();
-            accept_retry_at = accept_ready(&listener, &mut pending, MAX_PENDING_REGISTRATIONS)?
-                .then(|| Instant::now() + ACCEPT_RETRY_DELAY);
-            if pending.len() != before {
-                progress = true;
-            }
+        expire_pending(&mut pending, &events);
+        let before = pending.len();
+        accept_ready(&listener, &mut pending, &events)?;
+        if pending.len() != before {
+            progress = true;
         }
 
         for index in (0..pending.len()).rev() {
@@ -270,6 +292,7 @@ fn run_windows(
                 ReadOutcome::Packet(packet) => {
                     progress = true;
                     let connection = pending.swap_remove(index);
+                    let mut status = connection.stream.try_clone().map_err(RouterError::Io)?;
                     match router_registration::process(
                         packet,
                         connection.stream,
@@ -277,22 +300,38 @@ fn run_windows(
                         connection.peer,
                     ) {
                         Ok(terminal) => {
+                            if terminal.startup_ack
+                                && write_local_packet(
+                                    &mut status,
+                                    &status_packet(REGISTRATION_STATUS, Ok(())),
+                                )
+                                .is_err()
+                            {
+                                rollback_registration(&registry, &terminal.identity, &events)?;
+                                continue;
+                            }
                             let id = terminal.identity.id().to_owned();
                             watched.push(WatchedRegistration {
                                 stream: terminal.watcher,
                                 identity: terminal.identity,
+                                startup: terminal.startup_ack.then(LocalPacketDecoder::new),
                             });
-                            let _ = events.send(RouterEvent::Registered { id });
+                            emit(&events, RouterEvent::Registered { id });
                         }
                         Err(error) => {
-                            let _ = events.send(RouterEvent::Rejected(error));
+                            let message = format!("registration rejected: {error:?}");
+                            let _ = write_local_packet(
+                                &mut status,
+                                &status_packet(REGISTRATION_STATUS, Err(&message)),
+                            );
+                            emit(&events, RouterEvent::Rejected(error));
                         }
                     }
                 }
                 ReadOutcome::Reject => {
                     progress = true;
                     pending.swap_remove(index);
-                    let _ = events.send(RouterEvent::Rejected(RouterReject::MalformedFrame));
+                    emit(&events, RouterEvent::Rejected(RouterReject::MalformedFrame));
                 }
             }
         }
@@ -304,34 +343,67 @@ fn run_windows(
 }
 
 #[cfg(unix)]
-fn disconnect_ready(
+fn service_watched(
     readiness: &[PollFlags],
     watched: &mut Vec<WatchedRegistration>,
     registry: &Registry,
-    events: &Sender<RouterEvent>,
+    events: &SyncSender<RouterEvent>,
     lifecycle: Option<&Sender<LifecycleEvent>>,
 ) -> Result<(), RouterError> {
-    let ready: Vec<usize> = readiness
-        .iter()
-        .enumerate()
-        .filter_map(|(index, flags)| {
-            flags
-                .intersects(PollFlags::HUP | PollFlags::ERR)
-                .then_some(index)
-        })
-        .rev()
-        .collect();
-    for index in ready {
-        let registration = watched.swap_remove(index);
-        if registry
-            .remove_if_current(&registration.identity)
-            .map_err(|error| RouterError::Io(io::Error::other(error)))?
-        {
-            let id = registration.identity.id().to_owned();
-            let _ = events.send(RouterEvent::Disconnected { id });
-            if let Some(sender) = lifecycle {
-                let _ = sender.send(LifecycleEvent::TerminalDisconnected(registration.identity));
+    for index in (0..watched.len()).rev() {
+        let flags = readiness.get(index).copied().unwrap_or(PollFlags::empty());
+        if flags.contains(PollFlags::IN) && watched[index].startup.is_some() {
+            match read_startup(&mut watched[index])? {
+                ReadOutcome::Packet(packet) => {
+                    let result =
+                        parse_status(&packet, STARTUP_STATUS).map_err(|error| error.to_string());
+                    registry
+                        .report_startup(&watched[index].identity, result)
+                        .map_err(|error| RouterError::Io(io::Error::other(error)))?;
+                    watched[index].startup = None;
+                }
+                ReadOutcome::Reject => {
+                    let _ = registry.report_startup(
+                        &watched[index].identity,
+                        Err("malformed terminal startup status".to_owned()),
+                    );
+                    watched[index].startup = None;
+                }
+                ReadOutcome::Pending => {}
             }
+        }
+        if flags.intersects(PollFlags::HUP | PollFlags::ERR) {
+            disconnect_watched(index, watched, registry, events, lifecycle)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn read_startup(registration: &mut WatchedRegistration) -> Result<ReadOutcome, RouterError> {
+    let decoder = registration
+        .startup
+        .as_mut()
+        .expect("startup decoder checked by caller");
+    read_decoder(&mut registration.stream, decoder)
+}
+
+fn disconnect_watched(
+    index: usize,
+    watched: &mut Vec<WatchedRegistration>,
+    registry: &Registry,
+    events: &SyncSender<RouterEvent>,
+    lifecycle: Option<&Sender<LifecycleEvent>>,
+) -> Result<(), RouterError> {
+    let registration = watched.swap_remove(index);
+    if registry
+        .remove_if_current(&registration.identity)
+        .map_err(|error| RouterError::Io(io::Error::other(error)))?
+    {
+        let id = registration.identity.id().to_owned();
+        emit(events, RouterEvent::Disconnected { id });
+        if let Some(sender) = lifecycle {
+            let _ = sender.send(LifecycleEvent::TerminalDisconnected(registration.identity));
         }
     }
     Ok(())
@@ -340,60 +412,90 @@ fn disconnect_ready(
 fn accept_ready(
     listener: &OwnedRouterListener,
     pending: &mut Vec<PendingConnection>,
-    max_pending: usize,
-) -> Result<bool, RouterError> {
-    while pending.len() < max_pending {
+    events: &SyncSender<RouterEvent>,
+) -> Result<(), RouterError> {
+    loop {
         match listener.accept() {
             Ok((stream, _)) => {
                 let peer = PeerIdentity::from_stream(&stream).map_err(RouterError::Io)?;
                 stream.set_nonblocking(true).map_err(RouterError::Io)?;
+                if pending.len() >= MAX_PENDING_REGISTRATIONS {
+                    emit_capacity();
+                    emit(events, RouterEvent::Rejected(RouterReject::Capacity));
+                    continue;
+                }
                 pending.push(PendingConnection {
                     stream,
                     decoder: LocalPacketDecoder::new(),
+                    accepted: Instant::now(),
                     peer,
-                    deadline: Instant::now() + REGISTRATION_TIMEOUT,
+                    #[cfg(windows)]
+                    token: Vec::with_capacity(et_net::local::TOKEN_LEN + 1),
+                    #[cfg(windows)]
+                    expected_token: listener.token().to_owned(),
                 });
             }
-            Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(false),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(()),
             Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
-            Err(error) if accept_resource_exhausted(&error) => return Ok(true),
+            Err(error) if matches!(error.raw_os_error(), Some(23 | 24)) => {
+                emit_resource_error(&error);
+                return Ok(());
+            }
             Err(error) => return Err(RouterError::Io(error)),
         }
     }
-    Ok(false)
-}
-
-#[cfg(unix)]
-fn accept_resource_exhausted(error: &io::Error) -> bool {
-    matches!(
-        error.raw_os_error(),
-        Some(code)
-            if code == rustix::io::Errno::MFILE.raw_os_error()
-                || code == rustix::io::Errno::NFILE.raw_os_error()
-    )
-}
-
-#[cfg(windows)]
-fn accept_resource_exhausted(error: &io::Error) -> bool {
-    error.kind() == io::ErrorKind::OutOfMemory
 }
 
 fn read_ready(connection: &mut PendingConnection) -> Result<ReadOutcome, RouterError> {
+    #[cfg(windows)]
+    if connection.token.last() != Some(&b'\n') {
+        loop {
+            let mut byte = [0u8; 1];
+            match connection.stream.read(&mut byte) {
+                Ok(0) => return Ok(ReadOutcome::Reject),
+                Ok(_) => {
+                    connection.token.push(byte[0]);
+                    if connection.token.len() > et_net::local::TOKEN_LEN + 1 {
+                        return Ok(ReadOutcome::Reject);
+                    }
+                    if byte[0] == b'\n' {
+                        let supplied = &connection.token[..connection.token.len() - 1];
+                        if supplied != connection.expected_token.as_bytes() {
+                            return Ok(ReadOutcome::Reject);
+                        }
+                        break;
+                    }
+                }
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    return Ok(ReadOutcome::Pending)
+                }
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+                Err(_) => return Ok(ReadOutcome::Reject),
+            }
+        }
+    }
+    read_decoder(&mut connection.stream, &mut connection.decoder)
+}
+
+fn read_decoder(
+    stream: &mut LocalStream,
+    decoder: &mut LocalPacketDecoder,
+) -> Result<ReadOutcome, RouterError> {
     loop {
-        let needed = connection.decoder.required_bytes().min(8192);
+        let needed = decoder.required_bytes().min(8192);
         if needed == 0 {
             return Ok(ReadOutcome::Reject);
         }
         let mut buffer = [0u8; 8192];
-        match connection.stream.read(&mut buffer[..needed]) {
+        match stream.read(&mut buffer[..needed]) {
             Ok(0) => {
-                let decoder = std::mem::take(&mut connection.decoder);
+                let decoder = std::mem::take(decoder);
                 return Ok(match decoder.finish() {
                     Ok(()) => ReadOutcome::Pending,
                     Err(_) => ReadOutcome::Reject,
                 });
             }
-            Ok(count) => match connection.decoder.feed(&buffer[..count]) {
+            Ok(count) => match decoder.feed(&buffer[..count]) {
                 Ok(Some(packet)) => return Ok(ReadOutcome::Packet(packet)),
                 Ok(None) => {}
                 Err(_) => return Ok(ReadOutcome::Reject),
@@ -403,6 +505,60 @@ fn read_ready(connection: &mut PendingConnection) -> Result<ReadOutcome, RouterE
             }
             Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
             Err(_) => return Ok(ReadOutcome::Reject),
+        }
+    }
+}
+
+fn rollback_registration(
+    registry: &Registry,
+    identity: &RegistrationIdentity,
+    events: &SyncSender<RouterEvent>,
+) -> Result<(), RouterError> {
+    registry
+        .remove_if_current(identity)
+        .map_err(|error| RouterError::Io(io::Error::other(error)))?;
+    emit(
+        events,
+        RouterEvent::Rejected(RouterReject::RegistryUnavailable),
+    );
+    Ok(())
+}
+
+fn expire_pending(pending: &mut Vec<PendingConnection>, events: &SyncSender<RouterEvent>) {
+    let now = Instant::now();
+    let mut expired = 0;
+    pending.retain(|connection| {
+        let keep = now.duration_since(connection.accepted) < REGISTRATION_TIMEOUT;
+        expired += usize::from(!keep);
+        keep
+    });
+    for _ in 0..expired {
+        emit(events, RouterEvent::Rejected(RouterReject::Timeout));
+    }
+}
+
+fn emit(events: &SyncSender<RouterEvent>, event: RouterEvent) {
+    let _ = events.try_send(event);
+}
+
+fn emit_capacity() {
+    static LAST: std::sync::Mutex<Option<Instant>> = std::sync::Mutex::new(None);
+    if let Ok(mut last) = LAST.lock() {
+        let now = Instant::now();
+        if last.is_none_or(|previous| now.duration_since(previous) >= Duration::from_secs(1)) {
+            crate::diag::info("router registration capacity exhausted");
+            *last = Some(now);
+        }
+    }
+}
+
+fn emit_resource_error(error: &io::Error) {
+    static LAST: std::sync::Mutex<Option<Instant>> = std::sync::Mutex::new(None);
+    if let Ok(mut last) = LAST.lock() {
+        let now = Instant::now();
+        if last.is_none_or(|previous| now.duration_since(previous) >= Duration::from_secs(1)) {
+            crate::diag::info(format!("router accept resource exhaustion: {error}"));
+            *last = Some(now);
         }
     }
 }
@@ -420,17 +576,66 @@ fn drain_waker(wake_reader: &mut LocalStream) -> Result<(), RouterError> {
     }
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
-    use super::accept_resource_exhausted;
+    use super::*;
 
+    #[cfg(unix)]
     #[test]
-    fn descriptor_exhaustion_is_transient() {
-        for errno in [rustix::io::Errno::MFILE, rustix::io::Errno::NFILE] {
-            assert!(accept_resource_exhausted(&std::io::Error::from(errno)));
+    fn expired_hung_up_pending_is_removed_before_readiness_is_indexed() {
+        let (stream, peer) = std::os::unix::net::UnixStream::pair().unwrap();
+        stream.set_nonblocking(true).unwrap();
+        drop(peer);
+        let mut pending = vec![PendingConnection {
+            stream,
+            decoder: LocalPacketDecoder::new(),
+            accepted: Instant::now() - REGISTRATION_TIMEOUT,
+            peer: PeerIdentity::Unix {
+                uid: rustix::process::getuid().as_raw(),
+                gid: rustix::process::getgid().as_raw(),
+            },
+        }];
+        let (events, receiver) = std::sync::mpsc::sync_channel(1);
+        expire_pending(&mut pending, &events);
+        assert!(pending.is_empty());
+        assert_eq!(
+            receiver.recv_timeout(Duration::from_secs(1)).unwrap(),
+            RouterEvent::Rejected(RouterReject::Timeout)
+        );
+        // Poll descriptors are constructed only after this point, so no stale
+        // readiness index can address the removed connection.
+        assert_eq!(pending.len(), 0);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn stalled_startup_socket_remains_nonblocking_while_other_work_progresses() {
+        use std::net::{Ipv4Addr, TcpListener, TcpStream};
+
+        fn pair() -> (TcpStream, TcpStream) {
+            let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+            let address = listener.local_addr().unwrap();
+            let connector = std::thread::spawn(move || TcpStream::connect(address).unwrap());
+            let (server, _) = listener.accept().unwrap();
+            (server, connector.join().unwrap())
         }
-        assert!(!accept_resource_exhausted(&std::io::Error::from(
-            rustix::io::Errno::INVAL,
-        )));
+
+        let (mut stalled, _stalled_peer) = pair();
+        stalled.set_nonblocking(true).unwrap();
+        let mut stalled_decoder = LocalPacketDecoder::new();
+        assert!(matches!(
+            read_decoder(&mut stalled, &mut stalled_decoder).unwrap(),
+            ReadOutcome::Pending
+        ));
+
+        let (mut ready, mut ready_peer) = pair();
+        ready.set_nonblocking(true).unwrap();
+        let packet = et_core::packet::Packet::new(STARTUP_STATUS, vec![0]);
+        write_local_packet(&mut ready_peer, &packet).unwrap();
+        let mut ready_decoder = LocalPacketDecoder::new();
+        assert!(matches!(
+            read_decoder(&mut ready, &mut ready_decoder).unwrap(),
+            ReadOutcome::Packet(_)
+        ));
     }
 }

--- a/crates/et-server/src/runtime.rs
+++ b/crates/et-server/src/runtime.rs
@@ -38,6 +38,21 @@ impl Runtime {
         port: u16,
         router_path: RouterPath,
     ) -> Result<Self, RuntimeError> {
+        Self::start_with_forward_resolver(
+            bind_ip,
+            port,
+            router_path,
+            Arc::new(et_net::forward::SystemForwardResolver),
+        )
+    }
+
+    #[doc(hidden)]
+    pub fn start_with_forward_resolver(
+        bind_ip: IpAddr,
+        port: u16,
+        router_path: RouterPath,
+        forward_resolver: Arc<dyn et_net::forward::ForwardResolver>,
+    ) -> Result<Self, RuntimeError> {
         let bound = bind_tcp(bind_ip, port)?;
         let mut tcp_addresses = Vec::new();
         for listener in bound.iter() {
@@ -54,6 +69,7 @@ impl Runtime {
             handlers: HandlerThreads::new(),
             pre_auth_slots: Arc::new(PreAuthSlots::new(MAX_PRE_AUTH_CONNECTIONS)),
             shutdown: AtomicBool::new(false),
+            forward_resolver,
         });
         let router_name = router_path.path().to_path_buf();
         let (lifecycle_sender, lifecycle_events) = mpsc::channel();

--- a/crates/et-server/src/runtime.rs
+++ b/crates/et-server/src/runtime.rs
@@ -233,11 +233,12 @@ fn remember(first: &mut Option<RuntimeError>, error: RuntimeError) {
 #[cfg(test)]
 mod tests {
     use std::fs;
-    use std::io::Read;
+    use std::io::{self, Read};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::mpsc;
     use std::time::Duration;
 
     use et_core::packet::Packet;
@@ -278,6 +279,43 @@ mod tests {
         fn drop(&mut self) {
             let _ = fs::remove_dir_all(&self.0);
         }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore = "Miri does not support networking")]
+    fn disconnect_between_registration_lookup_and_raw_assignment_closes_handler() {
+        let directory = TestDirectory::new();
+        let router_path =
+            select_router_path_for(1000, Some(&directory.socket()), None, None).unwrap();
+        let mut runtime = Runtime::start(IpAddr::V4(Ipv4Addr::LOCALHOST), 0, router_path).unwrap();
+        let handle = runtime.handle();
+        let address = runtime.tcp_addresses()[0];
+        let terminal = register(&directory.socket(), &handle);
+        let (assignment_tx, assignment_rx) = mpsc::sync_channel(1);
+        let (release_tx, release_rx) = mpsc::sync_channel(1);
+        let (scan_tx, scan_rx) = mpsc::sync_channel(1);
+        crate::runtime_handler::install_raw_assignment_hook(ID, assignment_tx, release_rx);
+        crate::runtime_lifecycle::install_raw_scan_hook(ID, scan_tx);
+
+        let mut client = connect_request(address);
+        assignment_rx
+            .recv_timeout(TIMEOUT)
+            .expect("handler did not reach the post-lookup assignment barrier");
+        drop(terminal);
+        scan_rx
+            .recv_timeout(TIMEOUT)
+            .expect("terminal lifecycle did not complete its raw-socket scan");
+        release_tx.send(()).unwrap();
+        assert_prompt_closed(&mut client);
+
+        let (shutdown_tx, shutdown_rx) = mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            let _ = shutdown_tx.send(runtime.shutdown());
+        });
+        shutdown_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("raced handler and pre-auth permit were not released promptly")
+            .unwrap();
     }
 
     #[test]
@@ -356,5 +394,30 @@ mod tests {
     fn assert_closed(stream: &mut TcpStream) {
         let mut byte = [0; 1];
         assert_eq!(stream.read(&mut byte).unwrap_or(0), 0);
+    }
+
+    fn assert_prompt_closed(stream: &mut TcpStream) {
+        stream
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let mut byte = [0; 1];
+        match stream.read(&mut byte) {
+            Ok(0) => {}
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::ConnectionReset | io::ErrorKind::ConnectionAborted
+                ) => {}
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+                ) =>
+            {
+                panic!("raced initialization socket remained open: {error}")
+            }
+            Ok(read) => panic!("raced initialization socket produced {read} bytes before close"),
+            Err(error) => panic!("raced initialization socket close failed: {error}"),
+        }
     }
 }

--- a/crates/et-server/src/runtime.rs
+++ b/crates/et-server/src/runtime.rs
@@ -233,7 +233,6 @@ mod tests {
 
     use super::Runtime;
     use crate::path::select_router_path_for;
-    use crate::session_table::SessionState;
 
     const ID: &str = "aaaaaaaaaaaaaaaa";
     const KEY: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef";
@@ -278,23 +277,15 @@ mod tests {
 
         let (mut client_a, response) = handshake(address);
         assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
-        handle
-            .wait_for_state(ID, SessionState::Starting, TIMEOUT)
-            .unwrap();
+        assert_eq!(handle.session_state(ID).unwrap(), None);
 
-        let mut client_b = connect_request(address);
-        runtime
-            .core
-            .sessions
-            .wait_for_claim_waiters(ID, 1, TIMEOUT)
-            .unwrap();
+        // A newer unauthenticated connection displaces the old one without
+        // creating a Starting slot or a waiter.
+        let (mut client_b, response) = handshake(address);
+        assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+        assert_closed(&mut client_a);
 
         drop(terminal);
-        runtime
-            .core
-            .sessions
-            .wait_for_claim_waiters(ID, 0, TIMEOUT)
-            .unwrap();
         handle.wait_disconnected(ID, TIMEOUT).unwrap();
         assert_closed(&mut client_a);
         assert_closed(&mut client_b);

--- a/crates/et-server/src/runtime_accept.rs
+++ b/crates/et-server/src/runtime_accept.rs
@@ -96,12 +96,26 @@ fn accept_ready(listener: &TcpListener, core: &Arc<RuntimeCore>) -> Result<(), R
                     .name("et-session-handler".to_owned())
                     .spawn(move || {
                         runtime_handler::handle(stream, worker_core, guard, pre_auth_guard)
-                    })
-                    .map_err(RuntimeError::Spawn)?;
-                core.handlers.push(worker)?;
+                    });
+                match worker {
+                    Ok(worker) => core.handlers.push(worker)?,
+                    Err(error) => {
+                        // The closure is dropped here, releasing its socket and
+                        // admission permit. Keep the listener supervised and
+                        // observable rather than silently killing acceptance.
+                        crate::diag::info(format!("could not start session handler: {error}"));
+                        std::thread::sleep(std::time::Duration::from_millis(100));
+                        return Ok(());
+                    }
+                }
             }
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(()),
             Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(source) if matches!(source.raw_os_error(), Some(23 | 24)) => {
+                crate::diag::info(format!("TCP accept resource exhaustion: {source}"));
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                return Ok(());
+            }
             Err(source) => {
                 return Err(RuntimeError::Io {
                     operation: "accept TCP connection",

--- a/crates/et-server/src/runtime_handle.rs
+++ b/crates/et-server/src/runtime_handle.rs
@@ -51,6 +51,24 @@ impl RuntimeHandle {
             .map_err(HandleError::Session)
     }
 
+    #[doc(hidden)]
+    pub fn wait_for_bridge_generation(
+        &self,
+        id: &str,
+        generation: u64,
+        timeout: Duration,
+    ) -> Result<(), HandleError> {
+        let session = self
+            .core
+            .sessions
+            .active(id)
+            .map_err(HandleError::SessionTable)?
+            .ok_or_else(|| HandleError::NotActive(id.to_owned()))?;
+        session
+            .wait_for_bridge_generation(generation, timeout)
+            .map_err(HandleError::Session)
+    }
+
     pub fn session_state(&self, id: &str) -> Result<Option<SessionState>, HandleError> {
         self.core
             .sessions

--- a/crates/et-server/src/runtime_handler.rs
+++ b/crates/et-server/src/runtime_handler.rs
@@ -18,7 +18,6 @@ use crate::runtime_state::{PreAuthGuard, RawSocketGuard, RuntimeCore};
 use crate::session::ActiveSession;
 use crate::session_table::SessionClaim;
 
-const LEGACY_UNTRUSTED_ORIGIN_MARKER: &str = "ET_RS_SSH_CONFIG_REMOTE_FORWARD";
 // The client caps an individual initialization read at ten seconds. The server
 // owns one shorter absolute budget so authenticated failures arrive first.
 const INITIALIZATION_TIMEOUT: Duration = Duration::from_secs(8);
@@ -318,23 +317,17 @@ fn handle_new(
         );
         return;
     }
-    if payload.reversetunnels.len() > et_net::reverse_report::MAX_REVERSE_ROWS {
-        send_initial_error(&mut connection, "too many reverse forwarding rows");
+    if payload.reversetunnels.len() > et_net::forward::MAX_SESSION_LISTENERS {
+        send_initial_error(&mut connection, "reverse listener limit exceeded");
         return;
     }
     let owner = {
         let registration = start.registration();
         (registration.uid, registration.gid)
     };
-    let mut reverse_tunnels = payload.reversetunnels.clone();
-    for request in &mut reverse_tunnels {
-        if request.environmentvariable.as_deref() == Some(LEGACY_UNTRUSTED_ORIGIN_MARKER) {
-            request.environmentvariable = None;
-        }
-    }
-    let (forwarder, forward_environment, skipped) =
-        match et_net::forward::Forwarder::start_with_user_report_deadline(
-            reverse_tunnels,
+    let (forwarder, forward_environment) =
+        match et_net::forward::Forwarder::start_with_user_deadline(
+            payload.reversetunnels.clone(),
             Some(owner),
             initialization_deadline - INITIALIZATION_RESPONSE_MARGIN,
             core.forward_resolver.clone(),
@@ -356,30 +349,6 @@ fn handle_new(
                 return;
             }
         };
-    let response_error = if skipped.is_empty() {
-        None
-    } else {
-        let mut rows: Vec<_> = skipped
-            .iter()
-            .filter_map(|skipped| {
-                skipped
-                    .report_index
-                    .map(|index| et_net::reverse_report::SkippedRow {
-                        index,
-                        reason: skipped.reason,
-                    })
-            })
-            .collect();
-        rows.sort_unstable_by_key(|row| row.index);
-        match et_net::reverse_report::encode_skipped_rows(&rows) {
-            Ok(report) => Some(report),
-            Err(_) => {
-                drop(forwarder);
-                send_initial_error(&mut connection, "too many skipped reverse forwarding rows");
-                return;
-            }
-        }
-    };
     if Instant::now() >= initialization_deadline {
         send_initial_error(
             &mut connection,
@@ -436,14 +405,10 @@ fn handle_new(
         );
         return;
     }
-    let requires_ack = response_error.is_some();
     if connection
         .write_packet_strict(
             EtPacketType::InitialResponse as u8,
-            &InitialResponse {
-                error: response_error,
-            }
-            .encode_to_vec(),
+            &InitialResponse { error: None }.encode_to_vec(),
         )
         .is_err()
     {
@@ -451,17 +416,6 @@ fn handle_new(
             "id={id}: failed writing INITIAL_RESPONSE to {peer}"
         ));
         return;
-    }
-    if requires_ack {
-        if connection.set_io_timeout(Some(HANDSHAKE_TIMEOUT)).is_err() {
-            return;
-        }
-        let acknowledged = connection.read_packet().is_ok_and(|packet| {
-            packet.header() == EtPacketType::Heartbeat as u8 && packet.payload().is_empty()
-        });
-        if !acknowledged || connection.set_io_timeout(None).is_err() {
-            return;
-        }
     }
     let active = match ActiveSession::new(connection, &terminal) {
         Ok(active) => active,

--- a/crates/et-server/src/runtime_handler.rs
+++ b/crates/et-server/src/runtime_handler.rs
@@ -1,5 +1,7 @@
 use std::net::TcpStream;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use et_core::proto::{
     ConnectResponse, ConnectStatus, EtPacketType, InitialPayload, InitialResponse, TermInit,
@@ -9,14 +11,18 @@ use et_net::connection::Connection;
 use et_net::handshake::{
     protocol_matches, read_request_deadline, write_response, HANDSHAKE_TIMEOUT,
 };
-use et_net::local_packet::write_local_packet;
+use et_net::local_packet::{write_local_packet, write_local_packet_cancelled};
 use prost::Message;
 
 use crate::runtime_state::{PreAuthGuard, RawSocketGuard, RuntimeCore};
 use crate::session::ActiveSession;
 use crate::session_table::SessionClaim;
 
-const JUMPHOST_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+const LEGACY_UNTRUSTED_ORIGIN_MARKER: &str = "ET_RS_SSH_CONFIG_REMOTE_FORWARD";
+// The client caps an individual initialization read at ten seconds. The server
+// owns one shorter absolute budget so authenticated failures arrive first.
+const INITIALIZATION_TIMEOUT: Duration = Duration::from_secs(8);
+const INITIALIZATION_RESPONSE_MARGIN: Duration = Duration::from_millis(500);
 
 pub(crate) fn handle(
     stream: TcpStream,
@@ -30,22 +36,22 @@ pub(crate) fn handle(
         .unwrap_or_else(|_| "unknown".to_owned());
     crate::diag::verbose(1, format!("accepted TCP connection from {peer}"));
     let mut stream = stream;
-    let request =
-        match read_request_deadline(&mut stream, std::time::Instant::now() + HANDSHAKE_TIMEOUT) {
-            Ok(request) => request,
-            Err(error) => {
-                crate::diag::verbose(1, format!("malformed ConnectRequest from {peer}: {error}"));
-                reject(
-                    &mut stream,
-                    ConnectStatus::InvalidKey,
-                    "malformed ConnectRequest",
-                    &peer,
-                    None,
-                );
-                return;
-            }
-        };
-    drop(pre_auth_guard);
+    let initialization_deadline = Instant::now() + INITIALIZATION_TIMEOUT;
+    let handshake_deadline = (Instant::now() + HANDSHAKE_TIMEOUT).min(initialization_deadline);
+    let request = match read_request_deadline(&mut stream, handshake_deadline) {
+        Ok(request) => request,
+        Err(error) => {
+            crate::diag::verbose(1, format!("malformed ConnectRequest from {peer}: {error}"));
+            reject(
+                &mut stream,
+                ConnectStatus::InvalidKey,
+                "malformed ConnectRequest",
+                &peer,
+                None,
+            );
+            return;
+        }
+    };
     if !protocol_matches(&request) {
         let client_id = request
             .client_id
@@ -59,6 +65,18 @@ pub(crate) fn handle(
             &peer,
             client_id.as_deref(),
         );
+        return;
+    }
+    let remaining = initialization_deadline
+        .checked_duration_since(Instant::now())
+        .unwrap_or(Duration::ZERO);
+    if remaining.is_zero()
+        || stream
+            .set_read_timeout(Some(remaining))
+            .and_then(|()| stream.set_write_timeout(Some(remaining)))
+            .is_err()
+    {
+        crate::diag::info(format!("drop {peer}: initialization deadline expired"));
         return;
     }
     let Some(id) = request.client_id.filter(|id| valid_id(id)) else {
@@ -84,10 +102,35 @@ pub(crate) fn handle(
             return;
         }
     };
-    if guard.assign(registration.identity()).is_err() {
+    #[cfg(test)]
+    run_before_raw_assignment_hook(&id);
+    let registration_identity = registration.identity();
+    if guard.assign(registration_identity.clone()).is_err() {
         crate::diag::info(format!(
             "drop {peer} id={id}: could not track raw socket for registration"
         ));
+        return;
+    }
+    if !matches!(core.registry.contains(&registration_identity), Ok(true)) {
+        crate::diag::info(format!(
+            "drop {peer} id={id}: registration disconnected during raw socket assignment"
+        ));
+        return;
+    }
+    if !matches!(
+        core.sessions.state(&id),
+        Ok(Some(crate::session_table::SessionState::Active))
+    ) {
+        crate::diag::info(format!("id={id}: new client session from {peer}"));
+        handle_new(
+            stream,
+            registration,
+            &core,
+            &peer,
+            pre_auth_guard,
+            initialization_deadline,
+            &mut guard,
+        );
         return;
     }
     let claim = match core.sessions.claim(registration, &stream, &core.registry) {
@@ -110,20 +153,11 @@ pub(crate) fn handle(
         }
     };
     match claim {
-        SessionClaim::New { start, replaced } => {
-            if replaced.is_some() {
-                crate::diag::info(format!(
-                    "id={id}: replacing existing session for new client from {peer}"
-                ));
-            }
-            if replaced.is_some_and(|connection| connection.shutdown().is_err()) {
-                crate::diag::info(format!(
-                    "id={id}: failed to shut down replaced session; aborting new client"
-                ));
-                return;
-            }
-            crate::diag::info(format!("id={id}: new client session from {peer}"));
-            handle_new(stream, start, &core, &id, &peer);
+        SessionClaim::New { .. } => {
+            // The active session changed while this connection was being
+            // classified. Roll back and let the client retry from a fresh
+            // plaintext handshake rather than assigning the wrong status.
+            crate::diag::info(format!("id={id}: session changed while classifying {peer}"));
         }
         SessionClaim::Returning(session) => {
             crate::diag::info(format!("id={id}: returning client reconnect from {peer}"));
@@ -167,20 +201,45 @@ pub(crate) fn handle(
 
 fn handle_new(
     mut stream: TcpStream,
-    start: crate::session_slot::SessionStart,
+    registration: crate::registry::Registration,
     core: &RuntimeCore,
-    id: &str,
     peer: &str,
+    pre_auth_guard: PreAuthGuard,
+    initialization_deadline: Instant,
+    raw_guard: &mut RawSocketGuard,
 ) {
-    let initialization_deadline = std::time::Instant::now() + HANDSHAKE_TIMEOUT;
+    let id = registration.id.clone();
     if send_status(&mut stream, ConnectStatus::NewClient).is_err() {
         crate::diag::info(format!(
             "id={id}: failed to send NewClient status to {peer}"
         ));
         return;
     }
-    let mut connection = Connection::new_server(stream, &start.registration().key);
-    let packet = match connection.read_packet_until(initialization_deadline) {
+    let remaining = initialization_deadline
+        .checked_duration_since(Instant::now())
+        .unwrap_or(Duration::ZERO);
+    if remaining.is_zero()
+        || stream
+            .set_read_timeout(Some(remaining))
+            .and_then(|()| stream.set_write_timeout(Some(remaining)))
+            .is_err()
+    {
+        crate::diag::info(format!(
+            "id={id}: initialization deadline expired for {peer}"
+        ));
+        return;
+    }
+    let claim_stream = match stream.try_clone() {
+        Ok(stream) => stream,
+        Err(error) => {
+            crate::diag::info(format!(
+                "id={id}: could not clone initialization socket: {error}"
+            ));
+            return;
+        }
+    };
+    let mut connection = Connection::new_server(stream, &registration.key);
+    let packet = match connection.read_packet_deadline(initialization_deadline) {
         Ok(packet) => packet,
         Err(error) => {
             crate::diag::info(format!(
@@ -189,6 +248,13 @@ fn handle_new(
             return;
         }
     };
+    // Successfully decrypting this packet is the first cryptographic proof of
+    // possession of the registration key. Keep admission occupied until now.
+    if raw_guard.authenticate().is_err() {
+        crate::diag::info(format!("id={id}: could not mark authenticated socket"));
+        return;
+    }
+    drop(pre_auth_guard);
     let payload = if packet.header() == EtPacketType::InitialPayload as u8 {
         InitialPayload::decode(packet.payload()).map_err(|_| "malformed InitialPayload")
     } else {
@@ -204,44 +270,121 @@ fn handle_new(
             return;
         }
     };
-    if payload.jumphost.unwrap_or(false) {
-        crate::diag::info(format!("id={id}: jumphost session from {peer}"));
-        run_jumphost(connection, start, core, payload, id, peer);
+    let start = match core
+        .sessions
+        .claim(registration, &claim_stream, &core.registry)
+    {
+        Ok(SessionClaim::New {
+            start,
+            replaced: None,
+        }) => start,
+        Ok(SessionClaim::New {
+            replaced: Some(replaced),
+            ..
+        }) => {
+            let _ = replaced.shutdown();
+            send_initial_error(&mut connection, "session changed during authentication");
+            return;
+        }
+        Ok(SessionClaim::Returning(_)) => {
+            send_initial_error(
+                &mut connection,
+                "session became active during authentication",
+            );
+            return;
+        }
+        Err(error) => {
+            send_initial_error(&mut connection, &format!("session claim failed: {error}"));
+            return;
+        }
+    };
+    // This raw connection now owns the Starting/Active session slot. Lifecycle
+    // teardown closes Starting through the slot while preserving an Active
+    // transport long enough to drain terminal bytes buffered before HUP.
+    if raw_guard.own_session().is_err() {
+        send_initial_error(&mut connection, "could not track session owner");
         return;
     }
-    if payload.reversetunnels.len() > et_net::forward::MAX_SESSION_LISTENERS {
-        send_initial_error(&mut connection, "reverse listener limit exceeded");
+    if payload.jumphost.unwrap_or(false) {
+        crate::diag::info(format!("id={id}: jumphost session from {peer}"));
+        run_jumphost(
+            connection,
+            start,
+            core,
+            payload,
+            &id,
+            peer,
+            initialization_deadline,
+        );
+        return;
+    }
+    if payload.reversetunnels.len() > et_net::reverse_report::MAX_REVERSE_ROWS {
+        send_initial_error(&mut connection, "too many reverse forwarding rows");
         return;
     }
     let owner = {
         let registration = start.registration();
         (registration.uid, registration.gid)
     };
-    let (forwarder, forward_environment) = match et_net::forward::Forwarder::start_with_user_until(
-        payload.reversetunnels.clone(),
-        owner,
-        initialization_deadline,
-    ) {
-        Ok(started) => started,
-        Err(error) => {
-            crate::diag::info(format!(
-                "id={id}: reverse-tunnel setup failed for {peer}: {error}"
-            ));
-            send_initial_error(&mut connection, &error.to_string());
-            return;
+    let mut reverse_tunnels = payload.reversetunnels.clone();
+    for request in &mut reverse_tunnels {
+        if request.environmentvariable.as_deref() == Some(LEGACY_UNTRUSTED_ORIGIN_MARKER) {
+            request.environmentvariable = None;
+        }
+    }
+    let (forwarder, forward_environment, skipped) =
+        match et_net::forward::Forwarder::start_with_user_report_deadline(
+            reverse_tunnels,
+            Some(owner),
+            initialization_deadline - INITIALIZATION_RESPONSE_MARGIN,
+            core.forward_resolver.clone(),
+        ) {
+            Ok(started) => started,
+            Err(error) => {
+                crate::diag::info(format!(
+                    "id={id}: reverse-tunnel setup failed for {peer}: {error}"
+                ));
+                let message = error.to_string();
+                if error.is_timeout() {
+                    send_initial_error(
+                        &mut connection,
+                        &et_net::forward::encode_forward_timeout(&message),
+                    );
+                } else {
+                    send_initial_error(&mut connection, &message);
+                }
+                return;
+            }
+        };
+    let response_error = if skipped.is_empty() {
+        None
+    } else {
+        let mut rows: Vec<_> = skipped
+            .iter()
+            .filter_map(|skipped| {
+                skipped
+                    .report_index
+                    .map(|index| et_net::reverse_report::SkippedRow {
+                        index,
+                        reason: skipped.reason,
+                    })
+            })
+            .collect();
+        rows.sort_unstable_by_key(|row| row.index);
+        match et_net::reverse_report::encode_skipped_rows(&rows) {
+            Ok(report) => Some(report),
+            Err(_) => {
+                drop(forwarder);
+                send_initial_error(&mut connection, "too many skipped reverse forwarding rows");
+                return;
+            }
         }
     };
-    if connection
-        .write_packet_live_until(
-            EtPacketType::InitialResponse as u8,
-            &InitialResponse { error: None }.encode_to_vec(),
-            initialization_deadline,
-        )
-        .is_err()
-    {
-        crate::diag::info(format!(
-            "id={id}: failed writing INITIAL_RESPONSE to {peer}"
-        ));
+    if Instant::now() >= initialization_deadline {
+        send_initial_error(
+            &mut connection,
+            "initialization deadline elapsed during forwarding",
+        );
         return;
     }
     let mut terminal = match core.registry.clone_stream(start.registration()) {
@@ -267,8 +410,58 @@ fn handle_new(
         TerminalPacketType::TerminalInit as u8,
         term_init.encode_to_vec(),
     );
-    if write_local_packet(&mut terminal, &init_packet).is_err() {
+    if write_initial_local_packet(&mut terminal, &init_packet, initialization_deadline).is_err() {
+        send_initial_error(
+            &mut connection,
+            "terminal disconnected during initialization",
+        );
         return;
+    }
+    if start.registration().startup_ack {
+        if let Err(error) = wait_for_terminal_startup(
+            &core.registry,
+            start.registration(),
+            initialization_deadline,
+        ) {
+            crate::diag::info(format!("id={id}: terminal startup failed: {error}"));
+            send_initial_error(&mut connection, &error);
+            let _ = terminal.shutdown(std::net::Shutdown::Both);
+            return;
+        }
+    }
+    if Instant::now() >= initialization_deadline {
+        send_initial_error(
+            &mut connection,
+            "initialization deadline elapsed before response",
+        );
+        return;
+    }
+    let requires_ack = response_error.is_some();
+    if connection
+        .write_packet_strict(
+            EtPacketType::InitialResponse as u8,
+            &InitialResponse {
+                error: response_error,
+            }
+            .encode_to_vec(),
+        )
+        .is_err()
+    {
+        crate::diag::info(format!(
+            "id={id}: failed writing INITIAL_RESPONSE to {peer}"
+        ));
+        return;
+    }
+    if requires_ack {
+        if connection.set_io_timeout(Some(HANDSHAKE_TIMEOUT)).is_err() {
+            return;
+        }
+        let acknowledged = connection.read_packet().is_ok_and(|packet| {
+            packet.header() == EtPacketType::Heartbeat as u8 && packet.payload().is_empty()
+        });
+        if !acknowledged || connection.set_io_timeout(None).is_err() {
+            return;
+        }
     }
     let active = match ActiveSession::new(connection, &terminal) {
         Ok(active) => active,
@@ -300,7 +493,12 @@ fn run_jumphost(
     payload: InitialPayload,
     id: &str,
     peer: &str,
+    initialization_deadline: Instant,
 ) {
+    if Instant::now() >= initialization_deadline {
+        send_initial_error(&mut connection, "jumphost initialization deadline elapsed");
+        return;
+    }
     let mut terminal = match core.registry.clone_stream(start.registration()) {
         Ok(terminal) => terminal,
         Err(error) => {
@@ -314,14 +512,42 @@ fn run_jumphost(
         TerminalPacketType::JumphostInit as u8,
         payload.encode_to_vec(),
     );
-    if terminal
-        .set_nonblocking(false)
-        .and_then(|()| terminal.set_read_timeout(Some(JUMPHOST_RESPONSE_TIMEOUT)))
-        .and_then(|()| terminal.set_write_timeout(Some(JUMPHOST_RESPONSE_TIMEOUT)))
-        .is_err()
-        || write_local_packet(&mut terminal, &init_packet).is_err()
+    if terminal.set_nonblocking(true).is_err()
+        || write_initial_local_packet(&mut terminal, &init_packet, initialization_deadline).is_err()
     {
         crate::diag::info(format!("id={id}: jumphost failed sending JUMPHOST_INIT"));
+        send_initial_error(
+            &mut connection,
+            "jumphost disconnected during initialization",
+        );
+        return;
+    }
+    if start.registration().startup_ack {
+        if let Err(error) = wait_for_terminal_startup(
+            &core.registry,
+            start.registration(),
+            initialization_deadline,
+        ) {
+            crate::diag::info(format!("id={id}: jumphost startup failed: {error}"));
+            send_initial_error(&mut connection, &error);
+            let _ = terminal.shutdown(std::net::Shutdown::Both);
+            return;
+        }
+    }
+    let remaining = match initialization_deadline.checked_duration_since(Instant::now()) {
+        Some(remaining) => remaining,
+        None => {
+            send_initial_error(&mut connection, "jumphost initialization deadline elapsed");
+            return;
+        }
+    };
+    if terminal
+        .set_nonblocking(false)
+        .and_then(|()| terminal.set_read_timeout(Some(remaining)))
+        .and_then(|()| terminal.set_write_timeout(Some(remaining)))
+        .is_err()
+    {
+        send_initial_error(&mut connection, "jumphost initialization deadline elapsed");
         return;
     }
     let response_packet = match et_net::local_packet::read_local_packet(&mut terminal) {
@@ -339,8 +565,15 @@ fn run_jumphost(
         }
     };
     let response = InitialResponse::decode(response_packet.payload()).ok();
+    if Instant::now() >= initialization_deadline {
+        send_initial_error(
+            &mut connection,
+            "initialization deadline elapsed before response",
+        );
+        return;
+    }
     if connection
-        .write_packet_live(
+        .write_packet_strict(
             EtPacketType::InitialResponse as u8,
             response_packet.payload(),
         )
@@ -411,6 +644,31 @@ fn run_jumphost(
     let _ = active.finish_terminal();
 }
 
+fn wait_for_terminal_startup(
+    registry: &crate::registry::Registry,
+    registration: &crate::registry::Registration,
+    deadline: Instant,
+) -> Result<(), String> {
+    registry
+        .wait_for_startup(registration, deadline)
+        .map_err(|error| format!("terminal startup acknowledgement failed: {error}"))
+}
+
+fn write_initial_local_packet(
+    stream: &mut et_net::local::LocalStream,
+    packet: &et_core::packet::Packet,
+    deadline: Instant,
+) -> std::io::Result<()> {
+    let result = write_local_packet_cancelled(stream, packet, &AtomicBool::new(false), deadline);
+    if result.is_err() {
+        // A cancelled framed write may have emitted only a prefix. Poison this
+        // registration generation so the router retires it instead of letting
+        // a later initialization append to and reuse the partial frame.
+        let _ = stream.shutdown(std::net::Shutdown::Both);
+    }
+    result
+}
+
 fn send_initial_error(connection: &mut Connection, message: &str) {
     let _ = connection.write_packet(
         EtPacketType::InitialResponse as u8,
@@ -453,4 +711,179 @@ fn reject(
 
 fn valid_id(id: &str) -> bool {
     id.len() == 16 && id.bytes().all(|byte| byte.is_ascii_alphanumeric())
+}
+
+#[cfg(test)]
+struct RawAssignmentHook {
+    id: String,
+    reached: std::sync::mpsc::SyncSender<()>,
+    release: std::sync::mpsc::Receiver<()>,
+}
+
+#[cfg(test)]
+fn raw_assignment_hook() -> &'static std::sync::Mutex<Option<RawAssignmentHook>> {
+    static HOOK: std::sync::OnceLock<std::sync::Mutex<Option<RawAssignmentHook>>> =
+        std::sync::OnceLock::new();
+    HOOK.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+#[cfg(test)]
+pub(crate) fn install_raw_assignment_hook(
+    id: &str,
+    reached: std::sync::mpsc::SyncSender<()>,
+    release: std::sync::mpsc::Receiver<()>,
+) {
+    *raw_assignment_hook().lock().unwrap() = Some(RawAssignmentHook {
+        id: id.to_owned(),
+        reached,
+        release,
+    });
+}
+
+#[cfg(test)]
+fn run_before_raw_assignment_hook(id: &str) {
+    let hook = {
+        let mut installed = raw_assignment_hook().lock().unwrap();
+        if installed.as_ref().is_some_and(|hook| hook.id == id) {
+            installed.take()
+        } else {
+            None
+        }
+    };
+    if let Some(hook) = hook {
+        hook.reached.send(()).unwrap();
+        hook.release.recv().unwrap();
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::router::{Router, RouterEvent};
+    use et_core::proto::TerminalUserInfo;
+    use prost::Message;
+    use std::io::{Read, Write};
+    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::net::UnixStream;
+    use std::path::Path;
+
+    const TEST_ID: &str = "initialframe0001";
+    const TEST_KEY: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef";
+
+    fn register(path: &Path) -> UnixStream {
+        let mut terminal = UnixStream::connect(path).unwrap();
+        let packet = et_core::packet::Packet::new(
+            TerminalPacketType::TerminalUserInfo as u8,
+            TerminalUserInfo {
+                id: Some(TEST_ID.to_owned()),
+                passkey: Some(TEST_KEY.to_owned()),
+                uid: Some(i64::from(rustix::process::getuid().as_raw())),
+                gid: Some(i64::from(rustix::process::getgid().as_raw())),
+                fd: None,
+            }
+            .encode_to_vec(),
+        );
+        et_net::local_packet::write_local_packet(&mut terminal, &packet).unwrap();
+        terminal
+    }
+
+    fn interrupted_initial_write_retires_registration(header: TerminalPacketType) {
+        let directory = std::env::temp_dir().join(format!(
+            "et-interrupted-init-{}-{}",
+            std::process::id(),
+            header as i32
+        ));
+        std::fs::create_dir(&directory).unwrap();
+        std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let path = directory.join("router.sock");
+        let selected = crate::path::select_router_path_for(
+            rustix::process::getuid().as_raw(),
+            Some(&path),
+            None,
+            None,
+        )
+        .unwrap();
+        let registry = crate::registry::Registry::new();
+        let mut router = Router::start(selected, registry.clone()).unwrap();
+        let mut terminal = register(&path);
+        assert_eq!(
+            router.recv_event_timeout(Duration::from_secs(1)).unwrap(),
+            RouterEvent::Registered {
+                id: TEST_ID.to_owned()
+            }
+        );
+
+        let registration = registry.get(TEST_ID).unwrap().unwrap();
+        let mut writer = registry.clone_stream(&registration).unwrap();
+        writer.set_nonblocking(true).unwrap();
+        let fill = [0u8; 8192];
+        loop {
+            match writer.write(&fill) {
+                Ok(0) => panic!("local stream closed while being saturated"),
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
+                Err(error) => panic!("could not saturate local stream: {error}"),
+            }
+        }
+        let packet = et_core::packet::Packet::new(header as u8, vec![1; 1024]);
+        let error = write_initial_local_packet(
+            &mut writer,
+            &packet,
+            Instant::now() + Duration::from_millis(50),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+
+        assert_eq!(
+            router.recv_event_timeout(Duration::from_secs(1)).unwrap(),
+            RouterEvent::Disconnected {
+                id: TEST_ID.to_owned()
+            }
+        );
+        assert!(registry.get(TEST_ID).unwrap().is_none());
+
+        terminal
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let mut bytes = [0u8; 8192];
+        loop {
+            match terminal.read(&mut bytes) {
+                Ok(0) => break,
+                Ok(_) => {}
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionAborted
+                    ) =>
+                {
+                    break;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::TimedOut => {
+                    panic!("poisoned local stream remained open: {error}")
+                }
+                Err(error) => panic!("unexpected local stream error: {error}"),
+            }
+        }
+
+        let _fresh_terminal = register(&path);
+        assert_eq!(
+            router.recv_event_timeout(Duration::from_secs(1)).unwrap(),
+            RouterEvent::Registered {
+                id: TEST_ID.to_owned()
+            }
+        );
+        assert!(registry.get(TEST_ID).unwrap().is_some());
+        router.shutdown().unwrap();
+        std::fs::remove_dir(directory).unwrap();
+    }
+
+    #[test]
+    fn interrupted_terminal_init_retires_registration_generation() {
+        interrupted_initial_write_retires_registration(TerminalPacketType::TerminalInit);
+    }
+
+    #[test]
+    fn interrupted_jumphost_init_retires_registration_generation() {
+        interrupted_initial_write_retires_registration(TerminalPacketType::JumphostInit);
+    }
 }

--- a/crates/et-server/src/runtime_lifecycle.rs
+++ b/crates/et-server/src/runtime_lifecycle.rs
@@ -33,6 +33,8 @@ pub(crate) fn run(
                     ));
                     first_error.get_or_insert(error);
                 }
+                #[cfg(test)]
+                notify_raw_scan_complete(identity.id());
                 let removed = core.sessions.remove_registration_with(&identity, |_| {});
                 match removed {
                     Ok(Some(removed)) => {
@@ -78,4 +80,40 @@ pub(crate) fn run(
         }
     }
     first_error.map_or(Ok(()), Err)
+}
+
+#[cfg(test)]
+struct RawScanHook {
+    id: String,
+    complete: std::sync::mpsc::SyncSender<()>,
+}
+
+#[cfg(test)]
+fn raw_scan_hook() -> &'static std::sync::Mutex<Option<RawScanHook>> {
+    static HOOK: std::sync::OnceLock<std::sync::Mutex<Option<RawScanHook>>> =
+        std::sync::OnceLock::new();
+    HOOK.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+#[cfg(test)]
+pub(crate) fn install_raw_scan_hook(id: &str, complete: std::sync::mpsc::SyncSender<()>) {
+    *raw_scan_hook().lock().unwrap() = Some(RawScanHook {
+        id: id.to_owned(),
+        complete,
+    });
+}
+
+#[cfg(test)]
+fn notify_raw_scan_complete(id: &str) {
+    let complete = {
+        let mut installed = raw_scan_hook().lock().unwrap();
+        if installed.as_ref().is_some_and(|hook| hook.id == id) {
+            installed.take().map(|hook| hook.complete)
+        } else {
+            None
+        }
+    };
+    if let Some(complete) = complete {
+        let _ = complete.send(());
+    }
 }

--- a/crates/et-server/src/runtime_lifecycle.rs
+++ b/crates/et-server/src/runtime_lifecycle.rs
@@ -23,19 +23,17 @@ pub(crate) fn run(
                     "terminal disconnected for registration id={}",
                     identity.id()
                 ));
-                let removed = core
-                    .sessions
-                    .remove_registration_with(&identity, |shutdown_raw| {
-                        if shutdown_raw {
-                            if let Err(error) = core.raw_sockets.shutdown_registration(&identity) {
-                                crate::diag::info(format!(
-                                    "id={}: error shutting down raw sockets: {error}",
-                                    identity.id()
-                                ));
-                                first_error.get_or_insert(error);
-                            }
-                        }
-                    });
+                // Keep the active transport open long enough for the bridge to
+                // drain terminal bytes already buffered at HUP, but cancel every
+                // pre-slot, starting, and returning raw socket in this generation.
+                if let Err(error) = core.raw_sockets.shutdown_inactive_registration(&identity) {
+                    crate::diag::info(format!(
+                        "id={}: error shutting down inactive raw sockets: {error}",
+                        identity.id()
+                    ));
+                    first_error.get_or_insert(error);
+                }
+                let removed = core.sessions.remove_registration_with(&identity, |_| {});
                 match removed {
                     Ok(Some(removed)) => {
                         crate::diag::info(format!(

--- a/crates/et-server/src/runtime_state.rs
+++ b/crates/et-server/src/runtime_state.rs
@@ -15,6 +15,7 @@ pub(crate) struct RuntimeCore {
     pub(crate) handlers: HandlerThreads,
     pub(crate) pre_auth_slots: Arc<PreAuthSlots>,
     pub(crate) shutdown: AtomicBool,
+    pub(crate) forward_resolver: Arc<dyn et_net::forward::ForwardResolver>,
 }
 
 pub(crate) const MAX_PRE_AUTH_CONNECTIONS: usize = 128;

--- a/crates/et-server/src/runtime_state.rs
+++ b/crates/et-server/src/runtime_state.rs
@@ -57,6 +57,7 @@ struct TrackedSocket {
     stream: TcpStream,
     registration: Option<RegistrationIdentity>,
     authenticated: bool,
+    session_owner: bool,
 }
 
 pub(crate) struct RawSockets {
@@ -96,6 +97,7 @@ impl RawSockets {
                 stream: clone,
                 registration: None,
                 authenticated: false,
+                session_owner: false,
             },
         );
         Ok(RawSocketGuard {
@@ -115,7 +117,7 @@ impl RawSockets {
         Ok(())
     }
 
-    pub(crate) fn shutdown_registration(
+    pub(crate) fn shutdown_inactive_registration(
         &self,
         identity: &RegistrationIdentity,
     ) -> Result<(), RuntimeError> {
@@ -124,10 +126,11 @@ impl RawSockets {
             .lock()
             .map_err(|_| RuntimeError::WorkerUnavailable)?;
         for tracked in streams.values() {
-            if tracked
-                .registration
-                .as_ref()
-                .is_some_and(|current| current.same_generation(identity))
+            if !tracked.session_owner
+                && tracked
+                    .registration
+                    .as_ref()
+                    .is_some_and(|current| current.same_generation(identity))
             {
                 let _ = tracked.stream.shutdown(Shutdown::Both);
             }
@@ -178,6 +181,19 @@ impl RawSocketGuard {
             .get_mut(&self.id)
             .ok_or(RuntimeError::WorkerUnavailable)?;
         tracked.authenticated = true;
+        Ok(())
+    }
+
+    pub(crate) fn own_session(&mut self) -> Result<(), RuntimeError> {
+        let mut streams = self
+            .sockets
+            .streams
+            .lock()
+            .map_err(|_| RuntimeError::WorkerUnavailable)?;
+        let tracked = streams
+            .get_mut(&self.id)
+            .ok_or(RuntimeError::WorkerUnavailable)?;
+        tracked.session_owner = true;
         Ok(())
     }
 }

--- a/crates/et-server/src/runtime_state.rs
+++ b/crates/et-server/src/runtime_state.rs
@@ -55,6 +55,7 @@ impl Drop for PreAuthGuard {
 struct TrackedSocket {
     stream: TcpStream,
     registration: Option<RegistrationIdentity>,
+    authenticated: bool,
 }
 
 pub(crate) struct RawSockets {
@@ -93,6 +94,7 @@ impl RawSockets {
             TrackedSocket {
                 stream: clone,
                 registration: None,
+                authenticated: false,
             },
         );
         Ok(RawSocketGuard {
@@ -143,10 +145,38 @@ impl RawSocketGuard {
             .streams
             .lock()
             .map_err(|_| RuntimeError::WorkerUnavailable)?;
+        // A known-id peer must not allocate an unbounded set of stalled
+        // authentication workers. Newest wins: close the previous raw socket
+        // for this registration generation before assigning this one. A
+        // legitimate client can therefore displace a passkey-less staller.
+        for (id, tracked) in streams.iter() {
+            if *id != self.id
+                && !tracked.authenticated
+                && tracked
+                    .registration
+                    .as_ref()
+                    .is_some_and(|current| current.same_generation(&registration))
+            {
+                let _ = tracked.stream.shutdown(Shutdown::Both);
+            }
+        }
         let tracked = streams
             .get_mut(&self.id)
             .ok_or(RuntimeError::WorkerUnavailable)?;
         tracked.registration = Some(registration);
+        Ok(())
+    }
+
+    pub(crate) fn authenticate(&mut self) -> Result<(), RuntimeError> {
+        let mut streams = self
+            .sockets
+            .streams
+            .lock()
+            .map_err(|_| RuntimeError::WorkerUnavailable)?;
+        let tracked = streams
+            .get_mut(&self.id)
+            .ok_or(RuntimeError::WorkerUnavailable)?;
+        tracked.authenticated = true;
         Ok(())
     }
 }

--- a/crates/et-server/src/session.rs
+++ b/crates/et-server/src/session.rs
@@ -5,6 +5,9 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, TryLockError};
 use std::time::{Duration, Instant};
 
+use et_core::backed_writer::{
+    MAX_BACKUP_PACKETS, MAX_DISCONNECT_PACKETS, MAX_RECOVERY_BACKUP_BYTES,
+};
 use et_core::proto::TerminalPacketType;
 use et_net::connection::DEFAULT_RECOVERY_TIMEOUT;
 use et_net::connection::{ConnError, Connection};
@@ -29,6 +32,7 @@ pub(crate) struct ActiveSession {
     /// new stream after install so the connection mutex is not held for the
     /// recovery network RTT.
     recover_hold: Mutex<Vec<(u8, Vec<u8>)>>,
+    recover_hold_bytes: AtomicU64,
     shutdown: AtomicBool,
     /// Only one recover may run at a time. Concurrent returning clients used
     /// to queue on the connection mutex for minutes after a blackhole write.
@@ -94,6 +98,7 @@ impl ActiveSession {
             wake_writer: Mutex::new(wake_writer),
             wake_reader: Mutex::new(Some(wake_reader)),
             recover_hold: Mutex::new(Vec::new()),
+            recover_hold_bytes: AtomicU64::new(0),
             shutdown: AtomicBool::new(false),
             recovering: AtomicBool::new(false),
             connection_generation: AtomicU64::new(0),
@@ -144,7 +149,24 @@ impl ActiveSession {
         if !self.recovering.load(Ordering::Acquire) {
             return Ok(false);
         }
+        let held_bytes = self.recover_hold_bytes.load(Ordering::Acquire);
+        let payload_bytes = u64::try_from(payload.len()).map_err(|_| SessionError::Unavailable)?;
+        if hold.len() >= MAX_BACKUP_PACKETS + MAX_DISCONNECT_PACKETS {
+            return Err(SessionError::Unavailable);
+        }
+        let connection = self
+            .connection
+            .lock()
+            .map_err(|_| SessionError::Unavailable)?;
+        let requested = i64::try_from(held_bytes.saturating_add(payload_bytes))
+            .map_err(|_| SessionError::Unavailable)?;
+        if requested > MAX_RECOVERY_BACKUP_BYTES || !connection.can_buffer_write(requested) {
+            return Err(SessionError::Unavailable);
+        }
+        drop(connection);
         hold.push((header, payload.to_vec()));
+        self.recover_hold_bytes
+            .fetch_add(payload_bytes, Ordering::AcqRel);
         Ok(true)
     }
 
@@ -226,6 +248,9 @@ impl ActiveSession {
                 }
                 std::mem::take(&mut *hold)
             };
+            let batch_bytes = batch.iter().fold(0u64, |total, (_, payload)| {
+                total.saturating_add(payload.len() as u64)
+            });
             let mut connection = lock_timeout(&self.connection, RECOVERY_LOCK_TIMEOUT)?;
             let mut remaining = batch.into_iter();
             while let Some((header, payload)) = remaining.next() {
@@ -246,6 +271,8 @@ impl ActiveSession {
                     return Err(SessionError::Connection(error));
                 }
             }
+            self.recover_hold_bytes
+                .fetch_sub(batch_bytes, Ordering::AcqRel);
         }
     }
 
@@ -410,11 +437,24 @@ impl ActiveSession {
     }
 
     pub(crate) fn can_buffer_write(&self, bytes: i64) -> Result<bool, SessionError> {
+        let hold = self
+            .recover_hold
+            .lock()
+            .map_err(|_| SessionError::Unavailable)?;
+        if hold.len() >= MAX_BACKUP_PACKETS + MAX_DISCONNECT_PACKETS {
+            return Ok(false);
+        }
+        let held =
+            i64::try_from(self.recover_hold_bytes.load(Ordering::Acquire)).unwrap_or(i64::MAX);
+        let requested = held.checked_add(bytes).unwrap_or(i64::MAX);
+        if requested > MAX_RECOVERY_BACKUP_BYTES {
+            return Ok(false);
+        }
         Ok(self
             .connection
             .lock()
             .map_err(|_| SessionError::Unavailable)?
-            .can_buffer_write(bytes))
+            .can_buffer_write(requested))
     }
 
     pub(crate) fn is_shutting_down(&self) -> bool {
@@ -489,5 +529,45 @@ impl SessionConnection {
             },
             Self::Active(session) => session.shutdown(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stalled_recovery_hold_is_capacity_bounded_and_fifo() {
+        let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let peer = std::thread::spawn(move || TcpStream::connect(address).unwrap());
+        let (stream, _) = listener.accept().unwrap();
+        let _peer = peer.join().unwrap();
+        let (terminal, _terminal_peer) = et_net::local::wake_pair().unwrap();
+        let session =
+            ActiveSession::new(Connection::new_server(stream, &[7; 32]), &terminal).unwrap();
+        let permit = session.try_begin_recover().unwrap();
+
+        for index in 0..4u8 {
+            assert!(session.queue_if_recovering(index, &[index; 8]).unwrap());
+        }
+        let payload = vec![b'x'; 64 * 1024];
+        let mut accepted = 4usize;
+        while session.queue_if_recovering(9, &payload).is_ok() {
+            accepted += 1;
+            assert!(accepted <= MAX_BACKUP_PACKETS + MAX_DISCONNECT_PACKETS);
+        }
+        assert!(!session.can_buffer_write(payload.len() as i64).unwrap());
+
+        let mut hold = session.recover_hold.lock().unwrap();
+        assert_eq!(hold.len(), accepted);
+        for index in 0..4u8 {
+            assert_eq!(hold[index as usize], (index, vec![index; 8]));
+        }
+        hold.clear();
+        session.recover_hold_bytes.store(0, Ordering::Release);
+        drop(hold);
+        session.recovering.store(false, Ordering::Release);
+        drop(permit);
     }
 }

--- a/crates/et-server/src/session.rs
+++ b/crates/et-server/src/session.rs
@@ -2,7 +2,7 @@ use et_net::local::LocalStream;
 use std::io::{self, Write};
 use std::net::{Shutdown, TcpStream};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard, TryLockError};
 use std::time::{Duration, Instant};
 
 use et_core::proto::TerminalPacketType;
@@ -34,6 +34,8 @@ pub(crate) struct ActiveSession {
     /// to queue on the connection mutex for minutes after a blackhole write.
     recovering: AtomicBool,
     connection_generation: AtomicU64,
+    bridge_generation: Mutex<u64>,
+    bridge_changed: Condvar,
 }
 
 pub(crate) enum SessionConnection {
@@ -95,6 +97,8 @@ impl ActiveSession {
             shutdown: AtomicBool::new(false),
             recovering: AtomicBool::new(false),
             connection_generation: AtomicU64::new(0),
+            bridge_generation: Mutex::new(0),
+            bridge_changed: Condvar::new(),
         })
     }
 
@@ -312,6 +316,46 @@ impl ActiveSession {
             .map_err(|_| SessionError::Unavailable)?
             .try_read_packet()
             .map_err(SessionError::Connection)
+    }
+
+    pub(crate) fn note_bridge_generation(&self, generation: u64) -> Result<(), SessionError> {
+        let mut observed = self
+            .bridge_generation
+            .lock()
+            .map_err(|_| SessionError::Unavailable)?;
+        if generation > *observed {
+            *observed = generation;
+            self.bridge_changed.notify_all();
+        }
+        Ok(())
+    }
+
+    pub(crate) fn wait_for_bridge_generation(
+        &self,
+        expected: u64,
+        timeout: Duration,
+    ) -> Result<(), SessionError> {
+        let deadline = Instant::now()
+            .checked_add(timeout)
+            .ok_or(SessionError::Unavailable)?;
+        let mut observed = self
+            .bridge_generation
+            .lock()
+            .map_err(|_| SessionError::Unavailable)?;
+        while *observed < expected {
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .ok_or(SessionError::RecoverBusy)?;
+            let (next, result) = self
+                .bridge_changed
+                .wait_timeout(observed, remaining)
+                .map_err(|_| SessionError::Unavailable)?;
+            observed = next;
+            if result.timed_out() && *observed < expected {
+                return Err(SessionError::RecoverBusy);
+            }
+        }
+        Ok(())
     }
 
     pub(crate) fn connection_state(&self) -> Result<(bool, u64), SessionError> {

--- a/crates/et-server/src/session_table.rs
+++ b/crates/et-server/src/session_table.rs
@@ -21,6 +21,7 @@ pub enum SessionTableError {
     ObsoleteRegistration,
     Timeout,
     InvalidTransition,
+    StartingBusy,
     Io(io::Error),
 }
 
@@ -32,6 +33,7 @@ impl std::fmt::Display for SessionTableError {
             Self::ObsoleteRegistration => write!(f, "terminal registration is obsolete"),
             Self::Timeout => write!(f, "timed out waiting for session state"),
             Self::InvalidTransition => write!(f, "invalid session state transition"),
+            Self::StartingBusy => write!(f, "session initialization is already in progress"),
             Self::Io(error) => write!(f, "session socket: {error}"),
         }
     }
@@ -49,8 +51,6 @@ impl std::error::Error for SessionTableError {
 #[derive(Default)]
 pub(crate) struct TableState {
     pub(crate) slots: HashMap<String, Slot>,
-    #[cfg(test)]
-    pub(crate) claim_waiters: HashMap<String, usize>,
     pub(crate) shutdown: bool,
 }
 
@@ -145,27 +145,10 @@ impl SessionTable {
                     });
                 }
                 Some(Slot::Starting { .. }) => {
-                    #[cfg(test)]
-                    {
-                        *state.claim_waiters.entry(id.clone()).or_default() += 1;
-                        self.inner.changed.notify_all();
-                    }
-                    state = self
-                        .inner
-                        .changed
-                        .wait(state)
-                        .map_err(|_| SessionTableError::Unavailable)?;
-                    #[cfg(test)]
-                    {
-                        let remove = state.claim_waiters.get_mut(&id).is_some_and(|waiters| {
-                            *waiters -= 1;
-                            *waiters == 0
-                        });
-                        if remove {
-                            state.claim_waiters.remove(&id);
-                        }
-                        self.inner.changed.notify_all();
-                    }
+                    // Never allocate one blocking thread per known-id attacker.
+                    // The owner has an absolute initialization deadline and all
+                    // followers are rejected until it commits or rolls back.
+                    return Err(SessionTableError::StartingBusy);
                 }
                 Some(Slot::Active { session, .. }) => {
                     return Ok(SessionClaim::Returning(session.clone()));

--- a/crates/et-server/src/session_wait.rs
+++ b/crates/et-server/src/session_wait.rs
@@ -35,35 +35,6 @@ impl SessionTable {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn wait_for_claim_waiters(
-        &self,
-        id: &str,
-        expected: usize,
-        timeout: Duration,
-    ) -> Result<(), SessionTableError> {
-        let deadline = deadline(timeout)?;
-        let mut state = self.lock()?;
-        loop {
-            let waiters = state.claim_waiters.get(id).copied().unwrap_or(0);
-            if waiters == expected {
-                return Ok(());
-            }
-            let remaining = deadline
-                .checked_duration_since(Instant::now())
-                .ok_or(SessionTableError::Timeout)?;
-            let (next, wait) = self
-                .inner
-                .changed
-                .wait_timeout(state, remaining)
-                .map_err(|_| SessionTableError::Unavailable)?;
-            state = next;
-            if wait.timed_out() && state.claim_waiters.get(id).copied().unwrap_or(0) != expected {
-                return Err(SessionTableError::Timeout);
-            }
-        }
-    }
-
     fn wait_for(
         &self,
         id: &str,

--- a/crates/et-server/src/socket_path.rs
+++ b/crates/et-server/src/socket_path.rs
@@ -53,6 +53,25 @@ impl OwnedRouterListener {
             path: selected.path().to_path_buf(),
             source,
         })?;
+        let capability = et_net::local::capability_path(selected.path());
+        match fs::remove_file(&capability) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(source) => {
+                return Err(PathError::Io {
+                    operation: "remove stale router capability",
+                    path: capability,
+                    source,
+                });
+            }
+        }
+        et_net::local::write_registration_ack_capability(selected.path()).map_err(|source| {
+            PathError::Io {
+                operation: "write router capability",
+                path: et_net::local::capability_path(selected.path()),
+                source,
+            }
+        })?;
         owned
             .listener
             .set_nonblocking(true)
@@ -83,6 +102,7 @@ impl Drop for OwnedRouterListener {
             && metadata.uid() == rustix::process::geteuid().as_raw()
         {
             let _ = fs::remove_file(&self.path);
+            let _ = fs::remove_file(et_net::local::capability_path(&self.path));
         }
     }
 }

--- a/crates/et-server/src/socket_path.rs
+++ b/crates/et-server/src/socket_path.rs
@@ -101,8 +101,15 @@ impl Drop for OwnedRouterListener {
             && self.identity.matches(&metadata)
             && metadata.uid() == rustix::process::geteuid().as_raw()
         {
+            // Retire this generation's marker before making the socket path
+            // available for replacement. A replacement can then publish its
+            // marker without an older listener deleting it afterward.
+            let _ = et_net::local::retire_registration_ack_capability(
+                &self.path,
+                self.identity.device,
+                self.identity.inode,
+            );
             let _ = fs::remove_file(&self.path);
-            let _ = fs::remove_file(et_net::local::capability_path(&self.path));
         }
     }
 }

--- a/crates/et-server/src/socket_path_windows.rs
+++ b/crates/et-server/src/socket_path_windows.rs
@@ -46,7 +46,11 @@ impl OwnedRouterListener {
             source,
         })?;
         let token = et_net::local::new_token();
-        fs::write(&path, format!("{address}\n{token}\n")).map_err(|source| PathError::Io {
+        fs::write(
+            &path,
+            format!("{address}\n{token}\net-registration-ack-v1\n"),
+        )
+        .map_err(|source| PathError::Io {
             operation: "write router endpoint file",
             path: path.clone(),
             source,

--- a/crates/et-server/src/socket_path_windows.rs
+++ b/crates/et-server/src/socket_path_windows.rs
@@ -63,9 +63,10 @@ impl OwnedRouterListener {
         &self.listener
     }
 
-    /// Accept a terminal, enforcing loopback origin and token authentication.
+    /// Accept a terminal without blocking the sole router worker. Token bytes
+    /// are authenticated incrementally by the bounded pending state machine.
     pub(crate) fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
-        let (mut stream, peer) = self.listener.accept()?;
+        let (stream, peer) = self.listener.accept()?;
         if !peer.ip().is_loopback() {
             let _ = stream.shutdown(std::net::Shutdown::Both);
             return Err(io::Error::new(
@@ -73,21 +74,12 @@ impl OwnedRouterListener {
                 "router peer is not loopback",
             ));
         }
-        // Accepted sockets inherit the listener's non-blocking mode on Windows;
-        // the token exchange below is blocking with a timeout.
-        stream.set_nonblocking(false)?;
         stream.set_nodelay(true)?;
-        // The token line is short and sent immediately after connect.
-        stream.set_read_timeout(Some(std::time::Duration::from_secs(5)))?;
-        let authenticated = et_net::local::accept_token(&mut stream, &self.token);
-        stream.set_read_timeout(None)?;
-        match authenticated {
-            Ok(()) => Ok((stream, peer)),
-            Err(error) => {
-                let _ = stream.shutdown(std::net::Shutdown::Both);
-                Err(error)
-            }
-        }
+        Ok((stream, peer))
+    }
+
+    pub(crate) fn token(&self) -> &str {
+        &self.token
     }
 }
 

--- a/crates/et-server/src/terminal_bridge.rs
+++ b/crates/et-server/src/terminal_bridge.rs
@@ -66,6 +66,7 @@ fn run_mode_poll(
     wake.set_nonblocking(true).map_err(SessionError::Io)?;
     let mut decoder = LocalPacketDecoder::new();
     let (mut connected, mut connection_generation) = session.connection_state()?;
+    session.note_bridge_generation(connection_generation)?;
     // A forwarding packet the worker had no room for. While it is held, no
     // further client packets are read (ordering) and the client socket is not
     // watched for readability (it would busy-loop the poll).
@@ -126,6 +127,7 @@ fn run_mode_poll(
                 return Ok(());
             }
             (connected, connection_generation) = session.connection_state()?;
+            session.note_bridge_generation(connection_generation)?;
         }
         let terminal_closed = terminal_events.intersects(PollFlags::HUP | PollFlags::ERR);
         if terminal_closed || terminal_events.contains(PollFlags::IN) {
@@ -243,6 +245,7 @@ fn run_mode_windows(
     wake.set_nonblocking(true).map_err(SessionError::Io)?;
     let mut decoder = LocalPacketDecoder::new();
     let (mut connected, mut connection_generation) = session.connection_state()?;
+    session.note_bridge_generation(connection_generation)?;
     // A forwarding packet the worker had no room for; while it is held, no
     // further client packets are read so forwarding data stays ordered.
     let mut pending_forward: Option<Packet> = None;
@@ -274,6 +277,7 @@ fn run_mode_windows(
                 return Ok(());
             }
             (connected, connection_generation) = session.connection_state()?;
+            session.note_bridge_generation(connection_generation)?;
             progress = true;
         }
 

--- a/crates/et-server/tests/path_security.rs
+++ b/crates/et-server/tests/path_security.rs
@@ -99,9 +99,15 @@ fn cleanup_does_not_remove_a_replacement_inode() {
     let mut router = Router::start(selected, Registry::new()).unwrap();
 
     fs::remove_file(&path).unwrap();
+    fs::remove_file(et_net::local::capability_path(&path)).unwrap();
     File::create(&path).unwrap();
+    et_net::local::write_registration_ack_capability(&path).unwrap();
     router.shutdown().unwrap();
     assert!(path.is_file());
+    assert!(
+        et_net::local::supports_registration_ack(&path),
+        "old listener removed the replacement generation's marker"
+    );
 }
 
 #[test]
@@ -113,6 +119,12 @@ fn root_compatible_socket_is_read_write_without_execute_bits() {
 
     let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
     assert_eq!(mode, 0o666);
+    let capability = et_net::local::capability_path(&path);
+    assert_eq!(
+        fs::metadata(capability).unwrap().permissions().mode() & 0o777,
+        0o644
+    );
+    assert!(et_net::local::supports_registration_ack(&path));
     router.shutdown().unwrap();
 }
 

--- a/crates/et-server/tests/router_registration.rs
+++ b/crates/et-server/tests/router_registration.rs
@@ -9,14 +9,20 @@ use std::time::Duration;
 
 use et_core::packet::Packet;
 use et_core::proto::{TerminalPacketType, TerminalUserInfo};
-use et_net::local_packet::{write_local_packet, MAX_LOCAL_PACKET_LEN};
+use et_net::local_packet::{read_local_packet, write_local_packet, MAX_LOCAL_PACKET_LEN};
 use et_server::path::select_router_path_for;
-use et_server::{Registry, Router, RouterEvent, RouterReject};
+use et_server::{
+    Registry, Router, RouterEvent, RouterReject, MAX_PENDING_REGISTRATIONS, REGISTRATION_TIMEOUT,
+};
 use prost::Message;
 use support::TestDir;
 
 const ID: &str = "abcdefghijklmnop";
 const KEY: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef";
+
+fn current_ids() -> (i64, i64) {
+    peer_identity()
+}
 
 fn peer_identity() -> (i64, i64) {
     (
@@ -31,12 +37,22 @@ fn info(
     uid: Option<i64>,
     gid: Option<i64>,
 ) -> TerminalUserInfo {
+    info_with_capability(id, key, uid, gid, false)
+}
+
+fn info_with_capability(
+    id: Option<&str>,
+    key: Option<&str>,
+    uid: Option<i64>,
+    gid: Option<i64>,
+    startup_ack: bool,
+) -> TerminalUserInfo {
     TerminalUserInfo {
         id: id.map(str::to_owned),
         passkey: key.map(str::to_owned),
         uid,
         gid,
-        fd: None,
+        fd: startup_ack.then_some(-6),
     }
 }
 
@@ -245,6 +261,112 @@ fn terminal_disconnect_is_typed_and_same_id_can_register_again() {
         RouterEvent::Registered { id: ID.to_owned() }
     );
     assert_eq!(registry.len().unwrap(), 1);
+    router.shutdown().unwrap();
+}
+
+#[test]
+fn new_router_sends_no_control_packet_to_legacy_terminal() {
+    let dir = TestDir::new();
+    let path = dir.socket();
+    let registry = Registry::new();
+    let selected = select_router_path_for(1000, Some(&path), None, None).unwrap();
+    let mut router = Router::start(selected, registry).unwrap();
+    let (uid, gid) = current_ids();
+    let packet = Packet::new(
+        TerminalPacketType::TerminalUserInfo as u8,
+        info(Some(ID), Some(KEY), Some(uid), Some(gid)).encode_to_vec(),
+    );
+    let mut terminal = connect_packet(&path, &packet);
+    assert_eq!(
+        router.recv_event_timeout(Duration::from_secs(2)).unwrap(),
+        RouterEvent::Registered { id: ID.to_owned() }
+    );
+    terminal
+        .set_read_timeout(Some(Duration::from_millis(100)))
+        .unwrap();
+    let error = read_local_packet(&mut terminal).unwrap_err();
+    assert!(matches!(
+        error,
+        et_net::local_packet::LocalPacketError::Io(ref io)
+            if matches!(io.kind(), std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut)
+    ));
+    router.shutdown().unwrap();
+}
+
+#[test]
+fn broken_registration_ack_rolls_back_and_router_keeps_serving() {
+    let dir = TestDir::new();
+    let path = dir.socket();
+    let registry = Registry::new();
+    let selected = select_router_path_for(1000, Some(&path), None, None).unwrap();
+    let mut router = Router::start(selected, registry.clone()).unwrap();
+    let (uid, gid) = current_ids();
+    let mut broken = UnixStream::connect(&path).unwrap();
+    let packet = Packet::new(
+        TerminalPacketType::TerminalUserInfo as u8,
+        info_with_capability(Some(ID), Some(KEY), Some(uid), Some(gid), true).encode_to_vec(),
+    );
+    write_local_packet(&mut broken, &packet).unwrap();
+    broken.shutdown(Shutdown::Read).unwrap();
+    expect_rejected(&router, RouterReject::RegistryUnavailable);
+    assert!(registry.is_empty().unwrap());
+
+    let packet = Packet::new(
+        TerminalPacketType::TerminalUserInfo as u8,
+        info(Some(ID), Some(KEY), Some(uid), Some(gid)).encode_to_vec(),
+    );
+    let _terminal = connect_packet(&path, &packet);
+    assert_eq!(
+        router.recv_event_timeout(Duration::from_secs(2)).unwrap(),
+        RouterEvent::Registered { id: ID.to_owned() }
+    );
+    router.shutdown().unwrap();
+}
+
+#[test]
+fn idle_registration_capacity_is_bounded_and_recovers() {
+    let dir = TestDir::new();
+    let path = dir.socket();
+    let registry = Registry::new();
+    let selected = select_router_path_for(1000, Some(&path), None, None).unwrap();
+    let mut router = Router::start(selected, registry.clone()).unwrap();
+    let idle: Vec<_> = (0..MAX_PENDING_REGISTRATIONS)
+        .map(|_| UnixStream::connect(&path).unwrap())
+        .collect();
+    let excess = UnixStream::connect(&path).unwrap();
+    expect_rejected(&router, RouterReject::Capacity);
+    drop(excess);
+    drop(idle);
+    for _ in 0..MAX_PENDING_REGISTRATIONS {
+        expect_rejected(&router, RouterReject::MalformedFrame);
+    }
+
+    let (uid, gid) = current_ids();
+    let packet = Packet::new(
+        TerminalPacketType::TerminalUserInfo as u8,
+        info(Some(ID), Some(KEY), Some(uid), Some(gid)).encode_to_vec(),
+    );
+    let _terminal = connect_packet(&path, &packet);
+    assert_eq!(
+        router.recv_event_timeout(Duration::from_secs(2)).unwrap(),
+        RouterEvent::Registered { id: ID.to_owned() }
+    );
+    router.shutdown().unwrap();
+}
+
+#[test]
+fn idle_registration_expires_on_monotonic_deadline() {
+    let dir = TestDir::new();
+    let path = dir.socket();
+    let selected = select_router_path_for(1000, Some(&path), None, None).unwrap();
+    let mut router = Router::start(selected, Registry::new()).unwrap();
+    let _idle = UnixStream::connect(&path).unwrap();
+    assert_eq!(
+        router
+            .recv_event_timeout(REGISTRATION_TIMEOUT + Duration::from_secs(2))
+            .unwrap(),
+        RouterEvent::Rejected(RouterReject::Timeout)
+    );
     router.shutdown().unwrap();
 }
 

--- a/crates/et-server/tests/router_registration.rs
+++ b/crates/et-server/tests/router_registration.rs
@@ -11,9 +11,7 @@ use et_core::packet::Packet;
 use et_core::proto::{TerminalPacketType, TerminalUserInfo};
 use et_net::local_packet::{read_local_packet, write_local_packet, MAX_LOCAL_PACKET_LEN};
 use et_server::path::select_router_path_for;
-use et_server::{
-    Registry, Router, RouterEvent, RouterReject, MAX_PENDING_REGISTRATIONS, REGISTRATION_TIMEOUT,
-};
+use et_server::{Registry, Router, RouterEvent, RouterReject, REGISTRATION_TIMEOUT};
 use prost::Message;
 use support::TestDir;
 
@@ -324,37 +322,6 @@ fn broken_registration_ack_rolls_back_and_router_keeps_serving() {
 }
 
 #[test]
-fn idle_registration_capacity_is_bounded_and_recovers() {
-    let dir = TestDir::new();
-    let path = dir.socket();
-    let registry = Registry::new();
-    let selected = select_router_path_for(1000, Some(&path), None, None).unwrap();
-    let mut router = Router::start(selected, registry.clone()).unwrap();
-    let idle: Vec<_> = (0..MAX_PENDING_REGISTRATIONS)
-        .map(|_| UnixStream::connect(&path).unwrap())
-        .collect();
-    let excess = UnixStream::connect(&path).unwrap();
-    expect_rejected(&router, RouterReject::Capacity);
-    drop(excess);
-    drop(idle);
-    for _ in 0..MAX_PENDING_REGISTRATIONS {
-        expect_rejected(&router, RouterReject::MalformedFrame);
-    }
-
-    let (uid, gid) = current_ids();
-    let packet = Packet::new(
-        TerminalPacketType::TerminalUserInfo as u8,
-        info(Some(ID), Some(KEY), Some(uid), Some(gid)).encode_to_vec(),
-    );
-    let _terminal = connect_packet(&path, &packet);
-    assert_eq!(
-        router.recv_event_timeout(Duration::from_secs(2)).unwrap(),
-        RouterEvent::Registered { id: ID.to_owned() }
-    );
-    router.shutdown().unwrap();
-}
-
-#[test]
 fn idle_registration_expires_on_monotonic_deadline() {
     let dir = TestDir::new();
     let path = dir.socket();
@@ -432,6 +399,7 @@ fn idle_pending_registration_expires_and_router_remains_live() {
     idle.set_read_timeout(Some(Duration::from_secs(7))).unwrap();
     let mut byte = [0_u8; 1];
     assert_eq!(std::io::Read::read(&mut idle, &mut byte).unwrap(), 0);
+    expect_rejected(&router, RouterReject::Timeout);
 
     let (uid, gid) = peer_identity();
     let packet = Packet::new(

--- a/crates/et-server/tests/runtime_adversarial.rs
+++ b/crates/et-server/tests/runtime_adversarial.rs
@@ -32,10 +32,7 @@ fn bad_encrypted_initial_messages_reset_the_slot() {
         .write_packet(253, &default_payload().encode_to_vec())
         .unwrap();
     assert!(wrong.read_packet().is_err());
-    server
-        .handle
-        .wait_for_state(ID_A, SessionState::Registered, TIMEOUT)
-        .unwrap();
+    assert_eq!(server.handle.session_state(ID_A).unwrap(), None);
 
     for (header, bytes) in [(1, default_payload().encode_to_vec()), (253, vec![0xff])] {
         let (stream, response) = server.handshake(ID_A);
@@ -45,10 +42,7 @@ fn bad_encrypted_initial_messages_reset_the_slot() {
         let packet = client.read_packet().unwrap();
         let response = InitialResponse::decode(packet.payload()).unwrap();
         assert!(response.error.is_some());
-        server
-            .handle
-            .wait_for_state(ID_A, SessionState::Registered, TIMEOUT)
-            .unwrap();
+        assert_eq!(server.handle.session_state(ID_A).unwrap(), None);
     }
     server.runtime.shutdown().unwrap();
 }

--- a/crates/et-server/tests/runtime_adversarial.rs
+++ b/crates/et-server/tests/runtime_adversarial.rs
@@ -52,6 +52,22 @@ fn bad_encrypted_initial_messages_reset_the_slot() {
     server.runtime.shutdown().unwrap();
 }
 
+#[test]
+fn incomplete_initial_payload_expires_and_resets_the_slot() {
+    let mut server = TestRuntime::start();
+    let _terminal = server.register(ID_A, KEY_A);
+    let (mut stream, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    stream.write_all(&[0_u8; 1]).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(9)))
+        .unwrap();
+    let mut byte = [0_u8; 1];
+    assert_eq!(std::io::Read::read(&mut stream, &mut byte).unwrap_or(0), 0);
+    assert_eq!(server.handle.session_state(ID_A).unwrap(), None);
+    server.runtime.shutdown().unwrap();
+}
+
 struct DelayedResolver {
     address: SocketAddr,
     entered: mpsc::SyncSender<()>,
@@ -233,11 +249,15 @@ fn stalled_privileged_tcp_helper_honors_initialization_deadline_and_resets_slot(
         .recv_timeout(Duration::from_secs(8))
         .expect("privileged TCP helper exceeded initialization deadline");
     assert!(started.elapsed() < Duration::from_secs(8));
-    assert!(initial
-        .error
-        .as_deref()
-        .and_then(et_net::forward::decode_forward_timeout)
-        .is_some());
+    assert!(
+        initial
+            .error
+            .as_deref()
+            .and_then(et_net::forward::decode_forward_timeout)
+            .is_some(),
+        "unexpected stalled-helper response: {:?}",
+        initial.error
+    );
     server
         .handle
         .wait_for_state(ID_A, SessionState::Registered, TIMEOUT)
@@ -283,7 +303,7 @@ fn unbindable_reverse_tunnel_reports_an_error_and_resets_the_slot() {
 }
 
 #[test]
-fn occupied_reverse_row_is_reported_while_usable_row_stays_live() {
+fn occupied_reverse_row_is_fatal_and_rolls_back_sibling() {
     let mut server = TestRuntime::start();
     let _terminal = server.register(ID_A, KEY_A);
     let key = passkey_to_key(KEY_A).unwrap();
@@ -308,27 +328,41 @@ fn occupied_reverse_row_is_reported_while_usable_row_stays_live() {
     };
 
     let (stream, _) = server.handshake(ID_A);
-    let (mut client, initial) = runtime_support::initialize(stream, &key, payload);
-    let report = et_net::reverse_report::decode_skipped_rows(initial.error.as_deref().unwrap(), 2)
-        .unwrap()
-        .unwrap();
-
-    assert_eq!(
-        report,
-        [et_net::reverse_report::SkippedRow {
-            index: 0,
-            reason: et_net::reverse_report::SkipReason::Bind,
-        }]
-    );
-    runtime_support::acknowledge_skip_report(&mut client);
-    let usable = std::os::unix::net::UnixStream::connect(&usable_path).unwrap();
-    drop(usable);
+    let (client, initial) = runtime_support::initialize(stream, &key, payload);
+    assert!(initial.error.is_some());
     drop(client);
+    server
+        .handle
+        .wait_for_state(ID_A, SessionState::Registered, TIMEOUT)
+        .unwrap();
+    assert!(!usable_path.exists());
     server.runtime.shutdown().unwrap();
 }
 
 #[test]
-fn unacknowledged_report_releases_sibling_before_activation() {
+fn client_close_before_initial_payload_rolls_back_the_session_claim() {
+    let mut server = TestRuntime::start();
+    let _terminal = server.register(ID_A, KEY_A);
+    let key = passkey_to_key(KEY_A).unwrap();
+    let (stream, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    drop(stream);
+
+    assert_eq!(server.handle.session_state(ID_A).unwrap(), None);
+
+    let (stream, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    let (_client, initial) = runtime_support::initialize(stream, &key, default_payload());
+    assert_eq!(initial.error, None);
+    server
+        .handle
+        .wait_for_state(ID_A, SessionState::Active, TIMEOUT)
+        .unwrap();
+    server.runtime.shutdown().unwrap();
+}
+
+#[test]
+fn reverse_bind_failure_never_activates_the_session() {
     let mut server = TestRuntime::start();
     let _terminal = server.register(ID_A, KEY_A);
     let key = passkey_to_key(KEY_A).unwrap();
@@ -366,26 +400,22 @@ fn unacknowledged_report_releases_sibling_before_activation() {
 }
 
 #[test]
-fn reverse_row_and_report_bounds_are_global_fatal() {
+fn reverse_failures_are_plain_fatal_errors() {
     let cases = [
-        vec![Default::default(); et_net::reverse_report::MAX_REVERSE_ROWS + 1],
-        vec![
-            et_core::proto::PortForwardSourceRequest {
-                source: Some(et_core::proto::SocketEndpoint {
-                    name: Some("a".repeat(256)),
-                    port: Some(1),
-                }),
-                destination: Some(et_core::proto::SocketEndpoint {
-                    name: Some("127.0.0.1".to_owned()),
-                    port: Some(1),
-                }),
-                environmentvariable: None,
-            };
-            et_net::reverse_report::MAX_REVERSE_ROWS
-        ],
+        vec![Default::default()],
+        vec![et_core::proto::PortForwardSourceRequest {
+            source: Some(et_core::proto::SocketEndpoint {
+                name: Some("a".repeat(256)),
+                port: Some(1),
+            }),
+            destination: Some(et_core::proto::SocketEndpoint {
+                name: Some("127.0.0.1".to_owned()),
+                port: Some(1),
+            }),
+            environmentvariable: None,
+        }],
     ];
     for requests in cases {
-        let count = requests.len();
         let mut server = TestRuntime::start();
         let _terminal = server.register(ID_A, KEY_A);
         let key = passkey_to_key(KEY_A).unwrap();
@@ -399,10 +429,7 @@ fn reverse_row_and_report_bounds_are_global_fatal() {
         let (_, initial) = runtime_support::initialize(stream, &key, payload);
 
         let error = initial.error.unwrap();
-        assert_eq!(
-            et_net::reverse_report::decode_skipped_rows(&error, count).unwrap(),
-            None
-        );
+        assert!(!error.starts_with("ETRS-RF-SKIP"));
         server.runtime.shutdown().unwrap();
     }
 }
@@ -445,60 +472,39 @@ fn reverse_listener_cap_is_prebind_transactional_on_server() {
 }
 
 #[test]
-fn hostile_origin_marker_does_not_change_origin_independent_report() {
-    fn run(marker: Option<&str>) -> String {
-        let mut server = TestRuntime::start();
-        let _terminal = server.register(ID_A, KEY_A);
-        let key = passkey_to_key(KEY_A).unwrap();
-        let occupied_path = server.dir.path().join("hostile-origin.sock");
-        let usable_path = server.dir.path().join("hostile-usable.sock");
-        let _occupied = std::os::unix::net::UnixListener::bind(&occupied_path).unwrap();
-        let request = |path: &std::path::Path, environmentvariable: Option<String>| {
-            et_core::proto::PortForwardSourceRequest {
-                source: Some(et_core::proto::SocketEndpoint {
-                    name: Some(path.to_string_lossy().into_owned()),
-                    port: None,
-                }),
-                destination: Some(et_core::proto::SocketEndpoint {
-                    name: Some("/tmp/destination.sock".to_owned()),
-                    port: None,
-                }),
-                environmentvariable,
-            }
-        };
-        let payload = InitialPayload {
-            jumphost: Some(false),
-            reversetunnels: vec![
-                request(&occupied_path, marker.map(str::to_owned)),
-                request(&usable_path, None),
-            ],
-            environmentvariables: HashMap::new(),
-        };
+fn obsolete_origin_marker_has_no_privileged_meaning() {
+    let mut server = TestRuntime::start();
+    let _terminal = server.register(ID_A, KEY_A);
+    let key = passkey_to_key(KEY_A).unwrap();
+    let payload = InitialPayload {
+        jumphost: Some(false),
+        reversetunnels: vec![et_core::proto::PortForwardSourceRequest {
+            source: Some(et_core::proto::SocketEndpoint {
+                name: Some(
+                    server
+                        .dir
+                        .path()
+                        .join("hostile-origin.sock")
+                        .to_string_lossy()
+                        .into(),
+                ),
+                port: None,
+            }),
+            destination: Some(et_core::proto::SocketEndpoint {
+                name: Some("/tmp/destination.sock".to_owned()),
+                port: None,
+            }),
+            environmentvariable: Some("ET_RS_SSH_CONFIG_REMOTE_FORWARD".to_owned()),
+        }],
+        environmentvariables: HashMap::new(),
+    };
 
-        let (stream, _) = server.handshake(ID_A);
-        let (mut client, initial) = runtime_support::initialize(stream, &key, payload);
-        let report = initial.error.unwrap();
-        runtime_support::acknowledge_skip_report(&mut client);
-        let usable = std::os::unix::net::UnixStream::connect(&usable_path).unwrap();
-        drop(usable);
-        drop(client);
-        server.runtime.shutdown().unwrap();
-        report
-    }
-
-    let ordinary = run(None);
-    let hostile = run(Some("ET_RS_SSH_CONFIG_REMOTE_FORWARD"));
-
-    assert_eq!(hostile, ordinary);
-    assert_eq!(
-        et_net::reverse_report::decode_skipped_rows(&hostile, 2)
-            .unwrap()
-            .unwrap(),
-        [et_net::reverse_report::SkippedRow {
-            index: 0,
-            reason: et_net::reverse_report::SkipReason::Bind,
-        }]
-    );
+    let (stream, _) = server.handshake(ID_A);
+    let (_, initial) = runtime_support::initialize(stream, &key, payload);
+    assert!(initial
+        .error
+        .is_some_and(|error| error.contains("Do not set a source")));
+    server.runtime.shutdown().unwrap();
 }
 
 #[test]

--- a/crates/et-server/tests/runtime_adversarial.rs
+++ b/crates/et-server/tests/runtime_adversarial.rs
@@ -4,13 +4,18 @@ mod runtime_support;
 mod support;
 
 use std::collections::HashMap;
-use std::io::Write;
-use std::net::TcpStream;
-use std::time::Duration;
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::sync::{mpsc, Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use et_core::keys::passkey_to_key;
 use et_core::proto::{
     ConnectRequest, ConnectResponse, ConnectStatus, InitialPayload, InitialResponse,
+    PortForwardSourceRequest, SocketEndpoint,
 };
 use et_net::connection::Connection;
 use et_net::framing_io::{read_proto_limited, write_proto};
@@ -47,18 +52,209 @@ fn bad_encrypted_initial_messages_reset_the_slot() {
     server.runtime.shutdown().unwrap();
 }
 
-#[test]
-fn incomplete_initial_payload_expires_and_resets_the_slot() {
-    let mut server = TestRuntime::start();
-    let _terminal = server.register(ID_A, KEY_A);
-    let (mut stream, response) = server.handshake(ID_A);
-    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
-    stream.write_all(&[0_u8; 1]).unwrap();
+struct DelayedResolver {
+    address: SocketAddr,
+    entered: mpsc::SyncSender<()>,
+    release: Mutex<mpsc::Receiver<()>>,
+    finished: mpsc::SyncSender<()>,
+}
 
+impl et_net::forward::ForwardResolver for DelayedResolver {
+    fn resolve(&self, _host: &str, _port: u16) -> std::io::Result<Vec<SocketAddr>> {
+        let _ = self.entered.send(());
+        let _ = self.release.lock().unwrap().recv();
+        let _ = self.finished.send(());
+        Ok(vec![self.address])
+    }
+}
+
+#[test]
+fn delayed_valid_reverse_forward_times_out_rolls_back_and_resets_slot() {
+    let probe = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let address = probe.local_addr().unwrap();
+    drop(probe);
+    let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+    let (release_tx, release_rx) = mpsc::sync_channel(1);
+    let (finished_tx, finished_rx) = mpsc::sync_channel(1);
+    let mut server = TestRuntime::start_with_forward_resolver(Arc::new(DelayedResolver {
+        address,
+        entered: entered_tx,
+        release: Mutex::new(release_rx),
+        finished: finished_tx,
+    }));
+    let _terminal = server.register(ID_A, KEY_A);
+    let key = passkey_to_key(KEY_A).unwrap();
+    let payload = InitialPayload {
+        jumphost: Some(false),
+        reversetunnels: vec![PortForwardSourceRequest {
+            source: Some(SocketEndpoint {
+                name: Some("delayed.valid.test".to_owned()),
+                port: Some(i32::from(address.port())),
+            }),
+            destination: Some(SocketEndpoint {
+                name: Some("localhost".to_owned()),
+                port: Some(1),
+            }),
+            environmentvariable: None,
+        }],
+        environmentvariables: HashMap::new(),
+    };
+    let (stream, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    stream
+        .set_read_timeout(Some(Duration::from_secs(8)))
+        .unwrap();
+    let started = Instant::now();
+    let (initial_tx, initial_rx) = mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let (_, initial) = runtime_support::initialize(stream, &key, payload);
+        let _ = initial_tx.send(initial);
+    });
+    entered_rx.recv_timeout(TIMEOUT).unwrap();
+    let initial = initial_rx.recv_timeout(Duration::from_secs(8)).unwrap();
+    assert!(
+        started.elapsed() < Duration::from_secs(8),
+        "forwarding timeout missed the server initialization deadline"
+    );
+    let encoded = initial.error.as_deref().expect("typed forwarding timeout");
+    assert!(et_net::forward::decode_forward_timeout(encoded).is_some());
     server
         .handle
-        .wait_for_state(ID_A, SessionState::Registered, Duration::from_secs(7))
+        .wait_for_state(ID_A, SessionState::Registered, TIMEOUT)
         .unwrap();
+    // Runtime shutdown must not own or join a resolver currently blocked in
+    // the process-wide bounded executor.
+    server.runtime.shutdown().unwrap();
+    release_tx.send(()).unwrap();
+    finished_rx.recv_timeout(TIMEOUT).unwrap();
+    TcpListener::bind(address).expect("cancelled forwarding setup left a listener behind");
+}
+
+struct StalledTcpHelperResolver {
+    address: SocketAddr,
+    helper: PathBuf,
+}
+
+impl et_net::forward::ForwardResolver for StalledTcpHelperResolver {
+    fn resolve(&self, _host: &str, _port: u16) -> std::io::Result<Vec<SocketAddr>> {
+        Ok(vec![self.address])
+    }
+
+    fn listen_tcp_as_user(
+        &self,
+        address: SocketAddr,
+        uid: u32,
+        gid: u32,
+        deadline: Instant,
+    ) -> std::io::Result<TcpListener> {
+        et_net::user_socket_ops::listen_tcp_as_user_deadline_with_helper(
+            address,
+            uid,
+            gid,
+            deadline,
+            &self.helper,
+        )
+    }
+}
+
+#[test]
+fn stalled_privileged_tcp_helper_honors_initialization_deadline_and_resets_slot() {
+    let probe = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let address = probe.local_addr().unwrap();
+    drop(probe);
+    let helper_dir = support::TestDir::new();
+    let event = helper_dir.path().join("tcp-helper.event");
+    assert!(std::process::Command::new("mkfifo")
+        .arg(&event)
+        .status()
+        .unwrap()
+        .success());
+    let event_control = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&event)
+        .unwrap();
+    let pid_path = helper_dir.path().join("tcp-helper.pid");
+    let helper = helper_dir.path().join("tcp-helper.py");
+    fs::write(
+        &helper,
+        format!(
+            "#!/usr/bin/python3\nimport os, socket\nhost, port = os.environ['ET_RS_USER_SOCKET_PATH'].rsplit(':', 1)\ns = socket.socket(socket.AF_INET)\ns.bind((host, int(port)))\ns.listen(1)\nopen(r'{}', 'w').write(str(os.getpid()))\nopen(r'{}', 'wb').write(b'x')\nos.read(0, 1)\n",
+            pid_path.display(),
+            event.display()
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&helper, fs::Permissions::from_mode(0o700)).unwrap();
+    let mut server = TestRuntime::start_with_forward_resolver(Arc::new(StalledTcpHelperResolver {
+        address,
+        helper: helper.clone(),
+    }));
+    let _terminal = server.register(ID_A, KEY_A);
+    let key = passkey_to_key(KEY_A).unwrap();
+    let payload = InitialPayload {
+        jumphost: Some(false),
+        reversetunnels: vec![PortForwardSourceRequest {
+            source: Some(SocketEndpoint {
+                name: Some("stalled.helper.test".to_owned()),
+                port: Some(i32::from(address.port())),
+            }),
+            destination: Some(SocketEndpoint {
+                name: Some("localhost".to_owned()),
+                port: Some(1),
+            }),
+            environmentvariable: None,
+        }],
+        environmentvariables: HashMap::new(),
+    };
+    let (stream, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    stream
+        .set_read_timeout(Some(Duration::from_secs(8)))
+        .unwrap();
+    let started = Instant::now();
+    let (initial_tx, initial_rx) = mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let (_, initial) = runtime_support::initialize(stream, &key, payload);
+        let _ = initial_tx.send(initial);
+    });
+    let (event_tx, event_rx) = mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let mut event_control = event_control;
+        let mut byte = [0];
+        let result = event_control.read_exact(&mut byte);
+        let _ = event_tx.send(result);
+    });
+    event_rx
+        .recv_timeout(TIMEOUT)
+        .expect("privileged TCP helper did not bind and enter no-reply")
+        .unwrap();
+    let initial = initial_rx
+        .recv_timeout(Duration::from_secs(8))
+        .expect("privileged TCP helper exceeded initialization deadline");
+    assert!(started.elapsed() < Duration::from_secs(8));
+    assert!(initial
+        .error
+        .as_deref()
+        .and_then(et_net::forward::decode_forward_timeout)
+        .is_some());
+    server
+        .handle
+        .wait_for_state(ID_A, SessionState::Registered, TIMEOUT)
+        .unwrap();
+    let pid = fs::read_to_string(pid_path)
+        .unwrap()
+        .trim()
+        .parse()
+        .ok()
+        .and_then(rustix::process::Pid::from_raw)
+        .unwrap();
+    assert_eq!(
+        rustix::process::waitpid(Some(pid), rustix::process::WaitOptions::NOHANG).unwrap_err(),
+        rustix::io::Errno::CHILD,
+        "timed-out privileged helper was not killed and reaped"
+    );
+    TcpListener::bind(address).expect("timed-out privileged helper left a listener behind");
     server.runtime.shutdown().unwrap();
 }
 
@@ -87,7 +283,7 @@ fn unbindable_reverse_tunnel_reports_an_error_and_resets_the_slot() {
 }
 
 #[test]
-fn occupied_reverse_row_is_fatal_and_rolls_back_sibling() {
+fn occupied_reverse_row_is_reported_while_usable_row_stays_live() {
     let mut server = TestRuntime::start();
     let _terminal = server.register(ID_A, KEY_A);
     let key = passkey_to_key(KEY_A).unwrap();
@@ -112,44 +308,27 @@ fn occupied_reverse_row_is_fatal_and_rolls_back_sibling() {
     };
 
     let (stream, _) = server.handshake(ID_A);
-    let (client, initial) = runtime_support::initialize(stream, &key, payload);
-    assert!(initial.error.is_some());
+    let (mut client, initial) = runtime_support::initialize(stream, &key, payload);
+    let report = et_net::reverse_report::decode_skipped_rows(initial.error.as_deref().unwrap(), 2)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        report,
+        [et_net::reverse_report::SkippedRow {
+            index: 0,
+            reason: et_net::reverse_report::SkipReason::Bind,
+        }]
+    );
+    runtime_support::acknowledge_skip_report(&mut client);
+    let usable = std::os::unix::net::UnixStream::connect(&usable_path).unwrap();
+    drop(usable);
     drop(client);
-    server
-        .handle
-        .wait_for_state(ID_A, SessionState::Registered, TIMEOUT)
-        .unwrap();
-    assert!(!usable_path.exists());
     server.runtime.shutdown().unwrap();
 }
 
 #[test]
-fn client_close_before_initial_payload_rolls_back_the_session_claim() {
-    let mut server = TestRuntime::start();
-    let _terminal = server.register(ID_A, KEY_A);
-    let key = passkey_to_key(KEY_A).unwrap();
-    let (stream, response) = server.handshake(ID_A);
-    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
-    drop(stream);
-
-    server
-        .handle
-        .wait_for_state(ID_A, SessionState::Registered, TIMEOUT)
-        .unwrap();
-
-    let (stream, response) = server.handshake(ID_A);
-    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
-    let (_client, initial) = runtime_support::initialize(stream, &key, default_payload());
-    assert_eq!(initial.error, None);
-    server
-        .handle
-        .wait_for_state(ID_A, SessionState::Active, TIMEOUT)
-        .unwrap();
-    server.runtime.shutdown().unwrap();
-}
-
-#[test]
-fn reverse_bind_failure_never_activates_the_session() {
+fn unacknowledged_report_releases_sibling_before_activation() {
     let mut server = TestRuntime::start();
     let _terminal = server.register(ID_A, KEY_A);
     let key = passkey_to_key(KEY_A).unwrap();
@@ -187,22 +366,26 @@ fn reverse_bind_failure_never_activates_the_session() {
 }
 
 #[test]
-fn reverse_failures_are_plain_fatal_errors() {
+fn reverse_row_and_report_bounds_are_global_fatal() {
     let cases = [
-        vec![Default::default()],
-        vec![et_core::proto::PortForwardSourceRequest {
-            source: Some(et_core::proto::SocketEndpoint {
-                name: Some("a".repeat(256)),
-                port: Some(1),
-            }),
-            destination: Some(et_core::proto::SocketEndpoint {
-                name: Some("127.0.0.1".to_owned()),
-                port: Some(1),
-            }),
-            environmentvariable: None,
-        }],
+        vec![Default::default(); et_net::reverse_report::MAX_REVERSE_ROWS + 1],
+        vec![
+            et_core::proto::PortForwardSourceRequest {
+                source: Some(et_core::proto::SocketEndpoint {
+                    name: Some("a".repeat(256)),
+                    port: Some(1),
+                }),
+                destination: Some(et_core::proto::SocketEndpoint {
+                    name: Some("127.0.0.1".to_owned()),
+                    port: Some(1),
+                }),
+                environmentvariable: None,
+            };
+            et_net::reverse_report::MAX_REVERSE_ROWS
+        ],
     ];
     for requests in cases {
+        let count = requests.len();
         let mut server = TestRuntime::start();
         let _terminal = server.register(ID_A, KEY_A);
         let key = passkey_to_key(KEY_A).unwrap();
@@ -216,7 +399,10 @@ fn reverse_failures_are_plain_fatal_errors() {
         let (_, initial) = runtime_support::initialize(stream, &key, payload);
 
         let error = initial.error.unwrap();
-        assert!(!error.starts_with("ETRS-RF-SKIP"));
+        assert_eq!(
+            et_net::reverse_report::decode_skipped_rows(&error, count).unwrap(),
+            None
+        );
         server.runtime.shutdown().unwrap();
     }
 }
@@ -259,39 +445,60 @@ fn reverse_listener_cap_is_prebind_transactional_on_server() {
 }
 
 #[test]
-fn obsolete_origin_marker_has_no_privileged_meaning() {
-    let mut server = TestRuntime::start();
-    let _terminal = server.register(ID_A, KEY_A);
-    let key = passkey_to_key(KEY_A).unwrap();
-    let payload = InitialPayload {
-        jumphost: Some(false),
-        reversetunnels: vec![et_core::proto::PortForwardSourceRequest {
-            source: Some(et_core::proto::SocketEndpoint {
-                name: Some(
-                    server
-                        .dir
-                        .path()
-                        .join("hostile-origin.sock")
-                        .to_string_lossy()
-                        .into(),
-                ),
-                port: None,
-            }),
-            destination: Some(et_core::proto::SocketEndpoint {
-                name: Some("/tmp/destination.sock".to_owned()),
-                port: None,
-            }),
-            environmentvariable: Some("ET_RS_SSH_CONFIG_REMOTE_FORWARD".to_owned()),
-        }],
-        environmentvariables: HashMap::new(),
-    };
+fn hostile_origin_marker_does_not_change_origin_independent_report() {
+    fn run(marker: Option<&str>) -> String {
+        let mut server = TestRuntime::start();
+        let _terminal = server.register(ID_A, KEY_A);
+        let key = passkey_to_key(KEY_A).unwrap();
+        let occupied_path = server.dir.path().join("hostile-origin.sock");
+        let usable_path = server.dir.path().join("hostile-usable.sock");
+        let _occupied = std::os::unix::net::UnixListener::bind(&occupied_path).unwrap();
+        let request = |path: &std::path::Path, environmentvariable: Option<String>| {
+            et_core::proto::PortForwardSourceRequest {
+                source: Some(et_core::proto::SocketEndpoint {
+                    name: Some(path.to_string_lossy().into_owned()),
+                    port: None,
+                }),
+                destination: Some(et_core::proto::SocketEndpoint {
+                    name: Some("/tmp/destination.sock".to_owned()),
+                    port: None,
+                }),
+                environmentvariable,
+            }
+        };
+        let payload = InitialPayload {
+            jumphost: Some(false),
+            reversetunnels: vec![
+                request(&occupied_path, marker.map(str::to_owned)),
+                request(&usable_path, None),
+            ],
+            environmentvariables: HashMap::new(),
+        };
 
-    let (stream, _) = server.handshake(ID_A);
-    let (_, initial) = runtime_support::initialize(stream, &key, payload);
-    assert!(initial
-        .error
-        .is_some_and(|error| error.contains("Do not set a source")));
-    server.runtime.shutdown().unwrap();
+        let (stream, _) = server.handshake(ID_A);
+        let (mut client, initial) = runtime_support::initialize(stream, &key, payload);
+        let report = initial.error.unwrap();
+        runtime_support::acknowledge_skip_report(&mut client);
+        let usable = std::os::unix::net::UnixStream::connect(&usable_path).unwrap();
+        drop(usable);
+        drop(client);
+        server.runtime.shutdown().unwrap();
+        report
+    }
+
+    let ordinary = run(None);
+    let hostile = run(Some("ET_RS_SSH_CONFIG_REMOTE_FORWARD"));
+
+    assert_eq!(hostile, ordinary);
+    assert_eq!(
+        et_net::reverse_report::decode_skipped_rows(&hostile, 2)
+            .unwrap()
+            .unwrap(),
+        [et_net::reverse_report::SkippedRow {
+            index: 0,
+            reason: et_net::reverse_report::SkipReason::Bind,
+        }]
+    );
 }
 
 #[test]

--- a/crates/et-server/tests/runtime_disconnect.rs
+++ b/crates/et-server/tests/runtime_disconnect.rs
@@ -3,13 +3,40 @@
 mod runtime_support;
 mod support;
 
-use std::io::Read;
+use std::io::{self, Read};
+use std::sync::mpsc;
+use std::time::Duration;
 
 use et_core::keys::passkey_to_key;
 use et_core::proto::{ConnectStatus, SequenceHeader};
 use et_net::framing_io::read_proto_limited;
 use et_server::SessionState;
 use runtime_support::{default_payload, initialize, TestRuntime, ID_A, KEY_A, TIMEOUT};
+
+fn assert_prompt_eof_or_reset(stream: &mut std::net::TcpStream) {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .unwrap();
+    let mut byte = [0u8; 1];
+    match stream.read(&mut byte) {
+        Ok(0) => {}
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::ConnectionReset | io::ErrorKind::ConnectionAborted
+            ) => {}
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+            ) =>
+        {
+            panic!("terminal disconnect left initialization socket open: {error}")
+        }
+        Ok(read) => panic!("received {read} unexpected bytes after terminal disconnect"),
+        Err(error) => panic!("unexpected read error after terminal disconnect: {error}"),
+    }
+}
 
 #[test]
 fn terminal_eof_removes_active_session_and_allows_fresh_registration() {
@@ -60,14 +87,13 @@ fn terminal_eof_interrupts_blocked_returning_recovery() {
     let _: SequenceHeader = read_proto_limited(&mut returning, 80 * 1024 * 1024).unwrap();
     drop(terminal);
     server.handle.wait_disconnected(ID_A, TIMEOUT).unwrap();
-    let mut byte = [0u8; 1];
-    assert_eq!(returning.read(&mut byte).unwrap_or(0), 0);
+    assert_prompt_eof_or_reset(&mut returning);
     server.runtime.shutdown().unwrap();
 }
 
 #[test]
 fn terminal_eof_interrupts_an_unauthenticated_initialization() {
-    let mut server = TestRuntime::start();
+    let server = TestRuntime::start();
     let terminal = server.register(ID_A, KEY_A);
     let (mut starting_client, response) = server.handshake(ID_A);
     assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
@@ -75,7 +101,15 @@ fn terminal_eof_interrupts_an_unauthenticated_initialization() {
 
     drop(terminal);
     server.handle.wait_disconnected(ID_A, TIMEOUT).unwrap();
-    let mut byte = [0u8; 1];
-    assert_eq!(starting_client.read(&mut byte).unwrap_or(0), 0);
-    server.runtime.shutdown().unwrap();
+    assert_prompt_eof_or_reset(&mut starting_client);
+
+    let mut runtime = server.runtime;
+    let (shutdown_tx, shutdown_rx) = mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let _ = shutdown_tx.send(runtime.shutdown());
+    });
+    shutdown_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("pre-auth handler and permit were not released promptly")
+        .unwrap();
 }

--- a/crates/et-server/tests/runtime_disconnect.rs
+++ b/crates/et-server/tests/runtime_disconnect.rs
@@ -66,15 +66,12 @@ fn terminal_eof_interrupts_blocked_returning_recovery() {
 }
 
 #[test]
-fn terminal_eof_interrupts_a_starting_session() {
+fn terminal_eof_interrupts_an_unauthenticated_initialization() {
     let mut server = TestRuntime::start();
     let terminal = server.register(ID_A, KEY_A);
     let (mut starting_client, response) = server.handshake(ID_A);
     assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
-    server
-        .handle
-        .wait_for_state(ID_A, SessionState::Starting, TIMEOUT)
-        .unwrap();
+    assert_eq!(server.handle.session_state(ID_A).unwrap(), None);
 
     drop(terminal);
     server.handle.wait_disconnected(ID_A, TIMEOUT).unwrap();

--- a/crates/et-server/tests/runtime_initial.rs
+++ b/crates/et-server/tests/runtime_initial.rs
@@ -4,6 +4,7 @@ mod runtime_support;
 mod support;
 
 use std::thread;
+use std::time::Duration;
 
 use et_core::keys::passkey_to_key;
 use et_core::proto::{ConnectStatus, TerminalPacketType};
@@ -75,6 +76,51 @@ fn successful_initial_response_waits_for_terminal_startup_acknowledgement() {
         .handle
         .wait_for_state(ID_A, SessionState::Active, TIMEOUT)
         .unwrap();
+    server.runtime.shutdown().unwrap();
+}
+
+#[test]
+fn stalled_startup_does_not_block_another_registration() {
+    let mut server = TestRuntime::start();
+    let mut terminal_a = server.register_with_capability(ID_A, KEY_A, true);
+    let (stream, _) = server.handshake(ID_A);
+    let key = passkey_to_key(KEY_A).unwrap();
+    let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let _ = done_tx.send(initialize(stream, &key, default_payload()).1);
+    });
+    let init = read_local_packet(&mut terminal_a).unwrap();
+    assert_eq!(init.header(), TerminalPacketType::TerminalInit as u8);
+
+    let _terminal_b = server.register_with_capability(ID_B, KEY_B, true);
+    assert!(server.handle.wait_registered(ID_B, TIMEOUT).is_ok());
+    assert!(matches!(
+        done_rx.try_recv(),
+        Err(std::sync::mpsc::TryRecvError::Empty)
+    ));
+    write_local_packet(&mut terminal_a, &status_packet(STARTUP_STATUS, Ok(()))).unwrap();
+    assert_eq!(done_rx.recv_timeout(TIMEOUT).unwrap().error, None);
+    server.runtime.shutdown().unwrap();
+}
+
+#[test]
+fn server_startup_deadline_precedes_client_socket_timeout() {
+    let mut server = TestRuntime::start();
+    let mut terminal = server.register_with_capability(ID_A, KEY_A, true);
+    let (stream, _) = server.handshake(ID_A);
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
+    let key = passkey_to_key(KEY_A).unwrap();
+    let started = std::time::Instant::now();
+    let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let _ = done_tx.send(initialize(stream, &key, default_payload()).1);
+    });
+    let _init = read_local_packet(&mut terminal).unwrap();
+    let response = done_rx.recv_timeout(Duration::from_secs(10)).unwrap();
+    assert!(response.error.unwrap().contains("startup acknowledgement"));
+    assert!(started.elapsed() < Duration::from_secs(10));
     server.runtime.shutdown().unwrap();
 }
 

--- a/crates/et-server/tests/runtime_initial.rs
+++ b/crates/et-server/tests/runtime_initial.rs
@@ -6,7 +6,8 @@ mod support;
 use std::thread;
 
 use et_core::keys::passkey_to_key;
-use et_core::proto::ConnectStatus;
+use et_core::proto::{ConnectStatus, TerminalPacketType};
+use et_net::local_packet::{read_local_packet, status_packet, write_local_packet, STARTUP_STATUS};
 use et_server::SessionState;
 use runtime_support::{
     default_payload, initialize, TestRuntime, ID_A, ID_B, KEY_A, KEY_B, TIMEOUT,
@@ -26,6 +27,80 @@ fn real_new_client_completes_encrypted_initialization() {
         .handle
         .wait_for_state(ID_A, SessionState::Active, TIMEOUT)
         .unwrap();
+    server.runtime.shutdown().unwrap();
+}
+
+#[test]
+fn passkeyless_known_id_staller_cannot_starve_legitimate_client() {
+    let mut server = TestRuntime::start();
+    let _terminal = server.register(ID_A, KEY_A);
+    let (mut staller, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+
+    let (stream, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    let key = passkey_to_key(KEY_A).unwrap();
+    let (_client, initial) = initialize(stream, &key, default_payload());
+    assert_eq!(initial.error, None);
+    let mut probe = [0u8; 1];
+    assert_eq!(
+        std::io::Read::read(&mut staller, &mut probe).unwrap_or(0),
+        0
+    );
+    server.runtime.shutdown().unwrap();
+}
+
+#[test]
+fn successful_initial_response_waits_for_terminal_startup_acknowledgement() {
+    let mut server = TestRuntime::start();
+    let mut terminal = server.register_with_capability(ID_A, KEY_A, true);
+    let (stream, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    let key = passkey_to_key(KEY_A).unwrap();
+    let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let result = initialize(stream, &key, default_payload()).1;
+        let _ = done_tx.send(result);
+    });
+
+    let init = read_local_packet(&mut terminal).unwrap();
+    assert_eq!(init.header(), TerminalPacketType::TerminalInit as u8);
+    assert!(matches!(
+        done_rx.try_recv(),
+        Err(std::sync::mpsc::TryRecvError::Empty)
+    ));
+    write_local_packet(&mut terminal, &status_packet(STARTUP_STATUS, Ok(()))).unwrap();
+    assert_eq!(done_rx.recv_timeout(TIMEOUT).unwrap().error, None);
+    server
+        .handle
+        .wait_for_state(ID_A, SessionState::Active, TIMEOUT)
+        .unwrap();
+    server.runtime.shutdown().unwrap();
+}
+
+#[test]
+fn terminal_startup_failure_is_returned_in_initial_response() {
+    let mut server = TestRuntime::start();
+    let mut terminal = server.register_with_capability(ID_A, KEY_A, true);
+    let (stream, _) = server.handshake(ID_A);
+    let key = passkey_to_key(KEY_A).unwrap();
+    let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let _ = done_tx.send(initialize(stream, &key, default_payload()).1);
+    });
+    let _init = read_local_packet(&mut terminal).unwrap();
+    write_local_packet(
+        &mut terminal,
+        &status_packet(STARTUP_STATUS, Err("could not spawn terminal shell")),
+    )
+    .unwrap();
+    let response = done_rx.recv_timeout(TIMEOUT).unwrap();
+    assert!(response
+        .error
+        .unwrap()
+        .contains("could not spawn terminal shell"));
+    server.handle.wait_disconnected(ID_A, TIMEOUT).unwrap();
+    assert_eq!(server.handle.session_state(ID_A).unwrap(), None);
     server.runtime.shutdown().unwrap();
 }
 

--- a/crates/et-server/tests/runtime_recovery.rs
+++ b/crates/et-server/tests/runtime_recovery.rs
@@ -5,6 +5,7 @@ mod support;
 
 use std::sync::mpsc;
 use std::thread;
+use std::time::Instant;
 
 use et_core::keys::passkey_to_key;
 use et_core::proto::{ConnectResponse, ConnectStatus, TerminalPacketType};
@@ -209,13 +210,11 @@ fn repeated_recovery_does_not_let_stale_hup_disconnect_the_new_stream() {
 /// the session mutex. Returning clients then sat behind that lock after
 /// `ReturningClient` and timed out with "bootstrap timed out while recovering".
 ///
-/// Flood the live socket without draining it, then recover on a new stream —
-/// both the soft-disconnect write path and recover must finish within a tight
-/// bound, proving the shipped mutex/write timeout path works end-to-end.
+/// Flood the live socket without draining it, then recover on a new stream.
+/// Completion is awaited through exact bounded events rather than wall-clock
+/// assertions that become flaky under scheduler pressure.
 #[test]
 fn recover_succeeds_while_old_peer_blackholes_writes() {
-    use std::time::Instant;
-
     let mut server = TestRuntime::start();
     let mut terminal = server.register(ID_A, KEY_A);
     terminal.set_read_timeout(Some(TIMEOUT)).unwrap();
@@ -262,7 +261,6 @@ fn recover_succeeds_while_old_peer_blackholes_writes() {
         "socket flood never reached the bounded live-write timeout"
     );
 
-    let recover_started = Instant::now();
     let (returning, response) = server.handshake(ID_A);
     assert_eq!(
         response.status,
@@ -273,11 +271,6 @@ fn recover_succeeds_while_old_peer_blackholes_writes() {
     client
         .write_packet(TerminalPacketType::KeepAlive as u8, &[])
         .unwrap();
-    assert!(
-        recover_started.elapsed() < std::time::Duration::from_secs(8),
-        "recover took {:?} — session mutex still blocked by live write",
-        recover_started.elapsed()
-    );
 
     // Post-recovery traffic must flow on the new stream.
     client

--- a/crates/et-server/tests/runtime_recovery.rs
+++ b/crates/et-server/tests/runtime_recovery.rs
@@ -3,9 +3,11 @@
 mod runtime_support;
 mod support;
 
+use std::net::Shutdown;
+use std::os::unix::net::UnixStream;
 use std::sync::mpsc;
 use std::thread;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use et_core::keys::passkey_to_key;
 use et_core::proto::{ConnectResponse, ConnectStatus, TerminalPacketType};
@@ -15,6 +17,98 @@ use et_net::handshake::client_request;
 use et_net::local_packet::read_local_packet;
 use et_server::SessionState;
 use runtime_support::{default_payload, initialize, TestRuntime, ID_A, KEY_A, TIMEOUT};
+
+// Deadlock watchdog only. Success is driven by exact bridge-generation and
+// terminal-packet events, not by elapsed time.
+const PACKET_EVENT_TIMEOUT: Duration = Duration::from_secs(60);
+const MAX_INTERVENING_PACKETS: usize = 32;
+
+type PacketEvent = Result<Vec<(u8, Vec<u8>)>, String>;
+
+fn subscribe_to_terminal_packet(
+    mut terminal: UnixStream,
+    expected_header: u8,
+    expected_payload: &'static [u8],
+) -> (
+    UnixStream,
+    mpsc::Receiver<PacketEvent>,
+    thread::JoinHandle<()>,
+) {
+    terminal.set_read_timeout(None).unwrap();
+    let control = terminal.try_clone().unwrap();
+    let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+    let (event_tx, event_rx) = mpsc::sync_channel(1);
+    let observer = thread::spawn(move || {
+        ready_tx.send(()).unwrap();
+        let mut intervening = Vec::new();
+        loop {
+            let packet = match read_local_packet(&mut terminal) {
+                Ok(packet) => packet,
+                Err(error) => {
+                    let _ = event_tx.send(Err(format!(
+                        "terminal channel ended before post-recovery packet: {error}"
+                    )));
+                    return;
+                }
+            };
+            if packet.header() == expected_header && packet.payload() == expected_payload {
+                let _ = event_tx.send(Ok(intervening));
+                return;
+            }
+            if packet.header() != TerminalPacketType::TerminalBuffer as u8
+                && packet.header() != TerminalPacketType::TerminalInfo as u8
+            {
+                let _ = event_tx.send(Err(format!(
+                    "unexpected intervening terminal packet header {}",
+                    packet.header()
+                )));
+                return;
+            }
+            intervening.push((packet.header(), packet.payload().to_vec()));
+            if intervening.len() > MAX_INTERVENING_PACKETS {
+                let _ = event_tx.send(Err(
+                    "too many intervening packets before post-recovery traffic".to_owned(),
+                ));
+                return;
+            }
+        }
+    });
+    ready_rx
+        .recv_timeout(TIMEOUT)
+        .expect("terminal packet observer did not subscribe");
+    (control, event_rx, observer)
+}
+
+fn await_terminal_packet(
+    control: UnixStream,
+    events: mpsc::Receiver<PacketEvent>,
+    observer: thread::JoinHandle<()>,
+) -> Vec<(u8, Vec<u8>)> {
+    let event = events.recv_timeout(PACKET_EVENT_TIMEOUT);
+    if event.is_err() {
+        let _ = control.shutdown(Shutdown::Both);
+    }
+    let joined = observer.join();
+    assert!(joined.is_ok(), "terminal packet observer panicked");
+    event
+        .expect("post-recovery terminal packet did not arrive within the bounded event wait")
+        .unwrap_or_else(|error| panic!("post-recovery terminal packet failed: {error}"))
+}
+
+#[test]
+fn terminal_packet_observer_fails_if_recovery_traffic_never_flows() {
+    let (terminal, peer) = UnixStream::pair().unwrap();
+    let (control, events, observer) = subscribe_to_terminal_packet(
+        terminal,
+        TerminalPacketType::TerminalInfo as u8,
+        b"required-packet",
+    );
+    drop(peer);
+    let event = events.recv_timeout(TIMEOUT).unwrap();
+    assert!(event.is_err(), "EOF without the target packet was accepted");
+    drop(control);
+    observer.join().unwrap();
+}
 
 #[test]
 fn same_id_startup_is_newest_wins_then_returning() {
@@ -267,18 +361,42 @@ fn recover_succeeds_while_old_peer_blackholes_writes() {
         Some(ConnectStatus::ReturningClient as i32),
         "expected ReturningClient after blackhole, got {response:?}"
     );
+    let (terminal_control, packet_events, packet_observer) = subscribe_to_terminal_packet(
+        terminal,
+        TerminalPacketType::TerminalInfo as u8,
+        b"after-blackhole",
+    );
+    let bridge_handle = server.handle.clone();
+    let (bridge_ready_tx, bridge_ready_rx) = mpsc::sync_channel(1);
+    let (bridge_tx, bridge_rx) = mpsc::sync_channel(1);
+    let bridge_waiter = thread::spawn(move || {
+        bridge_ready_tx.send(()).unwrap();
+        let result = bridge_handle.wait_for_bridge_generation(ID_A, 1, PACKET_EVENT_TIMEOUT);
+        let _ = bridge_tx.send(result);
+    });
+    bridge_ready_rx
+        .recv_timeout(TIMEOUT)
+        .expect("bridge-generation observer did not subscribe");
+
     client.recover(returning).unwrap();
+    // The first encrypted packet authenticates the candidate and allows the
+    // server to install it. Wait for the bridge's exact generation event after
+    // sending that proof, before sending traffic whose forwarding we assert.
     client
         .write_packet(TerminalPacketType::KeepAlive as u8, &[])
         .unwrap();
+    bridge_rx
+        .recv_timeout(PACKET_EVENT_TIMEOUT)
+        .expect("bridge did not observe the recovered connection")
+        .unwrap();
+    bridge_waiter.join().unwrap();
 
-    // Post-recovery traffic must flow on the new stream.
+    // Post-recovery traffic must flow on the new stream. The terminal observer
+    // is subscribed before this write and classifies any valid replay packet.
     client
         .write_packet(TerminalPacketType::TerminalInfo as u8, b"after-blackhole")
         .unwrap();
-    let forwarded = read_local_packet(&mut terminal).unwrap();
-    assert_eq!(forwarded.header(), TerminalPacketType::TerminalInfo as u8);
-    assert_eq!(forwarded.payload(), b"after-blackhole");
+    let _intervening = await_terminal_packet(terminal_control, packet_events, packet_observer);
     server.runtime.shutdown().unwrap();
 }
 

--- a/crates/et-server/tests/runtime_recovery.rs
+++ b/crates/et-server/tests/runtime_recovery.rs
@@ -3,7 +3,7 @@
 mod runtime_support;
 mod support;
 
-use std::sync::{mpsc, Arc, Barrier};
+use std::sync::mpsc;
 use std::thread;
 
 use et_core::keys::passkey_to_key;
@@ -16,46 +16,31 @@ use et_server::SessionState;
 use runtime_support::{default_payload, initialize, TestRuntime, ID_A, KEY_A, TIMEOUT};
 
 #[test]
-fn simultaneous_same_id_is_new_then_serialized_returning() {
+fn same_id_startup_is_newest_wins_then_returning() {
     let mut server = TestRuntime::start();
     let _terminal = server.register(ID_A, KEY_A);
-    let barrier = Arc::new(Barrier::new(3));
-    let (sender, receiver) = mpsc::channel();
+    let (mut stale, stale_response) = server.handshake(ID_A);
+    assert_eq!(stale_response.status, Some(ConnectStatus::NewClient as i32));
 
-    let mut workers = Vec::new();
-    for _ in 0..2 {
-        let barrier = barrier.clone();
-        let sender = sender.clone();
-        let address = server.address;
-        workers.push(thread::spawn(move || {
-            let mut stream = std::net::TcpStream::connect(address).unwrap();
-            runtime_support::bound(&stream);
-            barrier.wait();
-            write_proto(&mut stream, &client_request(ID_A)).unwrap();
-            let response: ConnectResponse = read_proto_limited(&mut stream, 64 * 1024).unwrap();
-            sender.send((stream, response)).unwrap();
-        }));
-    }
-    barrier.wait();
-    let (first_stream, first_response) = receiver.recv_timeout(TIMEOUT).unwrap();
-    assert_eq!(first_response.status, Some(ConnectStatus::NewClient as i32));
+    let (new_stream, new_response) = server.handshake(ID_A);
+    assert_eq!(new_response.status, Some(ConnectStatus::NewClient as i32));
+    let mut probe = [0u8; 1];
+    assert_eq!(std::io::Read::read(&mut stale, &mut probe).unwrap_or(0), 0);
+
     let key = passkey_to_key(KEY_A).unwrap();
-    let (mut client, initial) = initialize(first_stream, &key, default_payload());
+    let (mut client, initial) = initialize(new_stream, &key, default_payload());
     assert_eq!(initial.error, None);
     server
         .handle
         .wait_for_state(ID_A, SessionState::Active, TIMEOUT)
         .unwrap();
 
-    let (returning_stream, response) = receiver.recv_timeout(TIMEOUT).unwrap();
+    let (returning_stream, response) = server.handshake(ID_A);
     assert_eq!(response.status, Some(ConnectStatus::ReturningClient as i32));
     client.recover(returning_stream).unwrap();
     client
         .write_packet(TerminalPacketType::KeepAlive as u8, &[])
         .unwrap();
-    for worker in workers {
-        worker.join().unwrap();
-    }
     server.runtime.shutdown().unwrap();
 }
 

--- a/crates/et-server/tests/runtime_support/mod.rs
+++ b/crates/et-server/tests/runtime_support/mod.rs
@@ -12,7 +12,9 @@ use et_core::proto::{
 use et_net::connection::Connection;
 use et_net::framing_io::{read_proto_limited, write_proto};
 use et_net::handshake::client_request;
-use et_net::local_packet::write_local_packet;
+use et_net::local_packet::{
+    parse_status, read_local_packet, write_local_packet, REGISTRATION_STATUS,
+};
 use et_server::path::select_router_path_for;
 use et_server::{Runtime, RuntimeHandle};
 use prost::Message;
@@ -50,6 +52,15 @@ impl TestRuntime {
     }
 
     pub fn register(&self, id: &str, passkey: &str) -> UnixStream {
+        self.register_with_capability(id, passkey, false)
+    }
+
+    pub fn register_with_capability(
+        &self,
+        id: &str,
+        passkey: &str,
+        startup_ack: bool,
+    ) -> UnixStream {
         let mut stream = UnixStream::connect(self.dir.socket()).unwrap();
         let uid = i64::from(rustix::process::getuid().as_raw());
         let gid = i64::from(rustix::process::getgid().as_raw());
@@ -58,13 +69,15 @@ impl TestRuntime {
             passkey: Some(passkey.to_owned()),
             uid: Some(uid),
             gid: Some(gid),
-            fd: None,
+            fd: startup_ack.then_some(-6),
         };
         let packet = Packet::new(
             TerminalPacketType::TerminalUserInfo as u8,
             user.encode_to_vec(),
         );
         write_local_packet(&mut stream, &packet).unwrap();
+        let acknowledgement = read_local_packet(&mut stream).unwrap();
+        parse_status(&acknowledgement, REGISTRATION_STATUS).unwrap();
         self.handle.wait_registered(id, TIMEOUT).unwrap();
         stream
     }

--- a/crates/et-server/tests/runtime_support/mod.rs
+++ b/crates/et-server/tests/runtime_support/mod.rs
@@ -76,8 +76,10 @@ impl TestRuntime {
             user.encode_to_vec(),
         );
         write_local_packet(&mut stream, &packet).unwrap();
-        let acknowledgement = read_local_packet(&mut stream).unwrap();
-        parse_status(&acknowledgement, REGISTRATION_STATUS).unwrap();
+        if startup_ack {
+            let acknowledgement = read_local_packet(&mut stream).unwrap();
+            parse_status(&acknowledgement, REGISTRATION_STATUS).unwrap();
+        }
         self.handle.wait_registered(id, TIMEOUT).unwrap();
         stream
     }

--- a/crates/et-server/tests/runtime_support/mod.rs
+++ b/crates/et-server/tests/runtime_support/mod.rs
@@ -36,11 +36,25 @@ pub struct TestRuntime {
 
 impl TestRuntime {
     pub fn start() -> Self {
+        Self::start_with_forward_resolver(std::sync::Arc::new(
+            et_net::forward::SystemForwardResolver,
+        ))
+    }
+
+    pub fn start_with_forward_resolver(
+        resolver: std::sync::Arc<dyn et_net::forward::ForwardResolver>,
+    ) -> Self {
         let dir = TestDir::new();
         let path = dir.socket();
         let uid = rustix::process::getuid().as_raw();
         let selected = select_router_path_for(uid, Some(&path), None, None).unwrap();
-        let runtime = Runtime::start(IpAddr::V4(Ipv4Addr::LOCALHOST), 0, selected).unwrap();
+        let runtime = Runtime::start_with_forward_resolver(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            0,
+            selected,
+            resolver,
+        )
+        .unwrap();
         let handle = runtime.handle();
         let address = runtime.tcp_addresses()[0];
         Self {


### PR DESCRIPTION
## Summary
- extend the detached terminal readiness deadline for heavily loaded hosts
- surface terminal child startup failures immediately through captured stderr
- add a regression test for missing-router startup failures

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo build --workspace
- cargo test --workspace -- --test-threads=1
- live high-load ET session QA at load average 73.93/146.16/162.21

## Operational evidence
- missing router error returns in 0.02s instead of the former 10s generic timeout
- new ET command session completed in 3.66s under severe host pressure

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Terminal startup now uses an authenticated, bounded two-phase handshake, so loaded hosts can finish initializing without reporting success before the relayer is ready.

**Startup lifecycle**

- Registration and PTY/relay readiness use separate acknowledgements over an inherited control channel.
- Unix peer credentials validate registration identity; pending registrations cap at 64 and expire after 5 seconds.
- New clients can replace stalled or passkey-less peers instead of waiting behind them.
- Session admission is serialized; the server rejects concurrent initialization of the same terminal.
- Daemon mode returns only after the child confirms runtime readiness; child failures surface as typed errors instead of an unclassified EOF.
- Bootstrap SSH waits up to 120 seconds, while missing routers still return captured errors immediately.

**Bounded cleanup and portability**

- Forwarding, DNS resolution, output draining, listener generations, and saturated worker shutdown are bounded or cancelled when startup goes stale.
- Detached children use `setsid` on Unix and an explicit handle allowlist with job breakaway on Windows.
- Startup and teardown are serialized, with regression coverage for admission, startup failures, disconnects, and recovery; scheduler-dependent fixtures were removed.
- macOS CI builds the socket helper before unit tests, and the macOS socket path limit is 104.

<sup>Written for commit f186512cd88be1db11b591732559bcc86dd56d33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

