### PR TITLE
fix(terminal): match PAM MOTD sources

### DIFF
--- a/.tegami/feat-session-motd.md
+++ b/.tegami/feat-session-motd.md
@@ -7,6 +7,7 @@ packages:
 ## Show the login message of the day
 
 Terminal sessions now display the message of the day before the login shell
-starts, matching an interactive `ssh` login. The banner follows `pam_motd`'s
-default file and directory precedence, honors `.hushlogin`, and never reaches
-the shell as input. Reconnecting to the same session does not print it again.
+starts, matching an interactive `ssh` login. The banner includes Ubuntu's
+generated dynamic message followed by `pam_motd`'s default file and directory
+sources, honors `.hushlogin`, and never reaches the shell as input.
+Reconnecting to the same session does not print it again.

--- a/crates/et-bin/src/terminal_motd.rs
+++ b/crates/et-bin/src/terminal_motd.rs
@@ -114,12 +114,11 @@ fn append_first_message(output: &mut Vec<u8>, paths: &[PathBuf]) {
     for path in paths {
         match try_read_message(path) {
             Err(()) => continue,
-            Ok(message) => {
-                if let Some(message) = message {
-                    append_terminal_bytes(output, &message);
-                }
+            Ok(Some(message)) => {
+                append_terminal_bytes(output, &message);
                 break;
             }
+            Ok(None) => continue,
         }
     }
 }
@@ -178,24 +177,30 @@ fn try_read_message(path: &Path) -> Result<Option<Vec<u8>>, ()> {
 
 /// Preserve existing CRLF and make lone LF render from column zero.
 fn append_terminal_bytes(output: &mut Vec<u8>, bytes: &[u8]) {
+    if bytes.is_empty() {
+        return;
+    }
+    let body = bytes.strip_suffix(b"\n").unwrap_or(bytes);
+    let body = if bytes.ends_with(b"\r\n") {
+        body.strip_suffix(b"\r").unwrap_or(body)
+    } else {
+        body
+    };
+    let content_limit = MAX_MOTD_TOTAL.saturating_sub(2);
     let mut previous = 0u8;
-    for byte in bytes {
-        if output.len() >= MAX_MOTD_TOTAL {
-            return;
-        }
+    for byte in body {
         if *byte == b'\n' && previous != b'\r' {
-            output.push(b'\r');
-            if output.len() >= MAX_MOTD_TOTAL {
-                return;
+            if output.len().saturating_add(2) > content_limit {
+                break;
             }
+            output.push(b'\r');
+        } else if output.len() >= content_limit {
+            break;
         }
         output.push(*byte);
         previous = *byte;
     }
-    if !bytes.is_empty()
-        && !bytes.ends_with(b"\n")
-        && output.len().saturating_add(2) <= MAX_MOTD_TOTAL
-    {
+    if output.len().saturating_add(2) <= MAX_MOTD_TOTAL {
         output.extend_from_slice(b"\r\n");
     }
 }

--- a/crates/et-bin/src/terminal_motd.rs
+++ b/crates/et-bin/src/terminal_motd.rs
@@ -28,6 +28,8 @@ const MAX_MOTD_TOTAL: usize = 256 * 1024;
 const MAX_MOTD_ENTRIES: usize = 1024;
 /// Operator override naming one file to display instead of the defaults.
 const OVERRIDE_VARIABLE: &str = "ET_MOTD_PATH";
+/// Ubuntu's generated message, displayed by a separate `pam_motd` invocation.
+const DYNAMIC_FILES: [&str; 1] = ["/run/motd.dynamic"];
 /// `pam_motd(8)`'s default single files, highest priority first.
 const DEFAULT_FILES: [&str; 3] = ["/etc/motd", "/run/motd", "/usr/lib/motd"];
 /// `pam_motd(8)`'s default directories, highest priority first.
@@ -44,12 +46,18 @@ pub fn emit(router: &mut LocalStream) -> Result<(), String> {
         .map(PathBuf::from);
     let files: Vec<PathBuf> = DEFAULT_FILES.iter().map(PathBuf::from).collect();
     let directories: Vec<PathBuf> = DEFAULT_DIRS.iter().map(PathBuf::from).collect();
-    let Some(text) = load_from(
-        &files,
-        &directories,
-        override_path.as_deref(),
-        home.as_deref(),
-    ) else {
+    let dynamic_files: Vec<PathBuf> = DYNAMIC_FILES.iter().map(PathBuf::from).collect();
+    let text = if override_path.is_some() {
+        load_from(
+            &files,
+            &directories,
+            override_path.as_deref(),
+            home.as_deref(),
+        )
+    } else {
+        load_defaults_from(&dynamic_files, &files, &directories, home.as_deref())
+    };
+    let Some(text) = text else {
         return Ok(());
     };
     write_output(router, &text)
@@ -65,45 +73,76 @@ fn load_from(
         return None;
     }
 
-    let mut output = Vec::new();
     if let Some(path) = override_path {
+        let mut output = Vec::new();
         let message = read_message(path)?;
         append_terminal_bytes(&mut output, &message);
-    } else {
-        for path in files {
-            if let Some(message) = read_message(path) {
-                append_terminal_bytes(&mut output, &message);
-                break;
-            }
+        return (!output.is_empty()).then_some(output);
+    }
+    load_defaults_from(&[], files, directories, home)
+}
+
+fn load_defaults_from(
+    dynamic_files: &[PathBuf],
+    files: &[PathBuf],
+    directories: &[PathBuf],
+    home: Option<&Path>,
+) -> Option<Vec<u8>> {
+    if home.is_some_and(|home| home.join(".hushlogin").exists()) {
+        return None;
+    }
+
+    let mut output = Vec::new();
+    append_first_message(&mut output, dynamic_files);
+    append_first_message(&mut output, files);
+    for candidates in directory_message_candidates(directories) {
+        if output.len() >= MAX_MOTD_TOTAL {
+            break;
         }
-        for path in directory_messages(directories) {
-            if output.len() >= MAX_MOTD_TOTAL {
-                break;
-            }
-            if let Some(message) = read_message(&path) {
-                append_terminal_bytes(&mut output, &message);
-            }
+        if let Some(message) = candidates
+            .iter()
+            .find_map(|path| try_read_message(path).ok())
+            .flatten()
+        {
+            append_terminal_bytes(&mut output, &message);
         }
     }
     (!output.is_empty()).then_some(output)
 }
 
-/// Resolve directory overrides by basename, then return lexical display order.
-fn directory_messages(directories: &[PathBuf]) -> Vec<PathBuf> {
-    let mut messages: BTreeMap<OsString, PathBuf> = BTreeMap::new();
+fn append_first_message(output: &mut Vec<u8>, paths: &[PathBuf]) {
+    for path in paths {
+        match try_read_message(path) {
+            Err(()) => continue,
+            Ok(message) => {
+                if let Some(message) = message {
+                    append_terminal_bytes(output, &message);
+                }
+                break;
+            }
+        }
+    }
+}
+
+/// Group directory overrides by basename in lexical display order.
+fn directory_message_candidates(directories: &[PathBuf]) -> Vec<Vec<PathBuf>> {
+    let mut messages: BTreeMap<OsString, Vec<PathBuf>> = BTreeMap::new();
     for directory in directories {
         let Ok(entries) = std::fs::read_dir(directory) else {
             continue;
         };
         for entry in entries.flatten() {
-            let name = entry.file_name();
-            if messages.contains_key(&name) {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !file_type.is_file() && !file_type.is_symlink() {
                 continue;
             }
-            if messages.len() >= MAX_MOTD_ENTRIES {
+            let name = entry.file_name();
+            if !messages.contains_key(&name) && messages.len() >= MAX_MOTD_ENTRIES {
                 break;
             }
-            messages.insert(name, entry.path());
+            messages.entry(name).or_default().push(entry.path());
         }
     }
     messages.into_values().collect()
@@ -111,22 +150,30 @@ fn directory_messages(directories: &[PathBuf]) -> Vec<PathBuf> {
 
 /// Open without blocking on special files, then validate the opened object.
 fn read_message(path: &Path) -> Option<Vec<u8>> {
+    try_read_message(path).ok().flatten()
+}
+
+fn try_read_message(path: &Path) -> Result<Option<Vec<u8>>, ()> {
     let descriptor = rustix::fs::open(
         path,
         OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NONBLOCK,
         Mode::empty(),
     )
-    .ok()?;
+    .map_err(|_| ())?;
     let file = File::from(descriptor);
-    if !file.metadata().ok()?.is_file() {
-        return None;
+    if !file.metadata().map_err(|_| ())?.is_file() {
+        return Ok(None);
     }
     let mut bytes = Vec::with_capacity(MAX_MOTD_MESSAGE);
-    file.take(u64::try_from(MAX_MOTD_MESSAGE).ok()?.saturating_add(1))
-        .read_to_end(&mut bytes)
-        .ok()?;
+    file.take(
+        u64::try_from(MAX_MOTD_MESSAGE)
+            .map_err(|_| ())?
+            .saturating_add(1),
+    )
+    .read_to_end(&mut bytes)
+    .map_err(|_| ())?;
     bytes.truncate(MAX_MOTD_MESSAGE);
-    Some(bytes)
+    Ok(Some(bytes))
 }
 
 /// Preserve existing CRLF and make lone LF render from column zero.
@@ -144,6 +191,12 @@ fn append_terminal_bytes(output: &mut Vec<u8>, bytes: &[u8]) {
         }
         output.push(*byte);
         previous = *byte;
+    }
+    if !bytes.is_empty()
+        && !bytes.ends_with(b"\n")
+        && output.len().saturating_add(2) <= MAX_MOTD_TOTAL
+    {
+        output.extend_from_slice(b"\r\n");
     }
 }
 
@@ -166,141 +219,5 @@ fn write_output(router: &mut LocalStream, text: &[u8]) -> Result<(), String> {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::fs;
-    use std::os::unix::fs::symlink;
-
-    use super::*;
-
-    struct Sandbox(PathBuf);
-
-    impl Sandbox {
-        fn new(label: &str) -> Self {
-            let path = std::env::temp_dir().join(format!(
-                "et-rs-motd-{label}-{}-{:?}",
-                std::process::id(),
-                std::thread::current().id()
-            ));
-            let _ = fs::remove_dir_all(&path);
-            fs::create_dir_all(&path).unwrap();
-            Self(path)
-        }
-
-        fn file(&self, name: &str, contents: &[u8]) -> PathBuf {
-            let path = self.0.join(name);
-            fs::write(&path, contents).unwrap();
-            path
-        }
-
-        fn directory(&self, name: &str) -> PathBuf {
-            let path = self.0.join(name);
-            fs::create_dir(&path).unwrap();
-            path
-        }
-    }
-
-    impl Drop for Sandbox {
-        fn drop(&mut self) {
-            let _ = fs::remove_dir_all(&self.0);
-        }
-    }
-
-    #[test]
-    fn load_suppresses_everything_when_home_has_hushlogin() {
-        let sandbox = Sandbox::new("hushlogin");
-        let motd = sandbox.file("motd", b"banner\n");
-        let home = Sandbox::new("hushlogin-home");
-        home.file(".hushlogin", b"");
-
-        assert_eq!(load_from(&[], &[], Some(&motd), Some(&home.0)), None);
-    }
-
-    #[test]
-    fn load_skips_missing_empty_and_nonregular_override_files() {
-        let sandbox = Sandbox::new("nonfatal");
-        let empty = sandbox.file("empty", b"");
-        let missing = sandbox.0.join("missing");
-        let directory = sandbox.directory("directory");
-        let fifo = sandbox.0.join("fifo");
-        assert!(std::process::Command::new("mkfifo")
-            .arg(&fifo)
-            .status()
-            .unwrap()
-            .success());
-
-        for source in [empty, missing, directory, fifo, PathBuf::from("/dev/null")] {
-            assert_eq!(load_from(&[], &[], Some(&source), None), None, "{source:?}");
-        }
-    }
-
-    #[test]
-    fn load_bounds_each_message_and_total_directory_output() {
-        let sandbox = Sandbox::new("bounded");
-        let directory = sandbox.directory("motd.d");
-        for index in 0..5 {
-            fs::write(
-                directory.join(format!("{index:02}-message")),
-                vec![b'x'; MAX_MOTD_MESSAGE * 3],
-            )
-            .unwrap();
-        }
-
-        let output = load_from(&[], std::slice::from_ref(&directory), None, None).unwrap();
-
-        assert_eq!(output.len(), MAX_MOTD_TOTAL);
-    }
-
-    #[test]
-    fn load_shows_only_the_first_readable_default_file() {
-        let sandbox = Sandbox::new("defaults");
-        let first = sandbox.file("first", b"first\n");
-        let second = sandbox.file("second", b"second\n");
-
-        assert_eq!(
-            load_from(&[first, second.clone()], &[], None, None).unwrap(),
-            b"first\r\n"
-        );
-        assert_eq!(
-            load_from(&[sandbox.0.join("absent"), second], &[], None, None).unwrap(),
-            b"second\r\n"
-        );
-    }
-
-    #[test]
-    fn load_orders_directory_union_and_honors_priority_overrides() {
-        let sandbox = Sandbox::new("directories");
-        let high = sandbox.directory("etc");
-        let middle = sandbox.directory("run");
-        let low = sandbox.directory("usr");
-        fs::write(high.join("10-first"), b"first\n").unwrap();
-        fs::write(high.join("20-shared"), b"high\n").unwrap();
-        fs::write(middle.join("20-shared"), b"middle\n").unwrap();
-        fs::write(low.join("20-shared"), b"low\n").unwrap();
-        fs::write(low.join("30-last"), b"last\n").unwrap();
-        fs::write(low.join("40-silenced"), b"must-not-appear\n").unwrap();
-        symlink("/dev/null", high.join("40-silenced")).unwrap();
-
-        assert_eq!(
-            load_from(&[], &[high, middle, low], None, None).unwrap(),
-            b"first\r\nhigh\r\nlast\r\n"
-        );
-    }
-
-    #[test]
-    fn load_preserves_raw_bytes_and_normalizes_only_lone_line_feeds() {
-        let sandbox = Sandbox::new("raw-bytes");
-        let motd = sandbox.file("motd", b"a\r\nb\n\x1b[31mc\x07\xff\xfe\n");
-
-        assert_eq!(
-            load_from(&[], &[], Some(&motd), None).unwrap(),
-            b"a\r\nb\r\n\x1b[31mc\x07\xff\xfe\r\n"
-        );
-    }
-
-    #[test]
-    fn maximum_output_packet_fits_the_local_frame_bound() {
-        let packet = output_packet(&vec![b'x'; MAX_OUTPUT_CHUNK]);
-
-        assert!(packet.wire_len() <= et_net::local_packet::MAX_LOCAL_PACKET_LEN);
-    }
-}
+#[path = "terminal_motd_tests.rs"]
+mod tests;

--- a/crates/et-bin/src/terminal_motd_tests.rs
+++ b/crates/et-bin/src/terminal_motd_tests.rs
@@ -79,6 +79,23 @@ fn load_bounds_each_message_and_total_directory_output() {
     let output = load_from(&[], std::slice::from_ref(&directory), None, None).unwrap();
 
     assert_eq!(output.len(), MAX_MOTD_TOTAL);
+    assert!(output.ends_with(b"\r\n"));
+}
+
+#[test]
+fn load_preserves_framing_when_newline_messages_hit_total_bound() {
+    let sandbox = Sandbox::new("bounded-newline");
+    let directory = sandbox.directory("motd.d");
+    for index in 0..5 {
+        let mut message = vec![b'x'; MAX_MOTD_MESSAGE];
+        *message.last_mut().unwrap() = b'\n';
+        fs::write(directory.join(format!("{index:02}-message")), message).unwrap();
+    }
+
+    let output = load_from(&[], std::slice::from_ref(&directory), None, None).unwrap();
+
+    assert_eq!(output.len(), MAX_MOTD_TOTAL);
+    assert!(output.ends_with(b"\r\n"));
 }
 
 #[test]
@@ -94,6 +111,13 @@ fn load_shows_only_the_first_readable_default_file() {
     assert_eq!(
         load_from(&[sandbox.0.join("absent"), second], &[], None, None).unwrap(),
         b"second\r\n"
+    );
+
+    let nonregular = sandbox.directory("nonregular");
+    let fallback = sandbox.file("fallback", b"fallback\n");
+    assert_eq!(
+        load_from(&[nonregular, fallback], &[], None, None).unwrap(),
+        b"fallback\r\n"
     );
 }
 

--- a/crates/et-bin/src/terminal_motd_tests.rs
+++ b/crates/et-bin/src/terminal_motd_tests.rs
@@ -1,0 +1,179 @@
+use std::fs;
+use std::os::unix::fs::symlink;
+
+use super::*;
+
+struct Sandbox(PathBuf);
+
+impl Sandbox {
+    fn new(label: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "et-rs-motd-{label}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).unwrap();
+        Self(path)
+    }
+
+    fn file(&self, name: &str, contents: &[u8]) -> PathBuf {
+        let path = self.0.join(name);
+        fs::write(&path, contents).unwrap();
+        path
+    }
+
+    fn directory(&self, name: &str) -> PathBuf {
+        let path = self.0.join(name);
+        fs::create_dir(&path).unwrap();
+        path
+    }
+}
+
+impl Drop for Sandbox {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn load_suppresses_everything_when_home_has_hushlogin() {
+    let sandbox = Sandbox::new("hushlogin");
+    let motd = sandbox.file("motd", b"banner\n");
+    let home = Sandbox::new("hushlogin-home");
+    home.file(".hushlogin", b"");
+
+    assert_eq!(load_from(&[], &[], Some(&motd), Some(&home.0)), None);
+}
+
+#[test]
+fn load_skips_missing_empty_and_nonregular_override_files() {
+    let sandbox = Sandbox::new("nonfatal");
+    let empty = sandbox.file("empty", b"");
+    let missing = sandbox.0.join("missing");
+    let directory = sandbox.directory("directory");
+    let fifo = sandbox.0.join("fifo");
+    assert!(std::process::Command::new("mkfifo")
+        .arg(&fifo)
+        .status()
+        .unwrap()
+        .success());
+
+    for source in [empty, missing, directory, fifo, PathBuf::from("/dev/null")] {
+        assert_eq!(load_from(&[], &[], Some(&source), None), None, "{source:?}");
+    }
+}
+
+#[test]
+fn load_bounds_each_message_and_total_directory_output() {
+    let sandbox = Sandbox::new("bounded");
+    let directory = sandbox.directory("motd.d");
+    for index in 0..5 {
+        fs::write(
+            directory.join(format!("{index:02}-message")),
+            vec![b'x'; MAX_MOTD_MESSAGE * 3],
+        )
+        .unwrap();
+    }
+
+    let output = load_from(&[], std::slice::from_ref(&directory), None, None).unwrap();
+
+    assert_eq!(output.len(), MAX_MOTD_TOTAL);
+}
+
+#[test]
+fn load_shows_only_the_first_readable_default_file() {
+    let sandbox = Sandbox::new("defaults");
+    let first = sandbox.file("first", b"first\n");
+    let second = sandbox.file("second", b"second\n");
+
+    assert_eq!(
+        load_from(&[first, second.clone()], &[], None, None).unwrap(),
+        b"first\r\n"
+    );
+    assert_eq!(
+        load_from(&[sandbox.0.join("absent"), second], &[], None, None).unwrap(),
+        b"second\r\n"
+    );
+}
+
+#[test]
+fn load_shows_dynamic_message_before_static_defaults() {
+    let sandbox = Sandbox::new("dynamic-defaults");
+    let dynamic = sandbox.file("motd.dynamic", b"dynamic\n");
+    let static_message = sandbox.file("motd", b"static\n");
+
+    assert_eq!(
+        load_defaults_from(
+            std::slice::from_ref(&dynamic),
+            std::slice::from_ref(&static_message),
+            &[],
+            None,
+        )
+        .unwrap(),
+        b"dynamic\r\nstatic\r\n"
+    );
+}
+
+#[test]
+fn load_orders_directory_union_and_honors_priority_overrides() {
+    let sandbox = Sandbox::new("directories");
+    let high = sandbox.directory("etc");
+    let middle = sandbox.directory("run");
+    let low = sandbox.directory("usr");
+    fs::write(high.join("10-first"), b"first\n").unwrap();
+    fs::write(high.join("20-shared"), b"high\n").unwrap();
+    fs::write(middle.join("20-shared"), b"middle\n").unwrap();
+    fs::write(low.join("20-shared"), b"low\n").unwrap();
+    fs::write(low.join("30-last"), b"last\n").unwrap();
+    fs::write(low.join("40-silenced"), b"must-not-appear\n").unwrap();
+    symlink("/dev/null", high.join("40-silenced")).unwrap();
+
+    assert_eq!(
+        load_from(&[], &[high, middle, low], None, None).unwrap(),
+        b"first\r\nhigh\r\nlast\r\n"
+    );
+}
+
+#[test]
+fn load_falls_back_when_higher_priority_directory_entry_is_unreadable() {
+    let sandbox = Sandbox::new("directory-fallback");
+    let high = sandbox.directory("etc");
+    let low = sandbox.directory("usr");
+    fs::create_dir(high.join("20-shared")).unwrap();
+    fs::write(low.join("20-shared"), b"fallback\n").unwrap();
+
+    assert_eq!(
+        load_from(&[], &[high, low], None, None).unwrap(),
+        b"fallback\r\n"
+    );
+}
+
+#[test]
+fn load_terminates_message_without_trailing_newline() {
+    let sandbox = Sandbox::new("unterminated-message");
+    let motd = sandbox.file("motd", b"maintenance tonight");
+
+    assert_eq!(
+        load_from(&[], &[], Some(&motd), None).unwrap(),
+        b"maintenance tonight\r\n"
+    );
+}
+
+#[test]
+fn load_preserves_raw_bytes_and_normalizes_only_lone_line_feeds() {
+    let sandbox = Sandbox::new("raw-bytes");
+    let motd = sandbox.file("motd", b"a\r\nb\n\x1b[31mc\x07\xff\xfe\n");
+
+    assert_eq!(
+        load_from(&[], &[], Some(&motd), None).unwrap(),
+        b"a\r\nb\r\n\x1b[31mc\x07\xff\xfe\r\n"
+    );
+}
+
+#[test]
+fn maximum_output_packet_fits_the_local_frame_bound() {
+    let packet = output_packet(&vec![b'x'; MAX_OUTPUT_CHUNK]);
+
+    assert!(packet.wire_len() <= et_net::local_packet::MAX_LOCAL_PACKET_LEN);
+}


### PR DESCRIPTION
## Summary
- display Ubuntu generated `/run/motd.dynamic` before static PAM defaults
- preserve lower-priority directory fallback when a higher-priority entry cannot be displayed
- terminate newline-less MOTD messages before shell output
- move MOTD unit tests into the established sibling test module

## Review finding
Follow-up to #63 and its unaddressed P1 at `terminal_motd.rs:32`. On stock Ubuntu, interactive SSH displayed `/run/motd.dynamic` while ET default discovery emitted zero banner bytes.

## Verification
- failing-first unit proofs for dynamic+static ordering, directory fallback, and newline termination
- real `et terminal --session-child` QA with `ET_MOTD_PATH` unset: dynamic content before shell, newline framing, exit 23, cleanup complete
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `cargo check -p et --target x86_64-pc-windows-gnu`
- protocol golden tests unchanged and green

Implements the required follow-up from the upstream MOTD compliance review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Matches PAM MOTD sources so terminal sessions now display Ubuntu's `/run/motd.dynamic` before static defaults, fixing the zero-banner case on stock Ubuntu.

**Bug Fixes**
- Displays `/run/motd.dynamic` before static files when `ET_MOTD_PATH` is unset.
- Falls back to lower-priority directory sources when a higher-priority entry is unreadable.
- Appends a CRLF terminator when a MOTD message has no trailing newline.
- Moves MOTD unit tests into `terminal_motd_tests.rs`.

<sup>Written for commit e12e475b72044d15c71fb8ef8379ac42b39e7376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

