### PR TITLE
feat(client): apply SSH config port forwarding

### DIFF
--- a/.tegami/add-ssh-config-forwarding.md
+++ b/.tegami/add-ssh-config-forwarding.md
@@ -1,0 +1,11 @@
+---
+packages:
+  et:
+    type: patch
+---
+
+## Apply SSH configuration port forwarding
+
+The client now reads effective `LocalForward` and `RemoteForward` entries from
+OpenSSH configuration and applies them as ET tunnels when matching command-line
+tunnel options are not provided.

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -87,14 +87,8 @@ fn run_client(
 ) -> Result<(), ClientError> {
     let destination = parse_positional_host(&args.host, args.port)?;
     validate_bootstrap_mode(args)?;
-    let forward_config =
+    let mut forward_config =
         crate::forward_config::build(args, std::env::var("SSH_AUTH_SOCK").ok().as_deref())?;
-    let has_forwarding = !forward_config.local_sources.is_empty()
-        || !forward_config.initial_payload.reversetunnels.is_empty();
-    // Bind local sources only after the encrypted session exists so accepted
-    // tunnels can be multiplexed immediately (avoids pre-handshake accept races).
-    let local_sources = forward_config.local_sources;
-    let mut initial_payload = forward_config.initial_payload;
     let local_term = std::env::var("TERM").ok();
     let local_colorterm = std::env::var("COLORTERM").ok();
     let term = normalize_terminal_type(local_term.as_deref());
@@ -105,12 +99,14 @@ fn run_client(
         .then(|| ghostty_colorterm(local_term.as_deref(), local_colorterm.as_deref()))
         .flatten();
     let reserved_environment = reserved_environment_value_lengths(
-        initial_payload
+        forward_config
+            .initial_payload
             .environmentvariables
             .iter()
             .map(|(name, value)| (name.as_str(), value.len())),
         colorterm,
-        initial_payload
+        forward_config
+            .initial_payload
             .reversetunnels
             .iter()
             .filter_map(|request| request.environmentvariable.as_deref()),
@@ -127,8 +123,12 @@ fn run_client(
         bounded_locale_environment(ssh_locale_environment(), &reserved_environment)
             .map_err(crate::forward_config::ForwardConfigError::EnvironmentPacketTooLarge)?;
     if args.jumphost.is_some() {
-        bound_jumphost_locale_environment(&initial_payload, &mut locale_environment, colorterm)
-            .map_err(crate::forward_config::ForwardConfigError::JumphostPacketTooLarge)?;
+        bound_jumphost_locale_environment(
+            &forward_config.initial_payload,
+            &mut locale_environment,
+            colorterm,
+        )
+        .map_err(crate::forward_config::ForwardConfigError::JumphostPacketTooLarge)?;
     }
 
     let requested_user = command_user(destination.user, args.username.clone());
@@ -140,6 +140,21 @@ fn run_client(
         &args.ssh_option,
         deadline,
     )?;
+    forward_config.apply_ssh_config(args, &resolved)?;
+    if args.jumphost.is_some() {
+        bound_jumphost_locale_environment(
+            &forward_config.initial_payload,
+            &mut locale_environment,
+            colorterm,
+        )
+        .map_err(crate::forward_config::ForwardConfigError::JumphostPacketTooLarge)?;
+    }
+    let has_forwarding = !forward_config.local_sources.is_empty()
+        || !forward_config.initial_payload.reversetunnels.is_empty();
+    // Bind local sources only after the encrypted session exists so accepted
+    // tunnels can be multiplexed immediately (avoids pre-handshake accept races).
+    let local_sources = forward_config.local_sources;
+    let mut initial_payload = forward_config.initial_payload;
     let user = requested_user.or(resolved.user);
     validate_ssh_destination(&destination.host, user.as_deref())?;
     let probe_request = BootstrapRequest {

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -138,6 +138,8 @@ fn run_client(
         &destination.host,
         requested_user.as_deref(),
         &args.ssh_option,
+        args.tunnel.is_empty(),
+        args.reverse_tunnel.is_empty(),
         deadline,
     )?;
     forward_config.apply_ssh_config(args, &resolved)?;
@@ -228,8 +230,15 @@ fn run_client(
             .to_owned();
         let jump_user = Some(parsed_jump.user.as_str()).filter(|user| !user.is_empty());
         validate_ssh_destination(&jump_host, jump_user)?;
-        let jump_resolved =
-            resolve_ssh_config(runner, &jump_host, jump_user, &args.ssh_option, deadline)?;
+        let jump_resolved = resolve_ssh_config(
+            runner,
+            &jump_host,
+            jump_user,
+            &args.ssh_option,
+            false,
+            false,
+            deadline,
+        )?;
         let jump_request = JumpBootstrapRequest {
             jumphost: jumphost.to_owned(),
             destination_host: endpoint.host.clone(),

--- a/crates/et-bin/src/error.rs
+++ b/crates/et-bin/src/error.rs
@@ -19,6 +19,10 @@ pub enum ClientError {
     SshNonZero(Option<i32>),
     SshOutputTooLarge(usize),
     SshConfigMalformed(&'static str),
+    SshConfigMalformedForward {
+        directive: &'static str,
+        reason: &'static str,
+    },
     MissingIdPasskeyMarker,
     MalformedIdPasskeyMarker,
     InvalidSessionId,
@@ -86,6 +90,9 @@ impl std::fmt::Display for ClientError {
             }
             Self::SshConfigMalformed(field) => {
                 write!(f, "system ssh -G output has no valid {field}")
+            }
+            Self::SshConfigMalformedForward { directive, reason } => {
+                write!(f, "system ssh -G output has a malformed {directive} record: {reason}")
             }
             Self::MissingIdPasskeyMarker => {
                 write!(f, "system ssh output is missing the IDPASSKEY marker")
@@ -178,7 +185,9 @@ impl ClientError {
 
     pub fn exit_code(&self) -> i32 {
         match self {
-            Self::Unsupported(_) | Self::ForwardConfig(_) => 2,
+            Self::Unsupported(_)
+            | Self::ForwardConfig(_)
+            | Self::SshConfigMalformedForward { .. } => 2,
             _ => 1,
         }
     }

--- a/crates/et-bin/src/forward_config.rs
+++ b/crates/et-bin/src/forward_config.rs
@@ -4,6 +4,7 @@ use et_cli::client::ClientArgs;
 use et_cli::tunnel::parse_tunnels;
 use et_core::proto::{InitialPayload, PortForwardSourceRequest, SocketEndpoint};
 
+use crate::ssh_config::ResolvedSshConfig;
 use crate::terminal_protocol::{valid_environment_name, MAX_ENVIRONMENT};
 
 #[derive(Debug)]
@@ -70,6 +71,24 @@ impl From<et_cli::tunnel::TunnelError> for ForwardConfigError {
 pub struct ForwardConfig {
     pub local_sources: Vec<PortForwardSourceRequest>,
     pub initial_payload: InitialPayload,
+}
+
+impl ForwardConfig {
+    pub fn apply_ssh_config(
+        &mut self,
+        args: &ClientArgs,
+        resolved: &ResolvedSshConfig,
+    ) -> Result<(), ForwardConfigError> {
+        if args.tunnel.is_empty() {
+            self.local_sources = parse_tunnels(&resolved.local_forwards)?;
+        }
+        if args.reverse_tunnel.is_empty() {
+            let mut configured = parse_tunnels(&resolved.remote_forwards)?;
+            configured.append(&mut self.initial_payload.reversetunnels);
+            self.initial_payload.reversetunnels = configured;
+        }
+        validate_environment_names(&self.initial_payload.reversetunnels)
+    }
 }
 
 pub fn build(

--- a/crates/et-bin/src/forward_config.rs
+++ b/crates/et-bin/src/forward_config.rs
@@ -80,10 +80,10 @@ impl ForwardConfig {
         resolved: &ResolvedSshConfig,
     ) -> Result<(), ForwardConfigError> {
         if args.tunnel.is_empty() {
-            self.local_sources = parse_tunnels(&resolved.local_forwards)?;
+            self.local_sources.clone_from(&resolved.local_forwards);
         }
         if args.reverse_tunnel.is_empty() {
-            let mut configured = parse_tunnels(&resolved.remote_forwards)?;
+            let mut configured = resolved.remote_forwards.clone();
             configured.append(&mut self.initial_payload.reversetunnels);
             self.initial_payload.reversetunnels = configured;
         }

--- a/crates/et-bin/src/forward_config_tests.rs
+++ b/crates/et-bin/src/forward_config_tests.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 use et_cli::client::ClientArgs;
 
+use crate::ssh_config::ResolvedSshConfig;
+
 use super::*;
 
 #[test]
@@ -49,4 +51,33 @@ fn agent_forwarding_falls_back_to_environment_and_requires_a_socket() {
         build(&args, None),
         Err(ForwardConfigError::MissingAgentSocket)
     ));
+}
+
+#[test]
+fn ssh_config_reverse_forwards_preserve_agent_forwarding() {
+    let args = ClientArgs::try_parse_from(["et", "host", "--forward-ssh-agent"]).unwrap();
+    let mut config = build(&args, Some("/run/agent.sock")).unwrap();
+    let resolved = ResolvedSshConfig {
+        hostname: "host".to_owned(),
+        user: None,
+        local_forwards: Vec::new(),
+        remote_forwards: vec!["localhost:1492:[127.0.0.1]:1492".to_owned()],
+    };
+
+    config.apply_ssh_config(&args, &resolved).unwrap();
+
+    assert_eq!(config.initial_payload.reversetunnels.len(), 2);
+    assert_eq!(
+        config.initial_payload.reversetunnels[0]
+            .source
+            .as_ref()
+            .and_then(|source| source.port),
+        Some(1492)
+    );
+    assert_eq!(
+        config.initial_payload.reversetunnels[1]
+            .environmentvariable
+            .as_deref(),
+        Some("SSH_AUTH_SOCK")
+    );
 }

--- a/crates/et-bin/src/forward_config_tests.rs
+++ b/crates/et-bin/src/forward_config_tests.rs
@@ -61,7 +61,17 @@ fn ssh_config_reverse_forwards_preserve_agent_forwarding() {
         hostname: "host".to_owned(),
         user: None,
         local_forwards: Vec::new(),
-        remote_forwards: vec!["localhost:1492:[127.0.0.1]:1492".to_owned()],
+        remote_forwards: vec![PortForwardSourceRequest {
+            source: Some(SocketEndpoint {
+                name: Some("localhost".to_owned()),
+                port: Some(1492),
+            }),
+            destination: Some(SocketEndpoint {
+                name: Some("127.0.0.1".to_owned()),
+                port: Some(1492),
+            }),
+            environmentvariable: None,
+        }],
     };
 
     config.apply_ssh_config(&args, &resolved).unwrap();

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -17,6 +17,8 @@ pub fn resolve_ssh_config(
     host_alias: &str,
     requested_user: Option<&str>,
     ssh_options: &[String],
+    parse_local_forwards: bool,
+    parse_remote_forwards: bool,
     deadline: Deadline,
 ) -> Result<ResolvedSshConfig, ClientError> {
     validate_ssh_destination(host_alias, requested_user)?;
@@ -36,10 +38,18 @@ pub fn resolve_ssh_config(
         operation: "resolving SSH configuration",
         completion: InvocationCompletion::Exit,
     };
-    parse_ssh_config(&run_checked(runner, &invocation, deadline)?)
+    parse_ssh_config(
+        &run_checked(runner, &invocation, deadline)?,
+        parse_local_forwards,
+        parse_remote_forwards,
+    )
 }
 
-fn parse_ssh_config(stdout: &[u8]) -> Result<ResolvedSshConfig, ClientError> {
+fn parse_ssh_config(
+    stdout: &[u8],
+    parse_local_forwards: bool,
+    parse_remote_forwards: bool,
+) -> Result<ResolvedSshConfig, ClientError> {
     let text =
         std::str::from_utf8(stdout).map_err(|_| ClientError::SshConfigMalformed("UTF-8 output"))?;
     let mut hostname = None;
@@ -55,10 +65,10 @@ fn parse_ssh_config(stdout: &[u8]) -> Result<ResolvedSshConfig, ClientError> {
             Some(key) if key.eq_ignore_ascii_case("user") => {
                 user = fields.next().map(str::to_string);
             }
-            Some(key) if key.eq_ignore_ascii_case("localforward") => {
+            Some(key) if parse_local_forwards && key.eq_ignore_ascii_case("localforward") => {
                 local_forwards.push(parse_forward(fields, "localforward")?);
             }
-            Some(key) if key.eq_ignore_ascii_case("remoteforward") => {
+            Some(key) if parse_remote_forwards && key.eq_ignore_ascii_case("remoteforward") => {
                 remote_forwards.push(parse_forward(fields, "remoteforward")?);
             }
             _ => {}
@@ -196,6 +206,8 @@ mod tests {
             "server-alias",
             Some("requested"),
             &["Port=2222".to_string()],
+            true,
+            true,
             Deadline::after(Duration::from_secs(1)),
         )
         .unwrap();
@@ -213,11 +225,11 @@ mod tests {
     #[test]
     fn malformed_and_option_like_values_are_rejected() {
         assert!(matches!(
-            parse_ssh_config(b"user somebody\n"),
+            parse_ssh_config(b"user somebody\n", true, true),
             Err(ClientError::SshConfigMalformed("hostname"))
         ));
         assert!(matches!(
-            parse_ssh_config(b"hostname host\nuser -oProxyCommand=bad\n"),
+            parse_ssh_config(b"hostname host\nuser -oProxyCommand=bad\n", true, true),
             Err(ClientError::InvalidSshComponent("user"))
         ));
     }
@@ -232,6 +244,8 @@ mod tests {
               localforward /tmp/mixed.sock [127.0.0.1]:8080\n\
               localforward [127.0.0.1]:9090 /tmp/destination.sock\n\
               remoteforward 1492 [127.0.0.1]:1492\n",
+            true,
+            true,
         )
         .unwrap();
 
@@ -261,7 +275,7 @@ mod tests {
             ),
         ] {
             assert!(matches!(
-                parse_ssh_config(config.as_bytes()),
+                parse_ssh_config(config.as_bytes(), true, true),
                 Err(ClientError::SshConfigMalformedForward {
                     directive: found,
                     reason: "expected exactly two fields",

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -2,13 +2,14 @@ use crate::bootstrap::{validate_ssh_destination, InvocationCompletion, SshInvoca
 use crate::deadline::Deadline;
 use crate::error::ClientError;
 use crate::ssh_process::{run_checked, SshRunner};
+use et_core::proto::{PortForwardSourceRequest, SocketEndpoint};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ResolvedSshConfig {
     pub hostname: String,
     pub user: Option<String>,
-    pub local_forwards: Vec<String>,
-    pub remote_forwards: Vec<String>,
+    pub local_forwards: Vec<PortForwardSourceRequest>,
+    pub remote_forwards: Vec<PortForwardSourceRequest>,
 }
 
 pub fn resolve_ssh_config(
@@ -55,10 +56,10 @@ fn parse_ssh_config(stdout: &[u8]) -> Result<ResolvedSshConfig, ClientError> {
                 user = fields.next().map(str::to_string);
             }
             Some(key) if key.eq_ignore_ascii_case("localforward") => {
-                local_forwards.push(parse_forward(fields));
+                local_forwards.push(parse_forward(fields, "localforward")?);
             }
             Some(key) if key.eq_ignore_ascii_case("remoteforward") => {
-                remote_forwards.push(parse_forward(fields));
+                remote_forwards.push(parse_forward(fields, "remoteforward")?);
             }
             _ => {}
         }
@@ -76,16 +77,83 @@ fn parse_ssh_config(stdout: &[u8]) -> Result<ResolvedSshConfig, ClientError> {
     })
 }
 
-fn parse_forward<'a>(fields: impl Iterator<Item = &'a str>) -> String {
+fn parse_forward<'a>(
+    fields: impl Iterator<Item = &'a str>,
+    directive: &'static str,
+) -> Result<PortForwardSourceRequest, ClientError> {
     let fields: Vec<&str> = fields.collect();
     let [source, destination] = fields.as_slice() else {
-        return fields.join(" ");
+        return Err(ClientError::SshConfigMalformedForward {
+            directive,
+            reason: "expected exactly two fields",
+        });
     };
-    if source.starts_with('/') || destination.starts_with('/') || source.contains(':') {
-        format!("{source}:{destination}")
-    } else {
-        format!("localhost:{source}:{destination}")
+    let source = parse_source_endpoint(source).ok_or(ClientError::SshConfigMalformedForward {
+        directive,
+        reason: "invalid source endpoint",
+    })?;
+    let destination =
+        parse_destination_endpoint(destination).ok_or(ClientError::SshConfigMalformedForward {
+            directive,
+            reason: "invalid destination endpoint",
+        })?;
+    Ok(PortForwardSourceRequest {
+        source: Some(source),
+        destination: Some(destination),
+        environmentvariable: None,
+    })
+}
+
+fn parse_source_endpoint(value: &str) -> Option<SocketEndpoint> {
+    if let Some(endpoint) = parse_unix_endpoint(value) {
+        return Some(endpoint);
     }
+    if !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Some(SocketEndpoint {
+            name: Some("localhost".to_owned()),
+            port: Some(parse_port(value)?),
+        });
+    }
+    parse_tcp_endpoint(value)
+}
+
+fn parse_destination_endpoint(value: &str) -> Option<SocketEndpoint> {
+    parse_unix_endpoint(value).or_else(|| parse_tcp_endpoint(value))
+}
+
+fn parse_unix_endpoint(value: &str) -> Option<SocketEndpoint> {
+    if !value.starts_with('/') || value == "/" || value.len() > 107 || value.contains('\0') {
+        return None;
+    }
+    Some(SocketEndpoint {
+        name: Some(value.to_owned()),
+        port: None,
+    })
+}
+
+fn parse_tcp_endpoint(value: &str) -> Option<SocketEndpoint> {
+    let (host, port) = if let Some(bracketed) = value.strip_prefix('[') {
+        let (host, port) = bracketed.split_once("]:")?;
+        if host.is_empty() || port.contains(':') {
+            return None;
+        }
+        (host, port)
+    } else {
+        let (host, port) = value.rsplit_once(':')?;
+        if host.is_empty() || host.contains(':') {
+            return None;
+        }
+        (host, port)
+    };
+    Some(SocketEndpoint {
+        name: Some(host.to_owned()),
+        port: Some(parse_port(port)?),
+    })
+}
+
+fn parse_port(value: &str) -> Option<i32> {
+    let port = value.parse::<u16>().ok()?;
+    (port != 0).then(|| i32::from(port))
 }
 
 #[cfg(test)]
@@ -155,12 +223,14 @@ mod tests {
     }
 
     #[test]
-    fn parses_ordered_tcp_ipv6_and_unix_forwards() {
+    fn parses_ordered_tcp_ipv6_unix_and_mixed_forwards() {
         let resolved = parse_ssh_config(
             b"hostname host\n\
               localforward 10022 [127.0.0.1]:22\n\
               localforward [::1]:18080 [::1]:80\n\
               localforward /tmp/local.sock /tmp/remote.sock\n\
+              localforward /tmp/mixed.sock [127.0.0.1]:8080\n\
+              localforward [127.0.0.1]:9090 /tmp/destination.sock\n\
               remoteforward 1492 [127.0.0.1]:1492\n",
         )
         .unwrap();
@@ -168,14 +238,54 @@ mod tests {
         assert_eq!(
             resolved.local_forwards,
             [
-                "localhost:10022:[127.0.0.1]:22",
-                "[::1]:18080:[::1]:80",
-                "/tmp/local.sock:/tmp/remote.sock",
+                request("localhost", Some(10022), "127.0.0.1", Some(22)),
+                request("::1", Some(18080), "::1", Some(80)),
+                request("/tmp/local.sock", None, "/tmp/remote.sock", None),
+                request("/tmp/mixed.sock", None, "127.0.0.1", Some(8080)),
+                request("127.0.0.1", Some(9090), "/tmp/destination.sock", None,),
             ]
         );
         assert_eq!(
             resolved.remote_forwards,
-            ["localhost:1492:[127.0.0.1]:1492"]
+            [request("localhost", Some(1492), "127.0.0.1", Some(1492))]
         );
+    }
+
+    #[test]
+    fn rejects_forward_records_without_exactly_two_fields() {
+        for (config, directive) in [
+            ("hostname host\nlocalforward only-one\n", "localforward"),
+            (
+                "hostname host\nremoteforward 1000 host:2000 extra\n",
+                "remoteforward",
+            ),
+        ] {
+            assert!(matches!(
+                parse_ssh_config(config.as_bytes()),
+                Err(ClientError::SshConfigMalformedForward {
+                    directive: found,
+                    reason: "expected exactly two fields",
+                }) if found == directive
+            ));
+        }
+    }
+
+    fn request(
+        source_name: &str,
+        source_port: Option<i32>,
+        destination_name: &str,
+        destination_port: Option<i32>,
+    ) -> PortForwardSourceRequest {
+        PortForwardSourceRequest {
+            source: Some(SocketEndpoint {
+                name: Some(source_name.to_owned()),
+                port: source_port,
+            }),
+            destination: Some(SocketEndpoint {
+                name: Some(destination_name.to_owned()),
+                port: destination_port,
+            }),
+            environmentvariable: None,
+        }
     }
 }

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -7,6 +7,8 @@ use crate::ssh_process::{run_checked, SshRunner};
 pub struct ResolvedSshConfig {
     pub hostname: String,
     pub user: Option<String>,
+    pub local_forwards: Vec<String>,
+    pub remote_forwards: Vec<String>,
 }
 
 pub fn resolve_ssh_config(
@@ -41,6 +43,8 @@ fn parse_ssh_config(stdout: &[u8]) -> Result<ResolvedSshConfig, ClientError> {
         std::str::from_utf8(stdout).map_err(|_| ClientError::SshConfigMalformed("UTF-8 output"))?;
     let mut hostname = None;
     let mut user = None;
+    let mut local_forwards = Vec::new();
+    let mut remote_forwards = Vec::new();
     for line in text.lines() {
         let mut fields = line.split_whitespace();
         match fields.next() {
@@ -50,6 +54,12 @@ fn parse_ssh_config(stdout: &[u8]) -> Result<ResolvedSshConfig, ClientError> {
             Some(key) if key.eq_ignore_ascii_case("user") => {
                 user = fields.next().map(str::to_string);
             }
+            Some(key) if key.eq_ignore_ascii_case("localforward") => {
+                local_forwards.push(parse_forward(fields));
+            }
+            Some(key) if key.eq_ignore_ascii_case("remoteforward") => {
+                remote_forwards.push(parse_forward(fields));
+            }
             _ => {}
         }
     }
@@ -58,7 +68,24 @@ fn parse_ssh_config(stdout: &[u8]) -> Result<ResolvedSshConfig, ClientError> {
         .ok_or(ClientError::SshConfigMalformed("hostname"))?;
     let user = user.filter(|user| !user.is_empty());
     validate_ssh_destination(&hostname, user.as_deref())?;
-    Ok(ResolvedSshConfig { hostname, user })
+    Ok(ResolvedSshConfig {
+        hostname,
+        user,
+        local_forwards,
+        remote_forwards,
+    })
+}
+
+fn parse_forward<'a>(fields: impl Iterator<Item = &'a str>) -> String {
+    let fields: Vec<&str> = fields.collect();
+    let [source, destination] = fields.as_slice() else {
+        return fields.join(" ");
+    };
+    if source.starts_with('/') || destination.starts_with('/') || source.contains(':') {
+        format!("{source}:{destination}")
+    } else {
+        format!("localhost:{source}:{destination}")
+    }
 }
 
 #[cfg(test)]
@@ -109,6 +136,8 @@ mod tests {
             ResolvedSshConfig {
                 hostname: "127.0.0.1".to_string(),
                 user: Some("config-user".to_string()),
+                local_forwards: Vec::new(),
+                remote_forwards: Vec::new(),
             }
         );
     }
@@ -123,5 +152,30 @@ mod tests {
             parse_ssh_config(b"hostname host\nuser -oProxyCommand=bad\n"),
             Err(ClientError::InvalidSshComponent("user"))
         ));
+    }
+
+    #[test]
+    fn parses_ordered_tcp_ipv6_and_unix_forwards() {
+        let resolved = parse_ssh_config(
+            b"hostname host\n\
+              localforward 10022 [127.0.0.1]:22\n\
+              localforward [::1]:18080 [::1]:80\n\
+              localforward /tmp/local.sock /tmp/remote.sock\n\
+              remoteforward 1492 [127.0.0.1]:1492\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolved.local_forwards,
+            [
+                "localhost:10022:[127.0.0.1]:22",
+                "[::1]:18080:[::1]:80",
+                "/tmp/local.sock:/tmp/remote.sock",
+            ]
+        );
+        assert_eq!(
+            resolved.remote_forwards,
+            ["localhost:1492:[127.0.0.1]:1492"]
+        );
     }
 }

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -284,6 +284,36 @@ fn ssh_config_extra_forward_field_is_rejected_before_bootstrap() {
 }
 
 #[test]
+fn ssh_config_malformed_replaced_axis_is_ignored() {
+    let config = concat!(
+        "host server-alias\n",
+        "user config-user\n",
+        "hostname 127.0.0.1\n",
+        "port 22\n",
+        "localforward unsupported\n",
+        "remoteforward 1492 [127.0.0.1]:1492 unexpected\n",
+    );
+
+    for (option, value, rejected, ignored) in [
+        ("-t", "5555:22", "remoteforward", "localforward"),
+        ("-r", "3000:4000", "localforward", "remoteforward"),
+    ] {
+        let fake = FakeSsh::new();
+        let output = fake
+            .command(config, VALID_MARKER, 0, "")
+            .args(["-N", option, value, "server-alias:1"])
+            .output()
+            .unwrap();
+        let error = stderr(&output);
+
+        assert_eq!(output.status.code(), Some(2), "{option}: {error}");
+        assert!(error.contains(&format!("malformed {rejected}")), "{error}");
+        assert!(!error.contains(&format!("malformed {ignored}")), "{error}");
+        assert_eq!(fake.invocations(), [["-G", "-T", "server-alias"]]);
+    }
+}
+
+#[test]
 fn ssh_config_cli_same_axis_replaces_config() {
     let (port, server) = initial_payload_server_with_error(Some("stop after payload"));
     let fake = FakeSsh::new();

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -250,10 +250,37 @@ fn ssh_config_malformed_forward_is_rejected() {
 
     assert_eq!(output.status.code(), Some(2), "{}", stderr(&output));
     assert!(
-        stderr(&output).contains("invalid tunnel"),
+        stderr(&output).contains("malformed localforward"),
         "{}",
         stderr(&output)
     );
+    assert_eq!(fake.invocations(), [["-G", "-T", "server-alias"]]);
+}
+
+#[test]
+fn ssh_config_extra_forward_field_is_rejected_before_bootstrap() {
+    let fake = FakeSsh::new();
+    let config = concat!(
+        "host server-alias\n",
+        "user config-user\n",
+        "hostname 127.0.0.1\n",
+        "port 22\n",
+        "localforward 10022 [127.0.0.1]:22 unexpected\n",
+    );
+
+    let output = fake
+        .command(config, VALID_MARKER, 0, "")
+        .args(["-N", "server-alias:1"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2), "{}", stderr(&output));
+    assert!(
+        stderr(&output).contains("malformed localforward"),
+        "{}",
+        stderr(&output)
+    );
+    assert_eq!(fake.invocations(), [["-G", "-T", "server-alias"]]);
 }
 
 #[test]

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -166,6 +166,132 @@ fn initial_payload_server_with_error(
 }
 
 #[test]
+fn ssh_config_local_and_remote_forwards_become_et_tunnels() {
+    let (port, server) = initial_payload_server_with_error(Some("stop after payload"));
+    let fake = FakeSsh::new();
+    let config = concat!(
+        "host server-alias\n",
+        "user config-user\n",
+        "hostname 127.0.0.1\n",
+        "port 22\n",
+        "localforward 10022 [127.0.0.1]:22\n",
+        "remoteforward 1492 [127.0.0.1]:1492\n",
+    );
+
+    let _output = fake
+        .command(config, VALID_MARKER, 0, "")
+        .args(["-N", &format!("server-alias:{port}")])
+        .output()
+        .unwrap();
+    let payload = server.join().unwrap();
+
+    assert_eq!(payload.reversetunnels.len(), 1);
+    let reverse = &payload.reversetunnels[0];
+    assert_eq!(
+        reverse.source.as_ref().and_then(|source| source.port),
+        Some(1492)
+    );
+    assert_eq!(
+        reverse
+            .destination
+            .as_ref()
+            .and_then(|destination| destination.port),
+        Some(1492)
+    );
+    assert_eq!(fake.invocations()[0], ["-G", "-T", "server-alias"]);
+}
+
+#[test]
+fn ssh_config_forwards_apply_on_the_unspecified_axis() {
+    let (port, server) = initial_payload_server_with_error(Some("stop after payload"));
+    let fake = FakeSsh::new();
+    let config = concat!(
+        "host server-alias\n",
+        "user config-user\n",
+        "hostname 127.0.0.1\n",
+        "port 22\n",
+        "localforward 10022 [127.0.0.1]:22\n",
+        "remoteforward 1492 [127.0.0.1]:1492\n",
+    );
+
+    let _output = fake
+        .command(config, VALID_MARKER, 0, "")
+        .args(["-N", "-t", "5555:22", &format!("server-alias:{port}")])
+        .output()
+        .unwrap();
+    let payload = server.join().unwrap();
+
+    assert_eq!(payload.reversetunnels.len(), 1);
+    assert_eq!(
+        payload.reversetunnels[0]
+            .source
+            .as_ref()
+            .and_then(|source| source.port),
+        Some(1492)
+    );
+}
+
+#[test]
+fn ssh_config_malformed_forward_is_rejected() {
+    let fake = FakeSsh::new();
+    let config = concat!(
+        "host server-alias\n",
+        "user config-user\n",
+        "hostname 127.0.0.1\n",
+        "port 22\n",
+        "localforward none\n",
+    );
+
+    let output = fake
+        .command(config, VALID_MARKER, 0, "")
+        .args(["-N", "server-alias:1"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2), "{}", stderr(&output));
+    assert!(
+        stderr(&output).contains("invalid tunnel"),
+        "{}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn ssh_config_cli_same_axis_replaces_config() {
+    let (port, server) = initial_payload_server_with_error(Some("stop after payload"));
+    let fake = FakeSsh::new();
+    let config = concat!(
+        "host server-alias\n",
+        "user config-user\n",
+        "hostname 127.0.0.1\n",
+        "port 22\n",
+        "localforward 10022 [127.0.0.1]:22\n",
+        "remoteforward 1492 [127.0.0.1]:1492\n",
+    );
+
+    let _output = fake
+        .command(config, VALID_MARKER, 0, "")
+        .args(["-N", "-r", "3000:4000", &format!("server-alias:{port}")])
+        .output()
+        .unwrap();
+    let payload = server.join().unwrap();
+
+    assert_eq!(payload.reversetunnels.len(), 1);
+    let reverse = &payload.reversetunnels[0];
+    assert_eq!(
+        reverse.source.as_ref().and_then(|source| source.port),
+        Some(3000)
+    );
+    assert_eq!(
+        reverse
+            .destination
+            .as_ref()
+            .and_then(|destination| destination.port),
+        Some(4000)
+    );
+}
+
+#[test]
 fn cli_proves_exact_ssh_bootstrap_v6_and_encrypted_initial_payload() {
     let (port, server) = initial_payload_server();
 

--- a/crates/et-bin/tests/reconnect_stack/mod.rs
+++ b/crates/et-bin/tests/reconnect_stack/mod.rs
@@ -61,6 +61,7 @@ impl Stack {
         fs::write(
             &ssh,
             "#!/bin/sh\nif [ \"$1\" = \"-G\" ]; then\n\
+             if [ -n \"$ET_SSH_CONFIG\" ]; then printf '%s' \"$ET_SSH_CONFIG\"; exit 0; fi\n\
              printf 'hostname 127.0.0.1\\nuser tester\\n'; exit 0; fi\n\
              printf x >> \"$ET_SSH_COUNT\"\nfor last do :; done\n\
              exec /bin/sh -c \"$last\"\n",

--- a/crates/et-bin/tests/tunnels_end_to_end.rs
+++ b/crates/et-bin/tests/tunnels_end_to_end.rs
@@ -18,6 +18,51 @@ use tunnel_support::SingleCutProxy;
 const TIMEOUT: Duration = Duration::from_secs(10);
 
 #[test]
+fn ssh_config_local_and_remote_tunnels_relay_real_tcp_payloads() {
+    let mut stack = Stack::start();
+    let local_destination = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let local_destination_port = local_destination.local_addr().unwrap().port();
+    let local_echo = spawn_tcp_echo(local_destination);
+    let local_source_port = reserve_port();
+    let reverse_destination = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let reverse_destination_port = reverse_destination.local_addr().unwrap().port();
+    let reverse_echo = spawn_tcp_echo(reverse_destination);
+    let reverse_source_port = reserve_port();
+    let gate = stack.directory.join("ssh-config-ready");
+    mkfifo(&gate);
+    let config = format!(
+        "hostname 127.0.0.1\nuser tester\n\
+         localforward {local_source_port} [127.0.0.1]:{local_destination_port}\n\
+         remoteforward {reverse_source_port} [127.0.0.1]:{reverse_destination_port}\n"
+    );
+    let mut client = Command::new(env!("CARGO_BIN_EXE_et"));
+    client
+        .env("PATH", &stack.directory)
+        .env("ET_SSH_COUNT", &stack.ssh_count)
+        .env("ET_SSH_CONFIG", config)
+        .env("ET_SSH_READY", &gate)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .args(["--terminal-path"])
+        .arg(&stack.terminal)
+        .args(["--serverfifo"])
+        .arg(&stack.router)
+        .arg("-N")
+        .arg(format!("tester@127.0.0.1:{}", stack.port));
+    let mut client = client.spawn().unwrap();
+
+    await_fifo(&gate);
+    assert_tcp_round_trip(local_source_port, b"config-local");
+    assert_tcp_round_trip(reverse_source_port, b"config-reverse");
+
+    stop(&mut client);
+    local_echo.join().unwrap();
+    reverse_echo.join().unwrap();
+    stack.shutdown();
+}
+
+#[test]
 fn cli_local_and_reverse_tunnels_relay_real_tcp_payloads() {
     let mut stack = Stack::start();
     let local_destination = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();

--- a/crates/et-bin/tests/tunnels_end_to_end.rs
+++ b/crates/et-bin/tests/tunnels_end_to_end.rs
@@ -63,6 +63,74 @@ fn ssh_config_local_and_remote_tunnels_relay_real_tcp_payloads() {
 }
 
 #[test]
+fn ssh_config_mixed_unix_tcp_tunnels_relay_on_both_axes() {
+    let mut stack = Stack::start();
+
+    let local_unix_source = stack.directory.join("local-unix-source.sock");
+    let local_tcp_destination = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let local_tcp_destination_port = local_tcp_destination.local_addr().unwrap().port();
+    let local_tcp_echo = spawn_tcp_echo_once(local_tcp_destination, b"local-unix-source");
+
+    let local_tcp_source_port = reserve_port();
+    let local_unix_destination_path = stack.directory.join("local-unix-destination.sock");
+    let local_unix_destination = UnixListener::bind(&local_unix_destination_path).unwrap();
+    let local_unix_echo = spawn_unix_echo(local_unix_destination, b"local-unix-destination");
+
+    let remote_unix_source = stack.directory.join("remote-unix-source.sock");
+    let remote_tcp_destination = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let remote_tcp_destination_port = remote_tcp_destination.local_addr().unwrap().port();
+    let remote_tcp_echo = spawn_tcp_echo_once(remote_tcp_destination, b"remote-unix-source");
+
+    let remote_tcp_source_port = reserve_port();
+    let remote_unix_destination_path = stack.directory.join("remote-unix-destination.sock");
+    let remote_unix_destination = UnixListener::bind(&remote_unix_destination_path).unwrap();
+    let remote_unix_echo = spawn_unix_echo(remote_unix_destination, b"remote-unix-destination");
+
+    let gate = stack.directory.join("ssh-config-mixed-ready");
+    mkfifo(&gate);
+    let config = format!(
+        "hostname 127.0.0.1\nuser tester\n\
+         localforward {} [127.0.0.1]:{local_tcp_destination_port}\n\
+         localforward [127.0.0.1]:{local_tcp_source_port} {}\n\
+         remoteforward {} [127.0.0.1]:{remote_tcp_destination_port}\n\
+         remoteforward [127.0.0.1]:{remote_tcp_source_port} {}\n",
+        local_unix_source.display(),
+        local_unix_destination_path.display(),
+        remote_unix_source.display(),
+        remote_unix_destination_path.display(),
+    );
+    let mut client = Command::new(env!("CARGO_BIN_EXE_et"));
+    client
+        .env("PATH", &stack.directory)
+        .env("ET_SSH_COUNT", &stack.ssh_count)
+        .env("ET_SSH_CONFIG", config)
+        .env("ET_SSH_READY", &gate)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .args(["--terminal-path"])
+        .arg(&stack.terminal)
+        .args(["--serverfifo"])
+        .arg(&stack.router)
+        .arg("-N")
+        .arg(format!("tester@127.0.0.1:{}", stack.port));
+    let mut client = client.spawn().unwrap();
+
+    await_fifo(&gate);
+    assert_unix_round_trip(&local_unix_source, b"local-unix-source");
+    assert_ready_tcp_round_trip(local_tcp_source_port, b"local-unix-destination");
+    assert_unix_round_trip(&remote_unix_source, b"remote-unix-source");
+    assert_ready_tcp_round_trip(remote_tcp_source_port, b"remote-unix-destination");
+
+    stop(&mut client);
+    local_tcp_echo.join().unwrap();
+    local_unix_echo.join().unwrap();
+    remote_tcp_echo.join().unwrap();
+    remote_unix_echo.join().unwrap();
+    stack.shutdown();
+}
+
+#[test]
 fn cli_local_and_reverse_tunnels_relay_real_tcp_payloads() {
     let mut stack = Stack::start();
     let local_destination = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
@@ -274,6 +342,29 @@ fn spawn_tcp_echo(listener: TcpListener) -> thread::JoinHandle<()> {
     })
 }
 
+fn spawn_tcp_echo_once(listener: TcpListener, expected: &'static [u8]) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        stream.set_read_timeout(Some(TIMEOUT)).unwrap();
+        echo_once(&mut stream, expected);
+    })
+}
+
+fn spawn_unix_echo(listener: UnixListener, expected: &'static [u8]) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        stream.set_read_timeout(Some(TIMEOUT)).unwrap();
+        echo_once(&mut stream, expected);
+    })
+}
+
+fn echo_once(stream: &mut (impl Read + Write), expected: &[u8]) {
+    let mut payload = vec![0u8; expected.len()];
+    stream.read_exact(&mut payload).unwrap();
+    assert_eq!(payload, expected);
+    stream.write_all(&payload).unwrap();
+}
+
 fn assert_tcp_round_trip(port: u16, payload: &[u8]) {
     // Poll until the tunnel source is bound and the multiplex path is live.
     let deadline = std::time::Instant::now() + TIMEOUT;
@@ -302,7 +393,7 @@ fn assert_tcp_round_trip(port: u16, payload: &[u8]) {
     );
 }
 
-fn try_stream_round_trip(stream: &mut TcpStream, payload: &[u8]) -> std::io::Result<()> {
+fn try_stream_round_trip(stream: &mut (impl Read + Write), payload: &[u8]) -> std::io::Result<()> {
     stream.write_all(payload)?;
     let mut echoed = vec![0u8; payload.len()];
     stream.read_exact(&mut echoed)?;
@@ -313,6 +404,18 @@ fn try_stream_round_trip(stream: &mut TcpStream, payload: &[u8]) -> std::io::Res
         ));
     }
     Ok(())
+}
+
+fn assert_ready_tcp_round_trip(port: u16, payload: &[u8]) {
+    let mut stream = TcpStream::connect((Ipv4Addr::LOCALHOST, port)).unwrap();
+    stream.set_read_timeout(Some(TIMEOUT)).unwrap();
+    try_stream_round_trip(&mut stream, payload).unwrap();
+}
+
+fn assert_unix_round_trip(path: &std::path::Path, payload: &[u8]) {
+    let mut stream = UnixStream::connect(path).unwrap();
+    stream.set_read_timeout(Some(TIMEOUT)).unwrap();
+    try_stream_round_trip(&mut stream, payload).unwrap();
 }
 
 fn wait_connect(port: u16) -> TcpStream {


### PR DESCRIPTION
## Summary
- parse effective OpenSSH LocalForward and RemoteForward entries from ssh -G
- apply config forwards only when the matching ET CLI tunnel axis is unspecified
- preserve SSH-agent forwarding, early CLI validation, and jumphost packet bounds

Upstream issue: https://github.com/MisterTea/EternalTerminal/issues/90

## Evidence
- failing-first process tests: missing config reverse tunnels failed 0 vs 1; malformed forward exited 1 vs typed 2
- mutation proofs cover OpenSSH grammar conversion and SSH-agent preservation
- real built-binary ET server/router scenario relays byte-exact local and reverse TCP payloads from config-only forwards
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1

## Compatibility
- protocol v6 and wire fixtures are unchanged
- explicit --tunnel and --reversetunnel replace config entries only on their respective axis

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies `LocalForward` and `RemoteForward` entries from the user's OpenSSH config as ET tunnels, so config-only port forwarding works without repeating options on the command line.

- Reads effective forward entries from `ssh -G` output alongside the existing host and user resolution.
- Config forwards apply only on the axis not specified via `--tunnel` or `--reversetunnel`; CLI options replace config on their matching axis and its malformed entries are ignored.
- Parses TCP, IPv6, and Unix socket endpoints in forward records; malformed active-axis entries exit with code 2 like malformed CLI tunnels.
- SSH-agent forwarding, initial payload validation, and jumphost packet bounds are preserved.

<sup>Written for commit b12893de5d74f758b99ff7314660b3059c52579b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

