### PR TITLE
fix(forward): harden SSH-configured forwarding

### DIFF
--- a/.tegami/fix-ssh-config-forwarding-hardening.md
+++ b/.tegami/fix-ssh-config-forwarding-hardening.md
@@ -6,7 +6,13 @@ packages:
 
 ## Harden SSH configuration port forwarding
 
-SSH-configured forwards now preserve their destination and OpenSSH bind
-semantics without duplicating operational SSH listeners. Reverse listeners are
-also bound with the authenticated session identity, reject wildcard and
-privileged authority escalation, and enforce a per-session resource limit.
+Operational SSH commands now suppress OpenSSH forwarding before user options,
+while configuration queries still import supported forwarding rows. Imported
+TCP destinations are limited to localhost, and local binds preserve
+GatewayPorts loopback and wildcard behavior.
+
+Reverse listeners bind with the authenticated session identity, reject wildcard
+or privileged authority escalation, and enforce a transactional per-session
+listener limit. Bind failures are reported by bounded row index: SSH-config-only
+rows warn and continue, while an unavailable explicit reverse row aborts the
+client and releases sibling listeners.

--- a/.tegami/fix-ssh-config-forwarding-hardening.md
+++ b/.tegami/fix-ssh-config-forwarding-hardening.md
@@ -1,0 +1,12 @@
+---
+packages:
+  et:
+    type: patch
+---
+
+## Harden SSH configuration port forwarding
+
+SSH-configured forwards now preserve their destination and OpenSSH bind
+semantics without duplicating operational SSH listeners. Reverse listeners are
+also bound with the authenticated session identity, reject wildcard and
+privileged authority escalation, and enforce a per-session resource limit.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +419,7 @@ version = "0.0.18"
 dependencies = [
  "et-core",
  "et-net",
+ "nix 0.31.3",
  "prost",
  "rustix",
 ]
@@ -612,6 +619,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +667,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.2",
  "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/crates/et-bin/src/bootstrap.rs
+++ b/crates/et-bin/src/bootstrap.rs
@@ -565,12 +565,13 @@ mod tests {
         req.jumphost = Some("jump.example,user@hop2".into());
         let invocation = build_invocation(&req, &credentials);
         assert_eq!(
-            invocation.args[0..4],
+            invocation.args[0..5],
             [
                 "-J",
                 "jump.example,user@hop2",
+                "-oClearAllForwardings=yes",
+                "-oPort=2222",
                 "alice@server",
-                "-oPort=2222"
             ]
         );
     }

--- a/crates/et-bin/src/bootstrap.rs
+++ b/crates/et-bin/src/bootstrap.rs
@@ -160,8 +160,8 @@ pub fn build_invocation(request: &BootstrapRequest, credentials: &Credentials) -
         Some(user) => format!("{user}@{}", request.host_alias),
         None => request.host_alias.clone(),
     };
-    args.push(destination);
     append_operational_options(&mut args, &request.ssh_options);
+    args.push(destination);
     args.push(remote_command(request, credentials));
 
     SshInvocation {
@@ -182,9 +182,9 @@ pub fn build_shell_probe(request: &BootstrapRequest) -> SshInvocation {
         Some(user) => format!("{user}@{}", request.host_alias),
         None => request.host_alias.clone(),
     };
-    args.push(destination);
     append_operational_options(&mut args, &request.ssh_options);
     args.push("-oLogLevel=ERROR".to_owned());
+    args.push(destination);
     args.push(format!("echo {WINDOWS_SHELL_PROBE_SENTINEL}%ComSpec%"));
     SshInvocation {
         program: "ssh".to_owned(),
@@ -195,13 +195,19 @@ pub fn build_shell_probe(request: &BootstrapRequest) -> SshInvocation {
 }
 
 fn append_operational_options(args: &mut Vec<String>, options: &[String]) {
+    args.push(format!("-o{CLEAR_ALL_FORWARDINGS}"));
     args.extend(
         options
             .iter()
-            .filter(|option| !option.eq_ignore_ascii_case(CLEAR_ALL_FORWARDINGS))
+            .filter(|option| {
+                !option
+                    .trim_start()
+                    .split(|character: char| character == '=' || character.is_ascii_whitespace())
+                    .next()
+                    .is_some_and(|key| key.eq_ignore_ascii_case("ClearAllForwardings"))
+            })
             .map(|option| format!("-o{option}")),
     );
-    args.push(format!("-o{CLEAR_ALL_FORWARDINGS}"));
 }
 
 pub fn parse_shell_probe(stdout: &[u8]) -> Result<RemoteShell, ClientError> {
@@ -422,12 +428,88 @@ mod tests {
     #[test]
     fn ssh_config_hardening_destination_bootstrap_suppresses_forwardings() {
         let mut request = request();
-        request
-            .ssh_options
-            .push("ClearAllForwardings=yes".to_owned());
+        request.ssh_options.extend([
+            "ClearAllForwardings=no".to_owned(),
+            "clearallforwardings NO".to_owned(),
+            "CLEARALLFORWARDINGS = no".to_owned(),
+        ]);
         let invocation = build_invocation(&request, &provisional_credentials().unwrap());
 
         assert_clear_all_forwardings_once(&invocation);
+        let suppression = invocation
+            .args
+            .iter()
+            .position(|argument| argument == "-oClearAllForwardings=yes")
+            .unwrap();
+        let destination = invocation
+            .args
+            .iter()
+            .position(|argument| argument == "alice@server")
+            .unwrap();
+        assert!(suppression < destination);
+        assert!(!invocation.args.iter().any(|argument| {
+            argument
+                .trim_start_matches("-o")
+                .split(['=', ' ', '\t'])
+                .next()
+                .is_some_and(|key| key.eq_ignore_ascii_case("ClearAllForwardings"))
+                && argument != "-oClearAllForwardings=yes"
+        }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ssh_config_hardening_real_openssh_observes_operational_precedence() {
+        struct RemoveFile(std::path::PathBuf);
+        impl Drop for RemoveFile {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_file(&self.0);
+            }
+        }
+
+        let path = std::env::temp_dir().join(format!(
+            "et-clear-forwarding-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("openssh")
+        ));
+        let _cleanup = RemoveFile(path.clone());
+        std::fs::write(
+            &path,
+            "Host oracle\n HostName localhost\n LocalForward 15432 localhost:5432\n",
+        )
+        .unwrap();
+        let mut request = request();
+        request.ssh_options.extend([
+            "clearallforwardings no".to_owned(),
+            "CLEARALLFORWARDINGS=no".to_owned(),
+        ]);
+        let invocation = build_invocation(&request, &provisional_credentials().unwrap());
+        let destination = invocation
+            .args
+            .iter()
+            .position(|argument| argument == "alice@server")
+            .unwrap();
+
+        let output = std::process::Command::new("ssh")
+            .args(["-G", "-F"])
+            .arg(&path)
+            .args(&invocation.args[..destination])
+            .arg("oracle")
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let effective = String::from_utf8(output.stdout).unwrap();
+        assert!(effective
+            .lines()
+            .any(|line| line == "clearallforwardings yes"));
+        assert!(!effective
+            .lines()
+            .any(|line| line.starts_with("localforward ")));
     }
 
     #[test]
@@ -465,7 +547,7 @@ mod tests {
         assert_eq!(invocation.program, "ssh");
         assert_eq!(
             invocation.args[0..3],
-            ["alice@server", "-oPort=2222", "-oClearAllForwardings=yes"]
+            ["-oClearAllForwardings=yes", "-oPort=2222", "alice@server"]
         );
         assert_eq!(
             invocation.args[3],
@@ -644,8 +726,8 @@ mod tests {
             [
                 "-p",
                 "2200",
-                "-oStrictHostKeyChecking=no",
                 "-oClearAllForwardings=yes",
+                "-oStrictHostKeyChecking=no",
                 "user@jump.example"
             ]
         );

--- a/crates/et-bin/src/bootstrap.rs
+++ b/crates/et-bin/src/bootstrap.rs
@@ -5,6 +5,7 @@ use crate::error::ClientError;
 const MARKER: &[u8] = b"IDPASSKEY:";
 const CREDENTIAL_LEN: usize = 16 + 1 + 32;
 pub const WINDOWS_SHELL_PROBE_SENTINEL: &str = "__ET_COMSPEC__";
+const CLEAR_ALL_FORWARDINGS: &str = "ClearAllForwardings=yes";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Credentials {
@@ -70,9 +71,7 @@ pub fn build_jump_invocation(
         args.push("-p".to_string());
         args.push(port.to_string());
     }
-    for option in &request.ssh_options {
-        args.push(format!("-o{option}"));
-    }
+    append_operational_options(&mut args, &request.ssh_options);
     let host = parsed.host.trim_matches(|c| c == '[' || c == ']');
     args.push(if parsed.user.is_empty() {
         host.to_string()
@@ -162,12 +161,7 @@ pub fn build_invocation(request: &BootstrapRequest, credentials: &Credentials) -
         None => request.host_alias.clone(),
     };
     args.push(destination);
-    args.extend(
-        request
-            .ssh_options
-            .iter()
-            .map(|option| format!("-o{option}")),
-    );
+    append_operational_options(&mut args, &request.ssh_options);
     args.push(remote_command(request, credentials));
 
     SshInvocation {
@@ -189,12 +183,7 @@ pub fn build_shell_probe(request: &BootstrapRequest) -> SshInvocation {
         None => request.host_alias.clone(),
     };
     args.push(destination);
-    args.extend(
-        request
-            .ssh_options
-            .iter()
-            .map(|option| format!("-o{option}")),
-    );
+    append_operational_options(&mut args, &request.ssh_options);
     args.push("-oLogLevel=ERROR".to_owned());
     args.push(format!("echo {WINDOWS_SHELL_PROBE_SENTINEL}%ComSpec%"));
     SshInvocation {
@@ -203,6 +192,16 @@ pub fn build_shell_probe(request: &BootstrapRequest) -> SshInvocation {
         operation: "detecting the remote login shell",
         completion: InvocationCompletion::ShellProbe,
     }
+}
+
+fn append_operational_options(args: &mut Vec<String>, options: &[String]) {
+    args.extend(
+        options
+            .iter()
+            .filter(|option| !option.eq_ignore_ascii_case(CLEAR_ALL_FORWARDINGS))
+            .map(|option| format!("-o{option}")),
+    );
+    args.push(format!("-o{CLEAR_ALL_FORWARDINGS}"));
 }
 
 pub fn parse_shell_probe(stdout: &[u8]) -> Result<RemoteShell, ClientError> {
@@ -407,6 +406,55 @@ mod tests {
         }
     }
 
+    fn assert_clear_all_forwardings_once(invocation: &SshInvocation) {
+        assert_eq!(
+            invocation
+                .args
+                .iter()
+                .filter(|argument| argument.as_str() == "-oClearAllForwardings=yes")
+                .count(),
+            1,
+            "operational SSH argv must suppress configured forwarding exactly once: {:?}",
+            invocation.args
+        );
+    }
+
+    #[test]
+    fn ssh_config_hardening_destination_bootstrap_suppresses_forwardings() {
+        let mut request = request();
+        request
+            .ssh_options
+            .push("ClearAllForwardings=yes".to_owned());
+        let invocation = build_invocation(&request, &provisional_credentials().unwrap());
+
+        assert_clear_all_forwardings_once(&invocation);
+    }
+
+    #[test]
+    fn ssh_config_hardening_shell_probe_suppresses_forwardings() {
+        let invocation = build_shell_probe(&request());
+
+        assert_clear_all_forwardings_once(&invocation);
+    }
+
+    #[test]
+    fn ssh_config_hardening_direct_jumphost_suppresses_forwardings() {
+        let request = JumpBootstrapRequest {
+            jumphost: "jump.example".to_owned(),
+            destination_host: "destination.example".to_owned(),
+            destination_port: 2022,
+            jump_server_fifo: None,
+            terminal_path: None,
+            kill_other_sessions: false,
+            verbose: 0,
+            ssh_options: Vec::new(),
+            term: "xterm-256color".to_owned(),
+        };
+        let invocation = build_jump_invocation(&request, &provisional_credentials().unwrap());
+
+        assert_clear_all_forwardings_once(&invocation);
+    }
+
     #[test]
     fn builds_upstream_ssh_shape() {
         let credentials = Credentials {
@@ -415,9 +463,12 @@ mod tests {
         };
         let invocation = build_invocation(&request(), &credentials);
         assert_eq!(invocation.program, "ssh");
-        assert_eq!(invocation.args[0..2], ["alice@server", "-oPort=2222"]);
         assert_eq!(
-            invocation.args[2],
+            invocation.args[0..3],
+            ["alice@server", "-oPort=2222", "-oClearAllForwardings=yes"]
+        );
+        assert_eq!(
+            invocation.args[3],
             "printf '%s\\n' 'XXXdefghijklmnop/ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef_xterm-256color' | 'etterminal' '--verbose=2'"
         );
     }
@@ -589,15 +640,16 @@ mod tests {
         };
         let invocation = build_jump_invocation(&request, &credentials);
         assert_eq!(
-            invocation.args[0..4],
+            invocation.args[0..5],
             [
                 "-p",
                 "2200",
                 "-oStrictHostKeyChecking=no",
+                "-oClearAllForwardings=yes",
                 "user@jump.example"
             ]
         );
-        let command = &invocation.args[4];
+        let command = &invocation.args[5];
         assert!(command.contains("'--serverfifo=/tmp/jump.fifo'"));
         assert!(command.contains("'--jump'"));
         assert!(command.contains("'--dsthost=dst.internal'"));

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -282,8 +282,21 @@ fn run_client(
     if args.no_terminal && !has_forwarding {
         return Ok(());
     }
-    let forwarder = et_net::forward::Forwarder::start(local_sources)
+    let (forwarder, skipped) = et_net::forward::Forwarder::start_with_origins(local_sources)
         .map_err(|error| ClientError::Terminal(error.to_string()))?;
+    for skipped in skipped {
+        let source = skipped.request.source.unwrap_or_default();
+        let label = match (source.name.as_deref(), source.port) {
+            (Some(name), Some(port)) if !name.is_empty() => format!("{name}:{port}"),
+            (_, Some(port)) => port.to_string(),
+            (Some(name), None) => name.to_owned(),
+            (None, None) => "<missing>".to_owned(),
+        };
+        et_cli::logging::warn(format!(
+            "SSH localforward source '{label}' could not bind: {}; skipping forwarding row",
+            skipped.error
+        ));
+    }
     crate::client_terminal::run(
         connection,
         crate::client_terminal::TerminalOptions {

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -156,6 +156,7 @@ fn run_client(
     // Bind local sources only after the encrypted session exists so accepted
     // tunnels can be multiplexed immediately (avoids pre-handshake accept races).
     let local_sources = forward_config.local_sources;
+    let remote_origins = forward_config.remote_origins;
     let mut initial_payload = forward_config.initial_payload;
     let user = requested_user.or(resolved.user);
     validate_ssh_destination(&destination.host, user.as_deref())?;
@@ -275,6 +276,7 @@ fn run_client(
         &endpoint,
         &credentials,
         &initial_payload,
+        &remote_origins,
         resolver,
         deadline,
     )?;

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -138,11 +138,11 @@ fn run_client(
         &destination.host,
         requested_user.as_deref(),
         &args.ssh_option,
-        args.tunnel.is_empty(),
-        args.reverse_tunnel.is_empty(),
+        true,
+        true,
         deadline,
     )?;
-    forward_config.apply_ssh_config(args, &resolved)?;
+    forward_config.apply_ssh_config(&resolved)?;
     if args.jumphost.is_some() {
         bound_jumphost_locale_environment(
             &forward_config.initial_payload,

--- a/crates/et-bin/src/forward_config.rs
+++ b/crates/et-bin/src/forward_config.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeSet;
 use et_cli::client::ClientArgs;
 use et_cli::tunnel::parse_tunnels;
 use et_core::proto::{InitialPayload, PortForwardSourceRequest, SocketEndpoint};
+use et_net::forward::ForwardSource;
 
 use crate::ssh_config::ResolvedSshConfig;
 use crate::terminal_protocol::{valid_environment_name, MAX_ENVIRONMENT};
@@ -69,7 +70,7 @@ impl From<et_cli::tunnel::TunnelError> for ForwardConfigError {
 }
 
 pub struct ForwardConfig {
-    pub local_sources: Vec<PortForwardSourceRequest>,
+    pub local_sources: Vec<ForwardSource>,
     pub initial_payload: InitialPayload,
 }
 
@@ -80,7 +81,12 @@ impl ForwardConfig {
         resolved: &ResolvedSshConfig,
     ) -> Result<(), ForwardConfigError> {
         if args.tunnel.is_empty() {
-            self.local_sources.clone_from(&resolved.local_forwards);
+            self.local_sources = resolved
+                .local_forwards
+                .iter()
+                .cloned()
+                .map(ForwardSource::ssh_config)
+                .collect();
         }
         if args.reverse_tunnel.is_empty() {
             let mut configured = resolved.remote_forwards.clone();
@@ -95,7 +101,10 @@ pub fn build(
     args: &ClientArgs,
     environment_agent: Option<&str>,
 ) -> Result<ForwardConfig, ForwardConfigError> {
-    let local_sources = parse_tunnels(&args.tunnel)?;
+    let local_sources = parse_tunnels(&args.tunnel)?
+        .into_iter()
+        .map(ForwardSource::explicit)
+        .collect();
     let mut reverse_tunnels = parse_tunnels(&args.reverse_tunnel)?;
     if args.forward_ssh_agent {
         // Upstream sends a reverse tunnel with no source: the server creates

--- a/crates/et-bin/src/forward_config.rs
+++ b/crates/et-bin/src/forward_config.rs
@@ -71,6 +71,7 @@ impl From<et_cli::tunnel::TunnelError> for ForwardConfigError {
 
 pub struct ForwardConfig {
     pub local_sources: Vec<ForwardSource>,
+    pub remote_origins: Vec<et_net::forward::ForwardOrigin>,
     pub initial_payload: InitialPayload,
 }
 
@@ -97,24 +98,29 @@ impl ForwardConfig {
         }
 
         let mut remote_requests = Vec::new();
-        self.initial_payload.reversetunnels.retain(|request| {
+        let mut deduplicated = Vec::new();
+        let mut origins = Vec::new();
+        for (request, origin) in std::mem::take(&mut self.initial_payload.reversetunnels)
+            .into_iter()
+            .zip(std::mem::take(&mut self.remote_origins))
+        {
             let is_agent_forward = request.source.is_none()
                 && request.environmentvariable.as_deref() == Some("SSH_AUTH_SOCK");
-            if is_agent_forward {
-                true
-            } else if remote_requests.contains(request) {
-                false
-            } else {
+            if is_agent_forward || !remote_requests.contains(&request) {
                 remote_requests.push(request.clone());
-                true
+                deduplicated.push(request);
+                origins.push(origin);
             }
-        });
+        }
         for request in &resolved.remote_forwards {
             if !remote_requests.contains(request) {
                 remote_requests.push(request.clone());
-                self.initial_payload.reversetunnels.push(request.clone());
+                deduplicated.push(request.clone());
+                origins.push(et_net::forward::ForwardOrigin::SshConfig);
             }
         }
+        self.initial_payload.reversetunnels = deduplicated;
+        self.remote_origins = origins;
         validate_environment_names(&self.initial_payload.reversetunnels)
     }
 }
@@ -148,8 +154,10 @@ pub fn build(
         });
     }
     validate_environment_names(&reverse_tunnels)?;
+    let remote_origins = vec![et_net::forward::ForwardOrigin::Explicit; reverse_tunnels.len()];
     Ok(ForwardConfig {
         local_sources,
+        remote_origins,
         initial_payload: InitialPayload {
             jumphost: Some(false),
             reversetunnels: reverse_tunnels,

--- a/crates/et-bin/src/forward_config.rs
+++ b/crates/et-bin/src/forward_config.rs
@@ -77,21 +77,43 @@ pub struct ForwardConfig {
 impl ForwardConfig {
     pub fn apply_ssh_config(
         &mut self,
-        args: &ClientArgs,
         resolved: &ResolvedSshConfig,
     ) -> Result<(), ForwardConfigError> {
-        if args.tunnel.is_empty() {
-            self.local_sources = resolved
-                .local_forwards
-                .iter()
-                .cloned()
-                .map(ForwardSource::ssh_config)
-                .collect();
+        let mut local_requests = Vec::new();
+        self.local_sources.retain(|source| {
+            if local_requests.contains(&source.request) {
+                false
+            } else {
+                local_requests.push(source.request.clone());
+                true
+            }
+        });
+        for request in &resolved.local_forwards {
+            if !local_requests.contains(request) {
+                local_requests.push(request.clone());
+                self.local_sources
+                    .push(ForwardSource::ssh_config(request.clone()));
+            }
         }
-        if args.reverse_tunnel.is_empty() {
-            let mut configured = resolved.remote_forwards.clone();
-            configured.append(&mut self.initial_payload.reversetunnels);
-            self.initial_payload.reversetunnels = configured;
+
+        let mut remote_requests = Vec::new();
+        self.initial_payload.reversetunnels.retain(|request| {
+            let is_agent_forward = request.source.is_none()
+                && request.environmentvariable.as_deref() == Some("SSH_AUTH_SOCK");
+            if is_agent_forward {
+                true
+            } else if remote_requests.contains(request) {
+                false
+            } else {
+                remote_requests.push(request.clone());
+                true
+            }
+        });
+        for request in &resolved.remote_forwards {
+            if !remote_requests.contains(request) {
+                remote_requests.push(request.clone());
+                self.initial_payload.reversetunnels.push(request.clone());
+            }
         }
         validate_environment_names(&self.initial_payload.reversetunnels)
     }

--- a/crates/et-bin/src/forward_config_tests.rs
+++ b/crates/et-bin/src/forward_config_tests.rs
@@ -180,6 +180,13 @@ fn ssh_config_forwards_are_cumulative_stable_and_exactly_deduplicated() {
     );
     assert_eq!(config.initial_payload.reversetunnels.len(), 2);
     assert_eq!(
+        config.remote_origins,
+        [
+            et_net::forward::ForwardOrigin::Explicit,
+            et_net::forward::ForwardOrigin::SshConfig,
+        ]
+    );
+    assert_eq!(
         config.initial_payload.reversetunnels[0],
         resolved.remote_forwards[0]
     );

--- a/crates/et-bin/src/forward_config_tests.rs
+++ b/crates/et-bin/src/forward_config_tests.rs
@@ -54,7 +54,7 @@ fn agent_forwarding_falls_back_to_environment_and_requires_a_socket() {
 }
 
 #[test]
-fn ssh_config_reverse_forwards_preserve_agent_forwarding() {
+fn ssh_config_reverse_forwards_follow_cli_agent_forwarding() {
     let args = ClientArgs::try_parse_from(["et", "host", "--forward-ssh-agent"]).unwrap();
     let mut config = build(&args, Some("/run/agent.sock")).unwrap();
     let resolved = ResolvedSshConfig {
@@ -74,20 +74,117 @@ fn ssh_config_reverse_forwards_preserve_agent_forwarding() {
         }],
     };
 
-    config.apply_ssh_config(&args, &resolved).unwrap();
+    // When
+    config.apply_ssh_config(&resolved).unwrap();
 
+    // Then
     assert_eq!(config.initial_payload.reversetunnels.len(), 2);
     assert_eq!(
         config.initial_payload.reversetunnels[0]
+            .environmentvariable
+            .as_deref(),
+        Some("SSH_AUTH_SOCK")
+    );
+    assert_eq!(
+        config.initial_payload.reversetunnels[1]
             .source
             .as_ref()
             .and_then(|source| source.port),
         Some(1492)
     );
+}
+
+#[test]
+fn ssh_config_forwards_are_cumulative_stable_and_exactly_deduplicated() {
+    // Given
+    let args = ClientArgs::try_parse_from([
+        "et",
+        "host",
+        "-t",
+        "localhost:1000:127.0.0.1:2000",
+        "-t",
+        "localhost:1000:127.0.0.1:2000",
+        "-t",
+        "localhost:1000:127.0.0.1:2001",
+        "-r",
+        "localhost:3000:127.0.0.1:4000",
+        "-r",
+        "localhost:3000:127.0.0.1:4000",
+    ])
+    .unwrap();
+    let mut config = build(&args, None).unwrap();
+    let local_duplicate = config.local_sources[0].request.clone();
+    let local_distinct = config.local_sources[2].request.clone();
+    let remote_duplicate = config.initial_payload.reversetunnels[0].clone();
+    let resolved = ResolvedSshConfig {
+        hostname: "host".to_owned(),
+        user: None,
+        local_forwards: vec![
+            local_duplicate.clone(),
+            local_duplicate,
+            PortForwardSourceRequest {
+                source: Some(SocketEndpoint {
+                    name: Some("localhost".to_owned()),
+                    port: Some(1001),
+                }),
+                destination: Some(SocketEndpoint {
+                    name: Some("127.0.0.1".to_owned()),
+                    port: Some(2002),
+                }),
+                environmentvariable: None,
+            },
+        ],
+        remote_forwards: vec![
+            remote_duplicate.clone(),
+            remote_duplicate,
+            PortForwardSourceRequest {
+                source: Some(SocketEndpoint {
+                    name: Some("localhost".to_owned()),
+                    port: Some(3001),
+                }),
+                destination: Some(SocketEndpoint {
+                    name: Some("127.0.0.1".to_owned()),
+                    port: Some(4001),
+                }),
+                environmentvariable: None,
+            },
+        ],
+    };
+
+    // When
+    config.apply_ssh_config(&resolved).unwrap();
+
+    // Then
+    assert_eq!(config.local_sources.len(), 3);
     assert_eq!(
-        config.initial_payload.reversetunnels[1]
-            .environmentvariable
-            .as_deref(),
-        Some("SSH_AUTH_SOCK")
+        config.local_sources[0].request.source,
+        local_distinct.source
+    );
+    assert_eq!(
+        config.local_sources[0]
+            .request
+            .destination
+            .as_ref()
+            .and_then(|value| value.port),
+        Some(2000)
+    );
+    assert_eq!(config.local_sources[1].request, local_distinct);
+    assert_eq!(config.local_sources[2].request, resolved.local_forwards[2]);
+    assert_eq!(
+        config.local_sources[0].origin,
+        et_net::forward::ForwardOrigin::Explicit
+    );
+    assert_eq!(
+        config.local_sources[2].origin,
+        et_net::forward::ForwardOrigin::SshConfig
+    );
+    assert_eq!(config.initial_payload.reversetunnels.len(), 2);
+    assert_eq!(
+        config.initial_payload.reversetunnels[0],
+        resolved.remote_forwards[0]
+    );
+    assert_eq!(
+        config.initial_payload.reversetunnels[1],
+        resolved.remote_forwards[2]
     );
 }

--- a/crates/et-bin/src/initial_connect.rs
+++ b/crates/et-bin/src/initial_connect.rs
@@ -7,6 +7,7 @@ use et_core::proto::{
     ConnectResponse, ConnectStatus, EtPacketType, InitialPayload, InitialResponse,
 };
 use et_net::connection::Connection;
+use et_net::forward::ForwardOrigin;
 use et_net::framing_io::{read_proto_limited, write_proto};
 use et_net::handshake::{client_request, MAX_HANDSHAKE_PROTO_LEN};
 use prost::Message;
@@ -53,6 +54,7 @@ pub fn connect_initial(
     endpoint: &Endpoint,
     credentials: &Credentials,
     initial_payload: &InitialPayload,
+    remote_origins: &[ForwardOrigin],
     resolver: &dyn EndpointResolver,
     deadline: Deadline,
 ) -> Result<Connection, ClientError> {
@@ -85,8 +87,12 @@ pub fn connect_initial(
     }
     let response =
         InitialResponse::decode(packet.payload()).map_err(ClientError::MalformedInitialResponse)?;
-    if let Some(message) = response.error {
-        return Err(ClientError::InitialResponseRejected(message));
+    if accept_initial_response(response, remote_origins)? {
+        connection
+            .write_packet(EtPacketType::Heartbeat as u8, &[])
+            .map_err(|error| {
+                transport_error(deadline, "acknowledging reverse forwarding skips", error)
+            })?;
     }
     connection
         .set_io_timeout(None)
@@ -164,6 +170,41 @@ fn transport_error(
         Some(_) => ClientError::Transport(error),
         None => ClientError::BootstrapTimeout(operation),
     }
+}
+
+fn accept_initial_response(
+    response: InitialResponse,
+    remote_origins: &[ForwardOrigin],
+) -> Result<bool, ClientError> {
+    let Some(message) = response.error else {
+        return Ok(false);
+    };
+    let rows = match et_net::reverse_report::decode_skipped_rows(&message, remote_origins.len()) {
+        Ok(Some(rows)) => rows,
+        Ok(None) => return Err(ClientError::InitialResponseRejected(message)),
+        Err(_) => {
+            return Err(ClientError::InitialResponseRejected(
+                "malformed reverse forwarding skip report".to_owned(),
+            ));
+        }
+    };
+    for row in &rows {
+        match remote_origins[row.index] {
+            ForwardOrigin::SshConfig => {}
+            ForwardOrigin::Explicit | ForwardOrigin::Reported(_) => {
+                return Err(ClientError::InitialResponseRejected(
+                    "explicit reverse forwarding row could not bind".to_owned(),
+                ));
+            }
+        }
+    }
+    for row in rows {
+        et_cli::logging::warn(format!(
+            "SSH remoteforward row {} could not bind; skipping forwarding row",
+            row.index
+        ));
+    }
+    Ok(true)
 }
 
 fn accept_response(response: ConnectResponse) -> Result<(), ClientError> {

--- a/crates/et-bin/src/initial_connect_tests.rs
+++ b/crates/et-bin/src/initial_connect_tests.rs
@@ -1,6 +1,8 @@
-use et_core::proto::{ConnectResponse, ConnectStatus};
+use et_core::proto::{ConnectResponse, ConnectStatus, InitialResponse};
+use et_net::forward::ForwardOrigin;
+use et_net::reverse_report::{encode_skipped_rows, SkipReason, SkippedRow};
 
-use super::{accept_reconnect_response, accept_response, ReconnectStatus};
+use super::{accept_initial_response, accept_reconnect_response, accept_response, ReconnectStatus};
 use crate::error::ClientError;
 
 #[test]
@@ -12,6 +14,58 @@ fn fresh_bootstrap_rejects_returning_status() {
     assert!(matches!(
         accept_response(response),
         Err(ClientError::ReturningSessionRequiresRecovery)
+    ));
+}
+
+#[test]
+fn config_only_skip_report_continues_but_explicit_report_is_fatal() {
+    let report = encode_skipped_rows(&[SkippedRow {
+        index: 0,
+        reason: SkipReason::Bind,
+    }])
+    .unwrap();
+
+    assert!(accept_initial_response(
+        InitialResponse {
+            error: Some(report.clone()),
+        },
+        &[ForwardOrigin::SshConfig],
+    )
+    .is_ok());
+    for origin in [ForwardOrigin::Explicit, ForwardOrigin::Reported(0)] {
+        assert!(matches!(
+            accept_initial_response(
+                InitialResponse {
+                    error: Some(report.clone()),
+                },
+                &[origin],
+            ),
+            Err(ClientError::InitialResponseRejected(message))
+                if message == "explicit reverse forwarding row could not bind"
+        ));
+    }
+}
+
+#[test]
+fn old_server_error_and_malformed_reserved_report_fail_closed() {
+    assert!(matches!(
+        accept_initial_response(
+            InitialResponse {
+                error: Some("port forwarding I/O: address in use".to_owned()),
+            },
+            &[ForwardOrigin::SshConfig],
+        ),
+        Err(ClientError::InitialResponseRejected(_))
+    ));
+    assert!(matches!(
+        accept_initial_response(
+            InitialResponse {
+                error: Some("ETRS-RF-SKIP/2;0:B".to_owned()),
+            },
+            &[ForwardOrigin::SshConfig],
+        ),
+        Err(ClientError::InitialResponseRejected(message))
+            if message == "malformed reverse forwarding skip report"
     ));
 }
 

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -242,7 +242,7 @@ fn is_representable_tcp_destination(host: &str) -> bool {
     host.eq_ignore_ascii_case("localhost")
         || host
             .parse::<Ipv4Addr>()
-            .is_ok_and(|address| address.is_loopback())
+            .is_ok_and(|address| address == Ipv4Addr::LOCALHOST)
         || host
             .parse::<Ipv6Addr>()
             .is_ok_and(|address| address == Ipv6Addr::LOCALHOST)
@@ -579,10 +579,7 @@ mod tests {
 
         assert_eq!(
             resolved.local_forwards,
-            [
-                request("localhost", Some(15433), "127.0.0.2", Some(5432)),
-                request("localhost", Some(15434), "LocalHost", Some(5432)),
-            ]
+            [request("localhost", Some(15434), "LocalHost", Some(5432))]
         );
         assert_eq!(
             resolved.remote_forwards,

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -1,3 +1,5 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+
 use crate::bootstrap::{validate_ssh_destination, InvocationCompletion, SshInvocation};
 use crate::deadline::Deadline;
 use crate::error::ClientError;
@@ -66,10 +68,14 @@ fn parse_ssh_config(
                 user = fields.next().map(str::to_string);
             }
             Some(key) if parse_local_forwards && key.eq_ignore_ascii_case("localforward") => {
-                local_forwards.push(parse_forward(fields, "localforward")?);
+                if let Some(forward) = parse_forward(fields, "localforward")? {
+                    local_forwards.push(forward);
+                }
             }
             Some(key) if parse_remote_forwards && key.eq_ignore_ascii_case("remoteforward") => {
-                remote_forwards.push(parse_forward(fields, "remoteforward")?);
+                if let Some(forward) = parse_forward(fields, "remoteforward")? {
+                    remote_forwards.push(forward);
+                }
             }
             _ => {}
         }
@@ -90,7 +96,7 @@ fn parse_ssh_config(
 fn parse_forward<'a>(
     fields: impl Iterator<Item = &'a str>,
     directive: &'static str,
-) -> Result<PortForwardSourceRequest, ClientError> {
+) -> Result<Option<PortForwardSourceRequest>, ClientError> {
     let fields: Vec<&str> = fields.collect();
     let [source, destination] = fields.as_slice() else {
         return Err(ClientError::SshConfigMalformedForward {
@@ -107,11 +113,29 @@ fn parse_forward<'a>(
             directive,
             reason: "invalid destination endpoint",
         })?;
-    Ok(PortForwardSourceRequest {
+    if let (Some(host), Some(_)) = (destination.name.as_deref(), destination.port) {
+        if !is_representable_tcp_destination(host) {
+            et_cli::logging::warn(format!(
+                "SSH {directive} destination host '{host}' is unsupported by ET protocol v6; skipping forwarding row"
+            ));
+            return Ok(None);
+        }
+    }
+    Ok(Some(PortForwardSourceRequest {
         source: Some(source),
         destination: Some(destination),
         environmentvariable: None,
-    })
+    }))
+}
+
+fn is_representable_tcp_destination(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<Ipv4Addr>()
+            .is_ok_and(|address| address.is_loopback())
+        || host
+            .parse::<Ipv6Addr>()
+            .is_ok_and(|address| address == Ipv6Addr::LOCALHOST)
 }
 
 fn parse_source_endpoint(value: &str) -> Option<SocketEndpoint> {
@@ -262,6 +286,33 @@ mod tests {
         assert_eq!(
             resolved.remote_forwards,
             [request("localhost", Some(1492), "127.0.0.1", Some(1492))]
+        );
+    }
+
+    #[test]
+    fn ssh_config_hardening_nonlocal_tcp_destinations_are_skipped_per_row() {
+        let resolved = parse_ssh_config(
+            b"hostname host\n\
+              localforward 15432 db.internal:5432\n\
+              localforward 15433 127.0.0.2:5432\n\
+              localforward 15434 LocalHost:5432\n\
+              remoteforward 25432 db.internal:5432\n\
+              remoteforward 25433 [::1]:5432\n",
+            true,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolved.local_forwards,
+            [
+                request("localhost", Some(15433), "127.0.0.2", Some(5432)),
+                request("localhost", Some(15434), "LocalHost", Some(5432)),
+            ]
+        );
+        assert_eq!(
+            resolved.remote_forwards,
+            [request("localhost", Some(25433), "::1", Some(5432))]
         );
     }
 

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -197,7 +197,7 @@ mod tests {
     }
 
     #[test]
-    fn query_preserves_alias_and_parses_effective_values() {
+    fn ssh_config_hardening_query_does_not_suppress_forwardings() {
         let runner = FakeRunner {
             stdout: b"host server-alias\nuser config-user\nhostname 127.0.0.1\nport 22\n".to_vec(),
         };

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -13,6 +13,18 @@ enum GatewayPorts {
     ClientSpecified,
 }
 
+#[derive(Clone, Copy)]
+enum StreamLocalBindPolicy {
+    Default,
+    Unsupported,
+}
+
+#[derive(Clone, Copy)]
+struct ForwardPolicies {
+    gateway_ports: GatewayPorts,
+    stream_local_bind: StreamLocalBindPolicy,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ResolvedSshConfig {
     pub hostname: String,
@@ -79,6 +91,10 @@ fn parse_ssh_config(
         .map(GatewayPorts::parse)
         .transpose()?
         .unwrap_or(GatewayPorts::No);
+    let policies = ForwardPolicies {
+        gateway_ports,
+        stream_local_bind: StreamLocalBindPolicy::parse(text),
+    };
     let mut hostname = None;
     let mut user = None;
     let mut local_forwards = Vec::new();
@@ -98,13 +114,13 @@ fn parse_ssh_config(
                 );
             }
             Some(key) if parse_local_forwards && key.eq_ignore_ascii_case("localforward") => {
-                match parse_forward(fields, "localforward", gateway_ports)? {
+                match parse_forward(fields, "localforward", policies)? {
                     ForwardRecord::Supported(forward) => local_forwards.push(forward),
                     ForwardRecord::Unsupported(reason) => warn_unsupported("localforward", &reason),
                 }
             }
             Some(key) if parse_remote_forwards && key.eq_ignore_ascii_case("remoteforward") => {
-                match parse_forward(fields, "remoteforward", gateway_ports)? {
+                match parse_forward(fields, "remoteforward", policies)? {
                     ForwardRecord::Supported(forward) => remote_forwards.push(forward),
                     ForwardRecord::Unsupported(reason) => {
                         warn_unsupported("remoteforward", &reason)
@@ -134,7 +150,7 @@ fn warn_unsupported(directive: &str, reason: &str) {
 fn parse_forward<'a>(
     fields: impl Iterator<Item = &'a str>,
     directive: &'static str,
-    gateway_ports: GatewayPorts,
+    policies: ForwardPolicies,
 ) -> Result<ForwardRecord, ClientError> {
     let fields: Vec<&str> = fields.collect();
     if fields.len() != 2 && fields.iter().any(|field| field.contains('/')) {
@@ -164,8 +180,17 @@ fn parse_forward<'a>(
         ));
     }
     if source.starts_with('/') {
+        match policies.stream_local_bind {
+            StreamLocalBindPolicy::Default => {}
+            StreamLocalBindPolicy::Unsupported => {
+                return Ok(ForwardRecord::Unsupported(
+                    "stream-local bind policy is unsupported".to_owned(),
+                ));
+            }
+        }
+        #[cfg(not(unix))]
         return Ok(ForwardRecord::Unsupported(
-            "stream-local bind policy is unsupported".to_owned(),
+            "stream-local forwarding is unsupported on this platform".to_owned(),
         ));
     }
     #[cfg(not(unix))]
@@ -176,7 +201,7 @@ fn parse_forward<'a>(
     }
     let source = parse_source_endpoint(
         source,
-        gateway_ports,
+        policies.gateway_ports,
         directive.eq_ignore_ascii_case("localforward"),
     )
     .ok_or(ClientError::SshConfigMalformedForward {
@@ -231,6 +256,32 @@ impl GatewayPorts {
             "clientspecified" => Ok(Self::ClientSpecified),
             _ => Err(ClientError::SshConfigMalformed("gatewayports")),
         }
+    }
+}
+
+impl StreamLocalBindPolicy {
+    fn parse(text: &str) -> Self {
+        let mut policy = Self::Default;
+        for line in text.lines() {
+            let mut fields = line.split_whitespace();
+            match (fields.next(), fields.next()) {
+                (Some(key), Some(value))
+                    if key.eq_ignore_ascii_case("streamlocalbindunlink")
+                        && !value.eq_ignore_ascii_case("no") =>
+                {
+                    policy = Self::Unsupported;
+                }
+                (Some(key), Some(value))
+                    if key.eq_ignore_ascii_case("streamlocalbindmask")
+                        && value != "0177"
+                        && value != "177" =>
+                {
+                    policy = Self::Unsupported;
+                }
+                _ => {}
+            }
+        }
+        policy
     }
 }
 
@@ -405,6 +456,8 @@ mod tests {
             [
                 request("localhost", Some(10022), "127.0.0.1", Some(22)),
                 request("localhost", Some(18080), "::1", Some(80)),
+                request("/tmp/local.sock", None, "/tmp/remote.sock", None),
+                request("/tmp/mixed.sock", None, "127.0.0.1", Some(8080)),
                 request("localhost", Some(9090), "/tmp/destination.sock", None,),
             ]
         );
@@ -539,6 +592,96 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn ssh_config_hardening_real_openssh_defaults_preserve_absolute_unix_forwards() {
+        // Given
+        struct RemoveFile(std::path::PathBuf);
+        impl Drop for RemoveFile {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_file(&self.0);
+            }
+        }
+        let path = std::env::temp_dir().join(format!(
+            "et-ssh-streamlocal-oracle-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("defaults")
+        ));
+        let _cleanup = RemoveFile(path.clone());
+        std::fs::write(
+            &path,
+            "Host oracle\n HostName localhost\n\
+             LocalForward /tmp/local.sock /tmp/local-destination.sock\n\
+             RemoteForward /tmp/remote.sock /tmp/remote-destination.sock\n",
+        )
+        .unwrap();
+
+        // When
+        let output = std::process::Command::new("ssh")
+            .args(["-G", "-F"])
+            .arg(&path)
+            .arg("oracle")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let resolved = parse_ssh_config(&output.stdout, true, true).unwrap();
+
+        // Then
+        assert_eq!(
+            resolved.local_forwards,
+            [request(
+                "/tmp/local.sock",
+                None,
+                "/tmp/local-destination.sock",
+                None,
+            )]
+        );
+        assert_eq!(
+            resolved.remote_forwards,
+            [request(
+                "/tmp/remote.sock",
+                None,
+                "/tmp/remote-destination.sock",
+                None,
+            )]
+        );
+    }
+
+    #[test]
+    fn ssh_config_hardening_emitted_nondefault_streamlocal_policy_skips_unix_sources() {
+        // Given / When
+        let unlink = parse_ssh_config(
+            b"hostname host\nstreamlocalbindunlink yes\n\
+              localforward /tmp/source.sock /tmp/destination.sock\n\
+              localforward 15433 localhost:5432\n",
+            true,
+            true,
+        )
+        .unwrap();
+        let mask = parse_ssh_config(
+            b"hostname host\nstreamlocalbindmask 0077\n\
+              remoteforward /tmp/source.sock /tmp/destination.sock\n\
+              remoteforward 25433 localhost:5432\n",
+            true,
+            true,
+        )
+        .unwrap();
+
+        // Then
+        assert_eq!(
+            unlink.local_forwards,
+            [request("localhost", Some(15433), "localhost", Some(5432))]
+        );
+        assert_eq!(
+            mask.remote_forwards,
+            [request("localhost", Some(25433), "localhost", Some(5432))]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn ssh_config_hardening_real_openssh_unsupported_records_skip_per_row() {
         struct RemoveFile(std::path::PathBuf);
         impl Drop for RemoveFile {
@@ -561,8 +704,6 @@ mod tests {
  RemoteForward 0 localhost:22
  LocalForward relative/source.sock /tmp/destination.sock
  LocalForward "/tmp/source path" "/tmp/destination path"
- StreamLocalBindUnlink yes
- StreamLocalBindMask 0077
  LocalForward /tmp/source.sock /tmp/destination.sock
  LocalForward 15433 localhost:5432
  RemoteForward 25433 localhost:5432
@@ -585,7 +726,10 @@ mod tests {
 
         assert_eq!(
             resolved.local_forwards,
-            [request("localhost", Some(15433), "localhost", Some(5432))]
+            [
+                request("/tmp/source.sock", None, "/tmp/destination.sock", None,),
+                request("localhost", Some(15433), "localhost", Some(5432)),
+            ]
         );
         assert_eq!(
             resolved.remote_forwards,

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -6,6 +6,13 @@ use crate::error::ClientError;
 use crate::ssh_process::{run_checked, SshRunner};
 use et_core::proto::{PortForwardSourceRequest, SocketEndpoint};
 
+#[derive(Clone, Copy)]
+enum GatewayPorts {
+    No,
+    Yes,
+    ClientSpecified,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ResolvedSshConfig {
     pub hostname: String,
@@ -54,6 +61,19 @@ fn parse_ssh_config(
 ) -> Result<ResolvedSshConfig, ClientError> {
     let text =
         std::str::from_utf8(stdout).map_err(|_| ClientError::SshConfigMalformed("UTF-8 output"))?;
+    let gateway_ports = text
+        .lines()
+        .find_map(|line| {
+            let mut fields = line.split_whitespace();
+            fields
+                .next()
+                .is_some_and(|key| key.eq_ignore_ascii_case("gatewayports"))
+                .then(|| fields.next())
+                .flatten()
+        })
+        .map(GatewayPorts::parse)
+        .transpose()?
+        .unwrap_or(GatewayPorts::No);
     let mut hostname = None;
     let mut user = None;
     let mut local_forwards = Vec::new();
@@ -68,12 +88,12 @@ fn parse_ssh_config(
                 user = fields.next().map(str::to_string);
             }
             Some(key) if parse_local_forwards && key.eq_ignore_ascii_case("localforward") => {
-                if let Some(forward) = parse_forward(fields, "localforward")? {
+                if let Some(forward) = parse_forward(fields, "localforward", gateway_ports)? {
                     local_forwards.push(forward);
                 }
             }
             Some(key) if parse_remote_forwards && key.eq_ignore_ascii_case("remoteforward") => {
-                if let Some(forward) = parse_forward(fields, "remoteforward")? {
+                if let Some(forward) = parse_forward(fields, "remoteforward", gateway_ports)? {
                     remote_forwards.push(forward);
                 }
             }
@@ -96,6 +116,7 @@ fn parse_ssh_config(
 fn parse_forward<'a>(
     fields: impl Iterator<Item = &'a str>,
     directive: &'static str,
+    gateway_ports: GatewayPorts,
 ) -> Result<Option<PortForwardSourceRequest>, ClientError> {
     let fields: Vec<&str> = fields.collect();
     let [source, destination] = fields.as_slice() else {
@@ -104,7 +125,12 @@ fn parse_forward<'a>(
             reason: "expected exactly two fields",
         });
     };
-    let source = parse_source_endpoint(source).ok_or(ClientError::SshConfigMalformedForward {
+    let source = parse_source_endpoint(
+        source,
+        gateway_ports,
+        directive.eq_ignore_ascii_case("localforward"),
+    )
+    .ok_or(ClientError::SshConfigMalformedForward {
         directive,
         reason: "invalid source endpoint",
     })?;
@@ -138,21 +164,63 @@ fn is_representable_tcp_destination(host: &str) -> bool {
             .is_ok_and(|address| address == Ipv6Addr::LOCALHOST)
 }
 
-fn parse_source_endpoint(value: &str) -> Option<SocketEndpoint> {
+impl GatewayPorts {
+    fn parse(value: &str) -> Result<Self, ClientError> {
+        match value {
+            "no" => Ok(Self::No),
+            "yes" => Ok(Self::Yes),
+            "clientspecified" => Ok(Self::ClientSpecified),
+            _ => Err(ClientError::SshConfigMalformed("gatewayports")),
+        }
+    }
+}
+
+fn parse_source_endpoint(
+    value: &str,
+    gateway_ports: GatewayPorts,
+    is_local_forward: bool,
+) -> Option<SocketEndpoint> {
     if let Some(endpoint) = parse_unix_endpoint(value) {
         return Some(endpoint);
     }
     if !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()) {
-        return Some(SocketEndpoint {
-            name: Some("localhost".to_owned()),
-            port: Some(parse_port(value)?),
-        });
+        return Some(normalize_tcp_source(
+            SocketEndpoint {
+                name: Some("localhost".to_owned()),
+                port: Some(parse_port(value)?),
+            },
+            gateway_ports,
+            is_local_forward,
+        ));
     }
-    parse_tcp_endpoint(value)
+    parse_tcp_endpoint(value, true)
+        .map(|endpoint| normalize_tcp_source(endpoint, gateway_ports, is_local_forward))
+}
+
+fn normalize_tcp_source(
+    mut endpoint: SocketEndpoint,
+    gateway_ports: GatewayPorts,
+    is_local_forward: bool,
+) -> SocketEndpoint {
+    let requested = endpoint.name.take().unwrap_or_default();
+    let normalized = match (is_local_forward, gateway_ports) {
+        (false, _) if requested == "*" || requested == "[*]" => String::new(),
+        (false, _) if requested.is_empty() => "localhost".to_owned(),
+        (false, _) => requested,
+        (true, GatewayPorts::No) => "localhost".to_owned(),
+        (true, GatewayPorts::Yes) => String::new(),
+        (true, GatewayPorts::ClientSpecified) if requested == "*" || requested == "[*]" => {
+            String::new()
+        }
+        (true, GatewayPorts::ClientSpecified) if requested.is_empty() => "localhost".to_owned(),
+        (true, GatewayPorts::ClientSpecified) => requested,
+    };
+    endpoint.name = Some(normalized);
+    endpoint
 }
 
 fn parse_destination_endpoint(value: &str) -> Option<SocketEndpoint> {
-    parse_unix_endpoint(value).or_else(|| parse_tcp_endpoint(value))
+    parse_unix_endpoint(value).or_else(|| parse_tcp_endpoint(value, false))
 }
 
 fn parse_unix_endpoint(value: &str) -> Option<SocketEndpoint> {
@@ -165,10 +233,10 @@ fn parse_unix_endpoint(value: &str) -> Option<SocketEndpoint> {
     })
 }
 
-fn parse_tcp_endpoint(value: &str) -> Option<SocketEndpoint> {
+fn parse_tcp_endpoint(value: &str, allow_empty_host: bool) -> Option<SocketEndpoint> {
     let (host, port) = if let Some(bracketed) = value.strip_prefix('[') {
         let (host, port) = bracketed.split_once("]:")?;
-        if host.is_empty() || port.contains(':') {
+        if (!allow_empty_host && host.is_empty()) || port.contains(':') {
             return None;
         }
         (host, port)
@@ -277,16 +345,112 @@ mod tests {
             resolved.local_forwards,
             [
                 request("localhost", Some(10022), "127.0.0.1", Some(22)),
-                request("::1", Some(18080), "::1", Some(80)),
+                request("localhost", Some(18080), "::1", Some(80)),
                 request("/tmp/local.sock", None, "/tmp/remote.sock", None),
                 request("/tmp/mixed.sock", None, "127.0.0.1", Some(8080)),
-                request("127.0.0.1", Some(9090), "/tmp/destination.sock", None,),
+                request("localhost", Some(9090), "/tmp/destination.sock", None,),
             ]
         );
         assert_eq!(
             resolved.remote_forwards,
             [request("localhost", Some(1492), "127.0.0.1", Some(1492))]
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ssh_config_hardening_normalizes_real_openssh_bind_shapes() {
+        struct RemoveFile(std::path::PathBuf);
+        impl Drop for RemoveFile {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_file(&self.0);
+            }
+        }
+        let path = std::env::temp_dir().join(format!(
+            "et-ssh-g-oracle-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("bind-policy")
+        ));
+        let _cleanup = RemoveFile(path.clone());
+        let config = |gatewayports: &str| {
+            format!(
+                "Host oracle\n HostName localhost\n GatewayPorts {gatewayports}\n\
+                 LocalForward *:15432 localhost:5432\n\
+                 LocalForward :15433 localhost:5432\n\
+                 LocalForward 127.0.0.2:15434 localhost:5432\n\
+                 RemoteForward *:25432 localhost:5432\n\
+                 RemoteForward :25433 localhost:5432\n\
+                 RemoteForward 127.0.0.2:25434 localhost:5432\n"
+            )
+        };
+        let query = |gatewayports: &str| {
+            std::fs::write(&path, config(gatewayports)).unwrap();
+            std::process::Command::new("ssh")
+                .args(["-G", "-F"])
+                .arg(&path)
+                .arg("oracle")
+                .output()
+                .unwrap()
+        };
+        let parse_oracle = |gatewayports: &str| {
+            let output = query(gatewayports);
+            assert!(
+                output.status.success(),
+                "{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            parse_ssh_config(&output.stdout, true, true).unwrap()
+        };
+
+        let no = parse_oracle("no");
+        assert_eq!(
+            no.local_forwards
+                .iter()
+                .map(|request| request.source.as_ref().unwrap().name.as_deref().unwrap())
+                .collect::<Vec<_>>(),
+            ["localhost", "localhost", "localhost"]
+        );
+        assert_eq!(
+            no.remote_forwards
+                .iter()
+                .map(|request| request.source.as_ref().unwrap().name.as_deref().unwrap())
+                .collect::<Vec<_>>(),
+            ["", "localhost", "127.0.0.2"]
+        );
+
+        let yes = parse_oracle("yes");
+        assert_eq!(
+            yes.local_forwards
+                .iter()
+                .map(|request| request.source.as_ref().unwrap().name.as_deref().unwrap())
+                .collect::<Vec<_>>(),
+            ["", "", ""]
+        );
+        assert_eq!(
+            yes.remote_forwards
+                .iter()
+                .map(|request| request.source.as_ref().unwrap().name.as_deref().unwrap())
+                .collect::<Vec<_>>(),
+            ["", "localhost", "127.0.0.2"]
+        );
+
+        let clientspecified = query("clientspecified");
+        if clientspecified.status.success() {
+            let resolved = parse_ssh_config(&clientspecified.stdout, true, true).unwrap();
+            assert_eq!(
+                resolved
+                    .local_forwards
+                    .iter()
+                    .map(|request| request.source.as_ref().unwrap().name.as_deref().unwrap())
+                    .collect::<Vec<_>>(),
+                ["", "localhost", "127.0.0.2"]
+            );
+        } else {
+            assert!(
+                String::from_utf8_lossy(&clientspecified.stderr).contains("unsupported option")
+                    && String::from_utf8_lossy(&clientspecified.stderr).contains("clientspecified")
+            );
+        }
     }
 
     #[test]

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -199,15 +199,18 @@ fn parse_forward<'a>(
             "stream-local forwarding is unsupported on this platform".to_owned(),
         ));
     }
-    let source = parse_source_endpoint(
-        source,
-        policies.gateway_ports,
-        directive.eq_ignore_ascii_case("localforward"),
-    )
-    .ok_or(ClientError::SshConfigMalformedForward {
-        directive,
-        reason: "invalid source endpoint",
-    })?;
+    let is_local_forward = directive.eq_ignore_ascii_case("localforward");
+    let source = parse_source_endpoint(source, policies.gateway_ports, is_local_forward).ok_or(
+        ClientError::SshConfigMalformedForward {
+            directive,
+            reason: "invalid source endpoint",
+        },
+    )?;
+    if !is_local_forward && source.name.as_deref() == Some("") {
+        return Ok(ForwardRecord::Unsupported(
+            "wildcard bind is prohibited by authenticated reverse forwarding policy".to_owned(),
+        ));
+    }
     let destination =
         parse_destination_endpoint(destination).ok_or(ClientError::SshConfigMalformedForward {
             directive,
@@ -296,7 +299,7 @@ fn parse_source_endpoint(
     if !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()) {
         return Some(normalize_tcp_source(
             SocketEndpoint {
-                name: Some("localhost".to_owned()),
+                name: None,
                 port: Some(parse_port(value)?),
             },
             gateway_ports,
@@ -312,18 +315,20 @@ fn normalize_tcp_source(
     gateway_ports: GatewayPorts,
     is_local_forward: bool,
 ) -> SocketEndpoint {
-    let requested = endpoint.name.take().unwrap_or_default();
-    let normalized = match (is_local_forward, gateway_ports) {
-        (false, _) if requested == "*" || requested == "[*]" => String::new(),
-        (false, _) if requested.is_empty() => "localhost".to_owned(),
-        (false, _) => requested,
-        (true, GatewayPorts::No) => "localhost".to_owned(),
-        (true, GatewayPorts::Yes) => String::new(),
-        (true, GatewayPorts::ClientSpecified) if requested == "*" || requested == "[*]" => {
+    let requested = endpoint.name.take();
+    let normalized = match (is_local_forward, gateway_ports, requested) {
+        (false, _, None) => "localhost".to_owned(),
+        (false, _, Some(requested)) if requested == "*" || requested == "[*]" => String::new(),
+        (false, _, Some(requested)) => requested,
+        (true, GatewayPorts::No, _) => "localhost".to_owned(),
+        (true, GatewayPorts::Yes, _) => String::new(),
+        (true, GatewayPorts::ClientSpecified, None) => "localhost".to_owned(),
+        (true, GatewayPorts::ClientSpecified, Some(requested))
+            if requested.is_empty() || requested == "*" || requested == "[*]" =>
+        {
             String::new()
         }
-        (true, GatewayPorts::ClientSpecified) if requested.is_empty() => "localhost".to_owned(),
-        (true, GatewayPorts::ClientSpecified) => requested,
+        (true, GatewayPorts::ClientSpecified, Some(requested)) => requested,
     };
     endpoint.name = Some(normalized);
     endpoint
@@ -525,7 +530,7 @@ mod tests {
                 .iter()
                 .map(|request| request.source.as_ref().unwrap().name.as_deref().unwrap())
                 .collect::<Vec<_>>(),
-            ["", "localhost", "127.0.0.2"]
+            ["127.0.0.2"]
         );
 
         let yes = parse_oracle("yes");
@@ -541,7 +546,7 @@ mod tests {
                 .iter()
                 .map(|request| request.source.as_ref().unwrap().name.as_deref().unwrap())
                 .collect::<Vec<_>>(),
-            ["", "localhost", "127.0.0.2"]
+            ["127.0.0.2"]
         );
 
         let clientspecified = query("clientspecified");
@@ -553,7 +558,15 @@ mod tests {
                     .iter()
                     .map(|request| request.source.as_ref().unwrap().name.as_deref().unwrap())
                     .collect::<Vec<_>>(),
-                ["", "localhost", "127.0.0.2"]
+                ["", "", "127.0.0.2"]
+            );
+            assert_eq!(
+                resolved
+                    .remote_forwards
+                    .iter()
+                    .map(|request| request.source.as_ref().unwrap().name.as_deref().unwrap())
+                    .collect::<Vec<_>>(),
+                ["127.0.0.2"]
             );
         } else {
             assert!(
@@ -561,6 +574,37 @@ mod tests {
                     && String::from_utf8_lossy(&clientspecified.stderr).contains("clientspecified")
             );
         }
+    }
+
+    #[test]
+    fn ssh_config_hardening_clientspecified_distinguishes_omitted_and_empty_binds() {
+        let resolved = parse_ssh_config(
+            b"hostname host\ngatewayports clientspecified\n\
+              localforward 15431 localhost:5432\n\
+              localforward []:15432 localhost:5432\n\
+              remoteforward 25431 localhost:5432\n\
+              remoteforward []:25432 localhost:5432\n",
+            true,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolved
+                .local_forwards
+                .iter()
+                .map(|request| request.source.as_ref().unwrap().name.as_deref().unwrap())
+                .collect::<Vec<_>>(),
+            ["localhost", ""]
+        );
+        assert_eq!(
+            resolved
+                .remote_forwards
+                .iter()
+                .map(|request| request.source.as_ref().unwrap().name.as_deref().unwrap())
+                .collect::<Vec<_>>(),
+            ["localhost"]
+        );
     }
 
     #[test]

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -21,6 +21,11 @@ pub struct ResolvedSshConfig {
     pub remote_forwards: Vec<PortForwardSourceRequest>,
 }
 
+enum ForwardRecord {
+    Supported(PortForwardSourceRequest),
+    Unsupported(String),
+}
+
 pub fn resolve_ssh_config(
     runner: &dyn SshRunner,
     host_alias: &str,
@@ -87,14 +92,23 @@ fn parse_ssh_config(
             Some(key) if key.eq_ignore_ascii_case("user") => {
                 user = fields.next().map(str::to_string);
             }
+            Some(key) if parse_local_forwards && key.eq_ignore_ascii_case("dynamicforward") => {
+                et_cli::logging::warn(
+                    "SSH dynamicforward is unsupported by ET protocol v6; skipping forwarding row",
+                );
+            }
             Some(key) if parse_local_forwards && key.eq_ignore_ascii_case("localforward") => {
-                if let Some(forward) = parse_forward(fields, "localforward", gateway_ports)? {
-                    local_forwards.push(forward);
+                match parse_forward(fields, "localforward", gateway_ports)? {
+                    ForwardRecord::Supported(forward) => local_forwards.push(forward),
+                    ForwardRecord::Unsupported(reason) => warn_unsupported("localforward", &reason),
                 }
             }
             Some(key) if parse_remote_forwards && key.eq_ignore_ascii_case("remoteforward") => {
-                if let Some(forward) = parse_forward(fields, "remoteforward", gateway_ports)? {
-                    remote_forwards.push(forward);
+                match parse_forward(fields, "remoteforward", gateway_ports)? {
+                    ForwardRecord::Supported(forward) => remote_forwards.push(forward),
+                    ForwardRecord::Unsupported(reason) => {
+                        warn_unsupported("remoteforward", &reason)
+                    }
                 }
             }
             _ => {}
@@ -113,18 +127,53 @@ fn parse_ssh_config(
     })
 }
 
+fn warn_unsupported(directive: &str, reason: &str) {
+    et_cli::logging::warn(format!("SSH {directive} {reason}; skipping forwarding row"));
+}
+
 fn parse_forward<'a>(
     fields: impl Iterator<Item = &'a str>,
     directive: &'static str,
     gateway_ports: GatewayPorts,
-) -> Result<Option<PortForwardSourceRequest>, ClientError> {
+) -> Result<ForwardRecord, ClientError> {
     let fields: Vec<&str> = fields.collect();
+    if fields.len() != 2 && fields.iter().any(|field| field.contains('/')) {
+        return Ok(ForwardRecord::Unsupported(
+            "ambiguous stream-local path is unsupported".to_owned(),
+        ));
+    }
     let [source, destination] = fields.as_slice() else {
         return Err(ClientError::SshConfigMalformedForward {
             directive,
             reason: "expected exactly two fields",
         });
     };
+    if directive.eq_ignore_ascii_case("remoteforward") && *destination == "[socks]:0" {
+        return Ok(ForwardRecord::Unsupported(
+            "dynamic forwarding is unsupported".to_owned(),
+        ));
+    }
+    if directive.eq_ignore_ascii_case("remoteforward") && endpoint_has_zero_port(source) {
+        return Ok(ForwardRecord::Unsupported(
+            "allocated remote port 0 is unsupported".to_owned(),
+        ));
+    }
+    if is_relative_stream_path(source) || is_relative_stream_path(destination) {
+        return Ok(ForwardRecord::Unsupported(
+            "relative stream-local path is unsupported".to_owned(),
+        ));
+    }
+    if source.starts_with('/') {
+        return Ok(ForwardRecord::Unsupported(
+            "stream-local bind policy is unsupported".to_owned(),
+        ));
+    }
+    #[cfg(not(unix))]
+    if destination.starts_with('/') {
+        return Ok(ForwardRecord::Unsupported(
+            "stream-local forwarding is unsupported on this platform".to_owned(),
+        ));
+    }
     let source = parse_source_endpoint(
         source,
         gateway_ports,
@@ -141,17 +190,27 @@ fn parse_forward<'a>(
         })?;
     if let (Some(host), Some(_)) = (destination.name.as_deref(), destination.port) {
         if !is_representable_tcp_destination(host) {
-            et_cli::logging::warn(format!(
-                "SSH {directive} destination host '{host}' is unsupported by ET protocol v6; skipping forwarding row"
-            ));
-            return Ok(None);
+            return Ok(ForwardRecord::Unsupported(format!(
+                "destination host '{host}' is unsupported by ET protocol v6"
+            )));
         }
     }
-    Ok(Some(PortForwardSourceRequest {
+    Ok(ForwardRecord::Supported(PortForwardSourceRequest {
         source: Some(source),
         destination: Some(destination),
         environmentvariable: None,
     }))
+}
+
+fn endpoint_has_zero_port(value: &str) -> bool {
+    value == "0"
+        || value
+            .strip_suffix(":0")
+            .is_some_and(|host| !host.is_empty())
+}
+
+fn is_relative_stream_path(value: &str) -> bool {
+    !value.starts_with('/') && value.contains('/')
 }
 
 fn is_representable_tcp_destination(host: &str) -> bool {
@@ -327,7 +386,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_ordered_tcp_ipv6_unix_and_mixed_forwards() {
+    fn parses_supported_tcp_and_unix_destination_forwards() {
         let resolved = parse_ssh_config(
             b"hostname host\n\
               localforward 10022 [127.0.0.1]:22\n\
@@ -346,8 +405,6 @@ mod tests {
             [
                 request("localhost", Some(10022), "127.0.0.1", Some(22)),
                 request("localhost", Some(18080), "::1", Some(80)),
-                request("/tmp/local.sock", None, "/tmp/remote.sock", None),
-                request("/tmp/mixed.sock", None, "127.0.0.1", Some(8080)),
                 request("localhost", Some(9090), "/tmp/destination.sock", None,),
             ]
         );
@@ -478,6 +535,77 @@ mod tests {
             resolved.remote_forwards,
             [request("localhost", Some(25433), "::1", Some(5432))]
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ssh_config_hardening_real_openssh_unsupported_records_skip_per_row() {
+        struct RemoveFile(std::path::PathBuf);
+        impl Drop for RemoveFile {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_file(&self.0);
+            }
+        }
+        let path = std::env::temp_dir().join(format!(
+            "et-ssh-unsupported-oracle-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("records")
+        ));
+        let _cleanup = RemoveFile(path.clone());
+        std::fs::write(
+            &path,
+            r#"Host oracle
+ HostName localhost
+ DynamicForward *:1080
+ RemoteForward 2080
+ RemoteForward 0 localhost:22
+ LocalForward relative/source.sock /tmp/destination.sock
+ LocalForward "/tmp/source path" "/tmp/destination path"
+ StreamLocalBindUnlink yes
+ StreamLocalBindMask 0077
+ LocalForward /tmp/source.sock /tmp/destination.sock
+ LocalForward 15433 localhost:5432
+ RemoteForward 25433 localhost:5432
+"#,
+        )
+        .unwrap();
+        let output = std::process::Command::new("ssh")
+            .args(["-G", "-F"])
+            .arg(&path)
+            .arg("oracle")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let resolved = parse_ssh_config(&output.stdout, true, true).unwrap();
+
+        assert_eq!(
+            resolved.local_forwards,
+            [request("localhost", Some(15433), "localhost", Some(5432))]
+        );
+        assert_eq!(
+            resolved.remote_forwards,
+            [request("localhost", Some(25433), "localhost", Some(5432))]
+        );
+    }
+
+    #[test]
+    fn ssh_config_hardening_malformed_record_remains_typed() {
+        assert!(matches!(
+            parse_ssh_config(
+                b"hostname host\nlocalforward 1000 localhost:22 unexpected\n",
+                true,
+                true,
+            ),
+            Err(ClientError::SshConfigMalformedForward {
+                directive: "localforward",
+                reason: "expected exactly two fields",
+            })
+        ));
     }
 
     #[test]

--- a/crates/et-bin/src/terminal_jump.rs
+++ b/crates/et-bin/src/terminal_jump.rs
@@ -48,7 +48,30 @@ pub fn run(
     payload.jumphost = Some(false);
 
     let mut destination = connect_destination(input, destination_host, destination_port, &payload)?;
-    relay(router, &mut destination)
+    write_local_packet(
+        &mut router,
+        &Packet::new(
+            TerminalPacketType::JumphostInit as u8,
+            destination.response_payload.clone(),
+        ),
+    )
+    .map_err(|error| format!("could not relay destination INITIAL_RESPONSE: {error}"))?;
+    if downstream_requires_ack(&destination.response_payload)? {
+        let acknowledgement = et_net::local_packet::read_local_packet(&mut router)
+            .map_err(|error| format!("could not read jumphost acknowledgement: {error}"))?;
+        if !is_acknowledgement(&acknowledgement) {
+            return Err("jumphost acknowledgement is malformed".to_owned());
+        }
+        destination
+            .connection
+            .write_packet(EtPacketType::Heartbeat as u8, &[])
+            .map_err(|error| format!("could not acknowledge destination response: {error}"))?;
+    }
+    destination
+        .connection
+        .set_io_timeout(None)
+        .map_err(|error| format!("could not clear the destination timeout: {error}"))?;
+    relay(router, &mut destination.connection)
 }
 
 fn read_jumphost_init(router: &mut LocalStream) -> Result<InitialPayload, String> {
@@ -64,12 +87,17 @@ fn read_jumphost_init(router: &mut LocalStream) -> Result<InitialPayload, String
         .map_err(|_| "JUMPHOST_INIT protobuf is malformed".to_owned())
 }
 
+struct DestinationHandshake {
+    connection: Connection,
+    response_payload: Vec<u8>,
+}
+
 fn connect_destination(
     input: &CredentialInput,
     host: &str,
     port: u16,
     payload: &InitialPayload,
-) -> Result<Connection, String> {
+) -> Result<DestinationHandshake, String> {
     let key = passkey_to_key(&input.passkey).ok_or_else(|| "invalid passkey".to_owned())?;
     let mut last_error = String::from("Connect Timeout");
     for _ in 0..CONNECT_ATTEMPTS {
@@ -90,7 +118,7 @@ fn try_connect_once(
     host: &str,
     port: u16,
     payload: &InitialPayload,
-) -> Result<Connection, String> {
+) -> Result<DestinationHandshake, String> {
     let addresses = (host, port)
         .to_socket_addrs()
         .map_err(|error| format!("could not resolve {host}: {error}"))?;
@@ -145,15 +173,22 @@ fn try_connect_once(
     if packet.header() != EtPacketType::InitialResponse as u8 {
         return Err("Missing initial response!".to_owned());
     }
-    let response = InitialResponse::decode(packet.payload())
-        .map_err(|_| "malformed INITIAL_RESPONSE".to_owned())?;
-    if let Some(error) = response.error {
-        return Err(format!("Error initializing connection: {error}"));
-    }
-    connection
-        .set_io_timeout(None)
-        .map_err(|error| format!("could not clear the destination timeout: {error}"))?;
-    Ok(connection)
+    Ok(DestinationHandshake {
+        connection,
+        response_payload: packet.payload().to_vec(),
+    })
+}
+
+fn downstream_requires_ack(payload: &[u8]) -> Result<bool, String> {
+    InitialResponse::decode(payload)
+        .map(|response| response.error.is_some())
+        .map_err(|_| "destination sent a malformed INITIAL_RESPONSE".to_owned())
+}
+
+fn is_acknowledgement(packet: &Packet) -> bool {
+    !packet.is_encrypted()
+        && packet.header() == EtPacketType::Heartbeat as u8
+        && packet.payload().is_empty()
 }
 
 /// Relay packets verbatim between the local router and the destination.
@@ -306,5 +341,29 @@ fn read_router_packet(
             Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
             Err(error) => return Err(format!("could not read the router: {error}")),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::downstream_requires_ack;
+    use et_core::proto::InitialResponse;
+    use prost::Message;
+
+    #[test]
+    fn malformed_downstream_initial_response_fails_closed() {
+        assert_eq!(
+            downstream_requires_ack(&[0xff]),
+            Err("destination sent a malformed INITIAL_RESPONSE".to_owned())
+        );
+        assert_eq!(
+            downstream_requires_ack(
+                &InitialResponse {
+                    error: Some("ordinary fatal".to_owned()),
+                }
+                .encode_to_vec()
+            ),
+            Ok(true)
+        );
     }
 }

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -250,6 +250,14 @@ fn ssh_config_hardening_nonlocal_destinations_warn_and_other_rows_continue() {
         .args(["--logtostdout", "-N", &format!("server-alias:{port}")])
         .output()
         .unwrap();
+    if output.status.code() == Some(2) {
+        let _ = TcpStream::connect(("127.0.0.1", port));
+        let _ = server.join();
+        panic!(
+            "expected unsupported rows to preserve the base session, got exit 2: {}",
+            stderr(&output)
+        );
+    }
     let payload = server.join().unwrap();
 
     assert_ne!(output.status.code(), Some(2), "{}", stderr(&output));
@@ -268,6 +276,75 @@ fn ssh_config_hardening_nonlocal_destinations_warn_and_other_rows_continue() {
             .count(),
         2
     );
+}
+
+#[test]
+fn ssh_config_hardening_unsupported_records_warn_and_base_session_continues() {
+    let (port, server) = initial_payload_server_with_error(Some("stop after payload"));
+    let fake = FakeSsh::new();
+    let config = concat!(
+        "host server-alias
+",
+        "user config-user
+",
+        "hostname 127.0.0.1
+",
+        "streamlocalbindunlink yes
+",
+        "streamlocalbindmask 0077
+",
+        "dynamicforward [*]:1080
+",
+        "remoteforward 2080 [socks]:0
+",
+        "remoteforward 0 [localhost]:22
+",
+        "localforward relative/source.sock /tmp/destination.sock
+",
+        "localforward /tmp/source path /tmp/destination path
+",
+        "localforward /tmp/source.sock /tmp/destination.sock
+",
+        "localforward 15433 [localhost]:5432
+",
+        "remoteforward 25433 [localhost]:5432
+",
+    );
+
+    let output = fake
+        .command(config, VALID_MARKER, 0, "")
+        .args(["--logtostdout", "-N", &format!("server-alias:{port}")])
+        .output()
+        .unwrap();
+    if output.status.code() == Some(2) {
+        let _ = TcpStream::connect(("127.0.0.1", port));
+        let _ = server.join();
+        panic!(
+            "expected unsupported rows to preserve the base session, got exit 2: {}",
+            stderr(&output)
+        );
+    }
+    let payload = server.join().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_ne!(output.status.code(), Some(2), "{}", stderr(&output));
+    assert_eq!(payload.reversetunnels.len(), 1);
+    assert_eq!(
+        payload.reversetunnels[0]
+            .source
+            .as_ref()
+            .and_then(|source| source.port),
+        Some(25433)
+    );
+    for reason in [
+        "dynamic forwarding is unsupported",
+        "allocated remote port 0 is unsupported",
+        "relative stream-local path is unsupported",
+        "ambiguous stream-local path is unsupported",
+        "stream-local bind policy is unsupported",
+    ] {
+        assert!(stdout.contains(reason), "missing {reason:?} in {stdout}");
+    }
 }
 
 #[test]

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -566,9 +566,9 @@ fn cli_proves_exact_ssh_bootstrap_v6_and_encrypted_initial_payload() {
     assert_eq!(
         &argv[..3],
         [
-            "test-user@server-alias",
-            "-oStrictHostKeyChecking=no",
             "-oClearAllForwardings=yes",
+            "-oStrictHostKeyChecking=no",
+            "test-user@server-alias",
         ]
     );
     let prefix = "printf '%s\\n' '";
@@ -883,8 +883,8 @@ fn explicit_posix_shell_skips_probe_and_uses_exact_posix_bootstrap() {
     assert_eq!(invocations.len(), 2, "{invocations:?}");
     assert_eq!(invocations[0], ["-G", "-T", "127.0.0.1"]);
     let bootstrap = &invocations[1];
-    assert_eq!(bootstrap[0], "config-user@127.0.0.1");
-    assert_eq!(bootstrap[1], "-oClearAllForwardings=yes");
+    assert_eq!(bootstrap[0], "-oClearAllForwardings=yes");
+    assert_eq!(bootstrap[1], "config-user@127.0.0.1");
     let input = bootstrap[2]
         .strip_prefix("printf '%s\\n' '")
         .unwrap()
@@ -1274,8 +1274,8 @@ fn jumphost_starts_a_jump_terminal_and_connects_to_the_jumphost() {
     let destination = &invocations[2];
     assert_eq!(destination[0], "-J");
     assert_eq!(destination[1], "jump.example");
-    assert_eq!(destination[2], "test-user@server-alias");
-    assert_eq!(destination[3], "-oClearAllForwardings=yes");
+    assert_eq!(destination[2], "-oClearAllForwardings=yes");
+    assert_eq!(destination[3], "test-user@server-alias");
     let destination_command = &destination[4];
     assert!(
         destination_command.starts_with("echo "),

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -414,18 +414,22 @@ fn cli_proves_exact_ssh_bootstrap_v6_and_encrypted_initial_payload() {
     assert!(invocations[1].last().unwrap().contains("__ET_COMSPEC__"));
     let argv = &invocations[2];
     assert_eq!(
-        &argv[..2],
-        ["test-user@server-alias", "-oStrictHostKeyChecking=no"]
+        &argv[..3],
+        [
+            "test-user@server-alias",
+            "-oStrictHostKeyChecking=no",
+            "-oClearAllForwardings=yes",
+        ]
     );
     let prefix = "printf '%s\\n' '";
-    let value = argv[2].strip_prefix(prefix).unwrap();
+    let value = argv[3].strip_prefix(prefix).unwrap();
     let provisional = value.split_once("_xterm-256color'").unwrap().0;
     let (id, key) = parse_id_passkey(provisional).unwrap();
     assert!(id.starts_with("XXX"));
     assert_eq!(id.len(), 16);
     assert_eq!(key.len(), 32);
     assert_eq!(
-        argv[2],
+        argv[3],
         format!(
             "printf '%s\\n' '{provisional}_xterm-256color' | '/opt/et terminal' '--verbose=2' '--serverfifo=/tmp/server fifo'"
         )
@@ -730,7 +734,8 @@ fn explicit_posix_shell_skips_probe_and_uses_exact_posix_bootstrap() {
     assert_eq!(invocations[0], ["-G", "-T", "127.0.0.1"]);
     let bootstrap = &invocations[1];
     assert_eq!(bootstrap[0], "config-user@127.0.0.1");
-    let input = bootstrap[1]
+    assert_eq!(bootstrap[1], "-oClearAllForwardings=yes");
+    let input = bootstrap[2]
         .strip_prefix("printf '%s\\n' '")
         .unwrap()
         .strip_suffix("_xterm-256color' | 'etterminal' '--verbose=0'")
@@ -1120,37 +1125,49 @@ fn jumphost_starts_a_jump_terminal_and_connects_to_the_jumphost() {
     assert_eq!(destination[0], "-J");
     assert_eq!(destination[1], "jump.example");
     assert_eq!(destination[2], "test-user@server-alias");
-    assert!(destination[3].starts_with("echo "), "{:?}", destination[3]);
+    assert_eq!(destination[3], "-oClearAllForwardings=yes");
+    let destination_command = &destination[4];
     assert!(
-        destination[3].contains("\"et.exe\""),
-        "{:?}",
-        destination[3]
+        destination_command.starts_with("echo "),
+        "{destination_command:?}"
     );
     assert!(
-        destination[3].contains("_xterm-256color|"),
-        "{:?}",
-        destination[3]
+        destination_command.contains("\"et.exe\""),
+        "{destination_command:?}"
     );
     assert!(
-        !destination[3].contains("_xterm-ghostty"),
-        "{:?}",
-        destination[3]
+        destination_command.contains("_xterm-256color|"),
+        "{destination_command:?}"
+    );
+    assert!(
+        !destination_command.contains("_xterm-ghostty"),
+        "{destination_command:?}"
     );
     assert_eq!(invocations[3], ["-G", "-T", "jump.example"]);
     let jump = &invocations[4];
-    assert_eq!(jump[0], "jump.example");
+    assert_eq!(jump[0], "-oClearAllForwardings=yes");
+    assert_eq!(jump[1], "jump.example");
+    let jump_command = &jump[2];
     // The jumphost remains POSIX even when the destination probe selects Cmd.
-    assert!(jump[1].contains("'etterminal'"), "{:?}", jump[1]);
-    assert!(!jump[1].contains("et.exe"), "{:?}", jump[1]);
-    assert!(jump[1].contains("_xterm-256color'"), "{:?}", jump[1]);
-    assert!(!jump[1].contains("_xterm-ghostty"), "{:?}", jump[1]);
-    assert!(jump[1].contains("'--jump'"), "{:?}", jump[1]);
-    assert!(jump[1].contains("'--dsthost=127.0.0.1'"), "{:?}", jump[1]);
-    assert!(jump[1].contains("'--dstport=2022'"), "{:?}", jump[1]);
+    assert!(jump_command.contains("'etterminal'"), "{jump_command:?}");
+    assert!(!jump_command.contains("et.exe"), "{jump_command:?}");
     assert!(
-        jump[1].contains("'--serverfifo=/tmp/jump.fifo'"),
-        "{:?}",
-        jump[1]
+        jump_command.contains("_xterm-256color'"),
+        "{jump_command:?}"
+    );
+    assert!(!jump_command.contains("_xterm-ghostty"), "{jump_command:?}");
+    assert!(jump_command.contains("'--jump'"), "{jump_command:?}");
+    assert!(
+        jump_command.contains("'--dsthost=127.0.0.1'"),
+        "{jump_command:?}"
+    );
+    assert!(
+        jump_command.contains("'--dstport=2022'"),
+        "{jump_command:?}"
+    );
+    assert!(
+        jump_command.contains("'--serverfifo=/tmp/jump.fifo'"),
+        "{jump_command:?}"
     );
 }
 

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -400,37 +400,50 @@ fn ssh_config_extra_forward_field_is_rejected_before_bootstrap() {
 }
 
 #[test]
-fn ssh_config_malformed_replaced_axis_is_ignored() {
-    let config = concat!(
+fn ssh_config_malformed_axis_is_rejected_even_with_explicit_forward() {
+    // Given
+    let base_config = concat!(
         "host server-alias\n",
         "user config-user\n",
         "hostname 127.0.0.1\n",
         "port 22\n",
-        "localforward unsupported\n",
-        "remoteforward 1492 [127.0.0.1]:1492 unexpected\n",
     );
 
-    for (option, value, rejected, ignored) in [
-        ("-t", "5555:22", "remoteforward", "localforward"),
-        ("-r", "3000:4000", "localforward", "remoteforward"),
+    for (option, value, malformed, row) in [
+        (
+            "-t",
+            "5555:22",
+            "localforward",
+            "localforward unsupported\n",
+        ),
+        (
+            "-r",
+            "3000:4000",
+            "remoteforward",
+            "remoteforward 1492 [127.0.0.1]:1492 unexpected\n",
+        ),
     ] {
         let fake = FakeSsh::new();
+        let config = format!("{base_config}{row}");
+
+        // When
         let output = fake
-            .command(config, VALID_MARKER, 0, "")
+            .command(&config, VALID_MARKER, 0, "")
             .args(["-N", option, value, "server-alias:1"])
             .output()
             .unwrap();
         let error = stderr(&output);
 
+        // Then
         assert_eq!(output.status.code(), Some(2), "{option}: {error}");
-        assert!(error.contains(&format!("malformed {rejected}")), "{error}");
-        assert!(!error.contains(&format!("malformed {ignored}")), "{error}");
+        assert!(error.contains(&format!("malformed {malformed}")), "{error}");
         assert_eq!(fake.invocations(), [["-G", "-T", "server-alias"]]);
     }
 }
 
 #[test]
-fn ssh_config_cli_same_axis_replaces_config() {
+fn ssh_config_and_cli_remote_forwards_are_cumulative_and_exactly_deduplicated() {
+    // Given
     let (port, server) = initial_payload_server_with_error(Some("stop after payload"));
     let fake = FakeSsh::new();
     let config = concat!(
@@ -440,27 +453,48 @@ fn ssh_config_cli_same_axis_replaces_config() {
         "port 22\n",
         "localforward 10022 [127.0.0.1]:22\n",
         "remoteforward 1492 [127.0.0.1]:1492\n",
+        "remoteforward 1492 [127.0.0.1]:1492\n",
+        "remoteforward 1492 [127.0.0.1]:1493\n",
     );
 
+    // When
     let _output = fake
         .command(config, VALID_MARKER, 0, "")
-        .args(["-N", "-r", "3000:4000", &format!("server-alias:{port}")])
+        .args([
+            "-N",
+            "-r",
+            "localhost:3000:127.0.0.1:4000",
+            "-r",
+            "localhost:3000:127.0.0.1:4000",
+            "-r",
+            "localhost:1492:127.0.0.1:1492",
+            &format!("server-alias:{port}"),
+        ])
         .output()
         .unwrap();
     let payload = server.join().unwrap();
 
-    assert_eq!(payload.reversetunnels.len(), 1);
-    let reverse = &payload.reversetunnels[0];
+    // Then
+    let ports = payload
+        .reversetunnels
+        .iter()
+        .map(|request| {
+            (
+                request.source.as_ref().and_then(|source| source.port),
+                request
+                    .destination
+                    .as_ref()
+                    .and_then(|destination| destination.port),
+            )
+        })
+        .collect::<Vec<_>>();
     assert_eq!(
-        reverse.source.as_ref().and_then(|source| source.port),
-        Some(3000)
-    );
-    assert_eq!(
-        reverse
-            .destination
-            .as_ref()
-            .and_then(|destination| destination.port),
-        Some(4000)
+        ports,
+        [
+            (Some(3000), Some(4000)),
+            (Some(1492), Some(1492)),
+            (Some(1492), Some(1493)),
+        ]
     );
 }
 

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -232,6 +232,45 @@ fn ssh_config_forwards_apply_on_the_unspecified_axis() {
 }
 
 #[test]
+fn ssh_config_hardening_nonlocal_destinations_warn_and_other_rows_continue() {
+    let (port, server) = initial_payload_server_with_error(Some("stop after payload"));
+    let fake = FakeSsh::new();
+    let config = concat!(
+        "host server-alias\n",
+        "user config-user\n",
+        "hostname 127.0.0.1\n",
+        "localforward 15432 db.internal:5432\n",
+        "localforward 15433 127.0.0.2:5432\n",
+        "remoteforward 25432 db.internal:5432\n",
+        "remoteforward 25433 [::1]:5432\n",
+    );
+
+    let output = fake
+        .command(config, VALID_MARKER, 0, "")
+        .args(["--logtostdout", "-N", &format!("server-alias:{port}")])
+        .output()
+        .unwrap();
+    let payload = server.join().unwrap();
+
+    assert_ne!(output.status.code(), Some(2), "{}", stderr(&output));
+    assert_eq!(payload.reversetunnels.len(), 1);
+    assert_eq!(
+        payload.reversetunnels[0]
+            .source
+            .as_ref()
+            .and_then(|source| source.port),
+        Some(25433)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter(|line| line.contains("WARNING"))
+            .count(),
+        2
+    );
+}
+
+#[test]
 fn ssh_config_malformed_forward_is_rejected() {
     let fake = FakeSsh::new();
     let config = concat!(

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -274,7 +274,7 @@ fn ssh_config_hardening_nonlocal_destinations_warn_and_other_rows_continue() {
             .lines()
             .filter(|line| line.contains("WARNING"))
             .count(),
-        2
+        3
     );
 }
 

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -243,6 +243,7 @@ fn ssh_config_hardening_nonlocal_destinations_warn_and_other_rows_continue() {
         "localforward 15433 127.0.0.2:5432\n",
         "remoteforward 25432 db.internal:5432\n",
         "remoteforward 25433 [::1]:5432\n",
+        "remoteforward []:25434 localhost:5432\n",
     );
 
     let output = fake
@@ -274,7 +275,7 @@ fn ssh_config_hardening_nonlocal_destinations_warn_and_other_rows_continue() {
             .lines()
             .filter(|line| line.contains("WARNING"))
             .count(),
-        3
+        4
     );
 }
 

--- a/crates/et-bin/tests/tunnels_end_to_end.rs
+++ b/crates/et-bin/tests/tunnels_end_to_end.rs
@@ -479,6 +479,7 @@ fn spawn_client(
     process
         .env("PATH", &stack.directory)
         .env("ET_SSH_COUNT", &stack.ssh_count)
+        .env("ET_SHELL", "/bin/sh")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())

--- a/crates/et-bin/tests/tunnels_end_to_end.rs
+++ b/crates/et-bin/tests/tunnels_end_to_end.rs
@@ -134,6 +134,109 @@ gatewayports no
 }
 
 #[test]
+fn imported_remote_bind_report_warns_and_keeps_usable_row_live() {
+    let mut stack = Stack::start();
+    let occupied = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let occupied_port = occupied.local_addr().unwrap().port();
+    let destination = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let destination_port = destination.local_addr().unwrap().port();
+    let echo = spawn_tcp_echo_once(destination, b"usable-remote-import");
+    let usable_port = reserve_port();
+    let gate = stack.directory.join("imported-remote-bind-ready");
+    mkfifo(&gate);
+    let config = format!(
+        "hostname 127.0.0.1\nuser tester\n\
+         remoteforward {occupied_port} [127.0.0.1]:{destination_port}\n\
+         remoteforward {usable_port} [127.0.0.1]:{destination_port}\n"
+    );
+    let mut client = Command::new(env!("CARGO_BIN_EXE_et"))
+        .env("PATH", &stack.directory)
+        .env("ET_SSH_COUNT", &stack.ssh_count)
+        .env("ET_SSH_CONFIG", config)
+        .env("ET_SSH_READY", &gate)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .args(["--logtostdout", "--terminal-path"])
+        .arg(&stack.terminal)
+        .args(["--serverfifo"])
+        .arg(&stack.router)
+        .arg("-N")
+        .arg(format!("tester@127.0.0.1:{}", stack.port))
+        .spawn()
+        .unwrap();
+
+    assert_eq!(await_fifo(&gate, &mut client), "ready");
+    assert_ready_tcp_round_trip(usable_port, b"usable-remote-import");
+
+    stop(&mut client);
+    let mut output = String::new();
+    client
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut output)
+        .unwrap();
+    assert_eq!(
+        output
+            .lines()
+            .filter(|line| line.contains("WARNING"))
+            .count(),
+        1
+    );
+    drop(occupied);
+    echo.join().unwrap();
+    stack.shutdown();
+}
+
+#[test]
+fn explicit_remote_bind_report_aborts_and_releases_sibling_listener() {
+    let mut stack = Stack::start();
+    let occupied = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let occupied_port = occupied.local_addr().unwrap().port();
+    let sibling_port = reserve_port();
+    let mut client = Command::new(env!("CARGO_BIN_EXE_et"))
+        .env("PATH", &stack.directory)
+        .env("ET_SSH_COUNT", &stack.ssh_count)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .args(["--terminal-path"])
+        .arg(&stack.terminal)
+        .args(["--serverfifo"])
+        .arg(&stack.router)
+        .args(["-N", "-r"])
+        .arg(format!("{occupied_port}:1"))
+        .arg("-r")
+        .arg(format!("{sibling_port}:1"))
+        .arg(format!("tester@127.0.0.1:{}", stack.port))
+        .spawn()
+        .unwrap();
+
+    let status = client
+        .wait_timeout(TIMEOUT)
+        .unwrap()
+        .expect("explicit reported bind failure did not terminate the client");
+    let mut error = String::new();
+    client
+        .stderr
+        .take()
+        .unwrap()
+        .read_to_string(&mut error)
+        .unwrap();
+
+    assert!(!status.success());
+    assert!(
+        error.contains("explicit reverse forwarding row could not bind"),
+        "{error}"
+    );
+    stack.shutdown();
+    let rebound = TcpListener::bind((Ipv4Addr::LOCALHOST, sibling_port)).unwrap();
+    drop(rebound);
+    drop(occupied);
+}
+
+#[test]
 fn cumulative_local_forwards_deduplicate_exact_rows_but_preserve_distinct_destinations() {
     // Given
     let mut stack = Stack::start();

--- a/crates/et-bin/tests/tunnels_end_to_end.rs
+++ b/crates/et-bin/tests/tunnels_end_to_end.rs
@@ -190,6 +190,121 @@ fn imported_remote_bind_report_warns_and_keeps_usable_row_live() {
 }
 
 #[test]
+fn native_jumphost_relays_imported_remote_skip_report_and_acknowledgement() {
+    let mut destination = Stack::start();
+    let mut jump = Stack::start();
+    let occupied = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let occupied_port = occupied.local_addr().unwrap().port();
+    let backend = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let backend_port = backend.local_addr().unwrap().port();
+    let echo = spawn_tcp_echo_once(backend, b"native-jump-report");
+    let usable_port = reserve_port();
+    let gate = destination.directory.join("native-jump-report-ready");
+    mkfifo(&gate);
+    let config = format!(
+        "hostname 127.0.0.1\nuser tester\n\
+         remoteforward {occupied_port} [127.0.0.1]:{backend_port}\n\
+         remoteforward {usable_port} [127.0.0.1]:{backend_port}\n"
+    );
+    let mut client = Command::new(env!("CARGO_BIN_EXE_et"))
+        .env("PATH", &destination.directory)
+        .env("ET_SSH_COUNT", &destination.ssh_count)
+        .env("ET_SSH_CONFIG", config)
+        .env("ET_SSH_READY", &gate)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .args(["--logtostdout", "--terminal-path"])
+        .arg(&destination.terminal)
+        .args(["--serverfifo"])
+        .arg(&destination.router)
+        .args(["--jumphost", "jump.example", "--jport"])
+        .arg(jump.port.to_string())
+        .args(["--jserverfifo"])
+        .arg(&jump.router)
+        .arg("-N")
+        .arg(format!("tester@127.0.0.1:{}", destination.port))
+        .spawn()
+        .unwrap();
+
+    assert_eq!(await_fifo(&gate, &mut client), "ready");
+    assert_ready_tcp_round_trip(usable_port, b"native-jump-report");
+
+    stop(&mut client);
+    let mut output = String::new();
+    client
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut output)
+        .unwrap();
+    assert_eq!(
+        output
+            .lines()
+            .filter(|line| line.contains("WARNING"))
+            .count(),
+        1
+    );
+    drop(occupied);
+    echo.join().unwrap();
+    jump.shutdown();
+    destination.shutdown();
+}
+
+#[test]
+fn native_jumphost_explicit_remote_skip_aborts_and_releases_final_sibling() {
+    let mut destination = Stack::start();
+    let mut jump = Stack::start();
+    let occupied = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let occupied_port = occupied.local_addr().unwrap().port();
+    let sibling_port = reserve_port();
+    let mut client = Command::new(env!("CARGO_BIN_EXE_et"))
+        .env("PATH", &destination.directory)
+        .env("ET_SSH_COUNT", &destination.ssh_count)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .args(["--terminal-path"])
+        .arg(&destination.terminal)
+        .args(["--serverfifo"])
+        .arg(&destination.router)
+        .args(["--jumphost", "jump.example", "--jport"])
+        .arg(jump.port.to_string())
+        .args(["--jserverfifo"])
+        .arg(&jump.router)
+        .args(["-N", "-r"])
+        .arg(format!("{occupied_port}:1"))
+        .arg("-r")
+        .arg(format!("{sibling_port}:1"))
+        .arg(format!("tester@127.0.0.1:{}", destination.port))
+        .spawn()
+        .unwrap();
+
+    let status = client
+        .wait_timeout(TIMEOUT)
+        .unwrap()
+        .expect("native jumphost explicit skip did not terminate the top-level client");
+    let mut error = String::new();
+    client
+        .stderr
+        .take()
+        .unwrap()
+        .read_to_string(&mut error)
+        .unwrap();
+
+    assert!(!status.success());
+    assert!(
+        error.contains("explicit reverse forwarding row could not bind"),
+        "{error}"
+    );
+    jump.shutdown();
+    destination.shutdown();
+    let rebound = TcpListener::bind((Ipv4Addr::LOCALHOST, sibling_port)).unwrap();
+    drop(rebound);
+    drop(occupied);
+}
+
+#[test]
 fn explicit_remote_bind_report_aborts_and_releases_sibling_listener() {
     let mut stack = Stack::start();
     let occupied = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();

--- a/crates/et-bin/tests/tunnels_end_to_end.rs
+++ b/crates/et-bin/tests/tunnels_end_to_end.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 
 use reconnect_stack::{mkfifo, shell_quote, Stack};
 use tunnel_support::SingleCutProxy;
+use wait_timeout::ChildExt;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -59,6 +60,107 @@ fn ssh_config_local_and_remote_tunnels_relay_real_tcp_payloads() {
     stop(&mut client);
     local_echo.join().unwrap();
     reverse_echo.join().unwrap();
+    stack.shutdown();
+}
+
+#[test]
+fn ssh_config_hardening_imported_bind_failure_skips_only_that_row() {
+    let mut stack = Stack::start();
+    let occupied = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let occupied_port = occupied.local_addr().unwrap().port();
+    let destination = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let destination_port = destination.local_addr().unwrap().port();
+    let echo = spawn_tcp_echo_once(destination, b"usable-import");
+    let usable_port = reserve_port();
+    let gate = stack.directory.join("imported-bind-ready");
+    mkfifo(&gate);
+    let config = format!(
+        "hostname 127.0.0.1
+user tester
+gatewayports no
+         localforward {occupied_port} [127.0.0.1]:{destination_port}
+         localforward {usable_port} [127.0.0.1]:{destination_port}
+"
+    );
+    let mut client = Command::new(env!("CARGO_BIN_EXE_et"));
+    client
+        .env("PATH", &stack.directory)
+        .env("ET_SSH_COUNT", &stack.ssh_count)
+        .env("ET_SSH_CONFIG", config)
+        .env("ET_SSH_READY", &gate)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .args(["--logtostdout", "--terminal-path"])
+        .arg(&stack.terminal)
+        .args(["--serverfifo"])
+        .arg(&stack.router)
+        .arg("-N")
+        .arg(format!("tester@127.0.0.1:{}", stack.port));
+    let mut client = client.spawn().unwrap();
+
+    let ready = {
+        let gate = gate.clone();
+        let (sender, receiver) = mpsc::sync_channel(1);
+        thread::spawn(move || {
+            let _ = sender.send(fs::read_to_string(gate));
+        });
+        receiver
+            .recv_timeout(TIMEOUT)
+            .expect("imported bind failure prevented client readiness")
+            .unwrap()
+    };
+    assert_eq!(ready, "ready");
+    assert_ready_tcp_round_trip(usable_port, b"usable-import");
+
+    stop(&mut client);
+    let mut output = String::new();
+    client
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut output)
+        .unwrap();
+    assert_eq!(
+        output
+            .lines()
+            .filter(|line| line.contains("WARNING"))
+            .count(),
+        1
+    );
+    drop(occupied);
+    echo.join().unwrap();
+    stack.shutdown();
+}
+
+#[test]
+fn ssh_config_hardening_explicit_bind_failure_remains_fatal() {
+    let mut stack = Stack::start();
+    let occupied = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let occupied_port = occupied.local_addr().unwrap().port();
+    let mut client = Command::new(env!("CARGO_BIN_EXE_et"))
+        .env("PATH", &stack.directory)
+        .env("ET_SSH_COUNT", &stack.ssh_count)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .args(["--terminal-path"])
+        .arg(&stack.terminal)
+        .args(["--serverfifo"])
+        .arg(&stack.router)
+        .args(["-N", "--tunnel"])
+        .arg(format!("{occupied_port}:1"))
+        .arg(format!("tester@127.0.0.1:{}", stack.port))
+        .spawn()
+        .unwrap();
+
+    let status = client
+        .wait_timeout(TIMEOUT)
+        .unwrap()
+        .expect("explicit bind failure did not terminate the client");
+
+    assert!(!status.success());
+    drop(occupied);
     stack.shutdown();
 }
 

--- a/crates/et-bin/tests/tunnels_end_to_end.rs
+++ b/crates/et-bin/tests/tunnels_end_to_end.rs
@@ -23,11 +23,11 @@ fn ssh_config_local_and_remote_tunnels_relay_real_tcp_payloads() {
     let mut stack = Stack::start();
     let local_destination = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let local_destination_port = local_destination.local_addr().unwrap().port();
-    let local_echo = spawn_tcp_echo(local_destination);
+    let local_echo = spawn_tcp_echo_once(local_destination, b"config-local");
     let local_source_port = reserve_port();
     let reverse_destination = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let reverse_destination_port = reverse_destination.local_addr().unwrap().port();
-    let reverse_echo = spawn_tcp_echo(reverse_destination);
+    let reverse_echo = spawn_tcp_echo_once(reverse_destination, b"config-reverse");
     let reverse_source_port = reserve_port();
     let gate = stack.directory.join("ssh-config-ready");
     mkfifo(&gate);
@@ -53,9 +53,9 @@ fn ssh_config_local_and_remote_tunnels_relay_real_tcp_payloads() {
         .arg(format!("tester@127.0.0.1:{}", stack.port));
     let mut client = client.spawn().unwrap();
 
-    await_fifo(&gate);
-    assert_tcp_round_trip(local_source_port, b"config-local");
-    assert_tcp_round_trip(reverse_source_port, b"config-reverse");
+    await_fifo(&gate, &mut client);
+    assert_ready_tcp_round_trip(local_source_port, b"config-local");
+    assert_ready_tcp_round_trip(reverse_source_port, b"config-reverse");
 
     stop(&mut client);
     local_echo.join().unwrap();
@@ -169,7 +169,7 @@ fn cumulative_local_forwards_deduplicate_exact_rows_but_preserve_distinct_destin
 
     // When
     let mut client = client.spawn().unwrap();
-    assert_eq!(await_fifo(&gate), "ready");
+    assert_eq!(await_fifo(&gate, &mut client), "ready");
     assert_ready_tcp_round_trip(source_port, b"cumulative");
 
     // Then
@@ -278,7 +278,7 @@ fn ssh_config_mixed_unix_tcp_tunnels_relay_on_both_axes() {
         .arg(format!("tester@127.0.0.1:{}", stack.port));
     let mut client = client.spawn().unwrap();
 
-    await_fifo(&gate);
+    await_fifo(&gate, &mut client);
     assert_unix_round_trip(&local_unix_source, b"local-unix-source");
     assert_ready_tcp_round_trip(local_tcp_source_port, b"local-unix-destination");
     assert_unix_round_trip(&remote_unix_source, b"remote-unix-source");
@@ -297,7 +297,7 @@ fn cli_local_and_reverse_tunnels_relay_real_tcp_payloads() {
     let mut stack = Stack::start();
     let local_destination = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let local_destination_port = local_destination.local_addr().unwrap().port();
-    let local_echo = spawn_tcp_echo(local_destination);
+    let local_echo = spawn_tcp_echo_once(local_destination, b"local");
     let local_source_port = reserve_port();
     let local_gate = stack.directory.join("local-ready");
     mkfifo(&local_gate);
@@ -310,14 +310,16 @@ fn cli_local_and_reverse_tunnels_relay_real_tcp_payloads() {
         true,
         None,
     );
-    await_fifo(&local_gate);
-    assert_tcp_round_trip(local_source_port, b"local");
+    await_fifo(&local_gate, &mut local_client);
+    assert_ready_tcp_round_trip(local_source_port, b"local");
     stop(&mut local_client);
     local_echo.join().unwrap();
+    stack.shutdown();
 
+    let mut stack = Stack::start();
     let reverse_destination = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let reverse_destination_port = reverse_destination.local_addr().unwrap().port();
-    let reverse_echo = spawn_tcp_echo(reverse_destination);
+    let reverse_echo = spawn_tcp_echo_once(reverse_destination, b"reverse");
     let reverse_source_port = reserve_port();
     let reverse_gate = stack.directory.join("reverse-ready");
     mkfifo(&reverse_gate);
@@ -330,8 +332,8 @@ fn cli_local_and_reverse_tunnels_relay_real_tcp_payloads() {
         false,
         None,
     );
-    await_fifo(&reverse_gate);
-    assert_tcp_round_trip(reverse_source_port, b"reverse");
+    await_fifo(&reverse_gate, &mut reverse_client);
+    assert_ready_tcp_round_trip(reverse_source_port, b"reverse");
     stop(&mut reverse_client);
     reverse_echo.join().unwrap();
     stack.shutdown();
@@ -358,7 +360,7 @@ fn cli_remote_unix_tunnel_relays_on_a_fresh_source_path() {
     );
 
     // When
-    assert_eq!(await_fifo(&gate), "ready");
+    assert_eq!(await_fifo(&gate, &mut client), "ready");
     assert_unix_round_trip(&source, b"cli-remote-unix");
 
     // Then
@@ -390,7 +392,7 @@ fn cli_ssh_agent_forwarding_relays_a_real_unix_socket() {
         false,
         None,
     );
-    let remote_agent_path = await_fifo(&gate);
+    let remote_agent_path = await_fifo(&gate, &mut client);
     let mut remote = UnixStream::connect(&remote_agent_path).unwrap();
     remote.set_read_timeout(Some(TIMEOUT)).unwrap();
     remote.write_all(b"agent").unwrap();
@@ -435,7 +437,7 @@ fn active_local_tunnel_survives_et_reconnect() {
         true,
         Some(proxy.port),
     );
-    await_fifo(&gate);
+    await_fifo(&gate, &mut client);
     // Wait until the local source accepts (listener bound after handshake).
     let mut application = wait_connect(source_port);
     application.set_read_timeout(Some(TIMEOUT)).unwrap();
@@ -505,35 +507,6 @@ fn spawn_client(
         .unwrap()
 }
 
-fn spawn_tcp_echo(listener: TcpListener) -> thread::JoinHandle<()> {
-    thread::spawn(move || {
-        // Accept multiple times so readiness retries do not exhaust a one-shot echo.
-        let deadline = std::time::Instant::now() + TIMEOUT + TIMEOUT;
-        listener
-            .set_nonblocking(true)
-            .expect("echo listener nonblocking");
-        while std::time::Instant::now() < deadline {
-            match listener.accept() {
-                Ok((mut stream, _)) => {
-                    stream.set_nonblocking(false).ok();
-                    stream.set_read_timeout(Some(TIMEOUT)).ok();
-                    let mut payload = [0u8; 16];
-                    if let Ok(count) = stream.read(&mut payload) {
-                        if count > 0 {
-                            let _ = stream.write_all(&payload[..count]);
-                        }
-                    }
-                }
-                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                    // Brief park while waiting for the next tunnel probe.
-                    thread::park_timeout(Duration::from_millis(10));
-                }
-                Err(_) => break,
-            }
-        }
-    })
-}
-
 fn spawn_tcp_echo_once(listener: TcpListener, expected: &'static [u8]) -> thread::JoinHandle<()> {
     thread::spawn(move || {
         let (mut stream, _) = listener.accept().unwrap();
@@ -555,34 +528,6 @@ fn echo_once(stream: &mut (impl Read + Write), expected: &[u8]) {
     stream.read_exact(&mut payload).unwrap();
     assert_eq!(payload, expected);
     stream.write_all(&payload).unwrap();
-}
-
-fn assert_tcp_round_trip(port: u16, payload: &[u8]) {
-    // Poll until the tunnel source is bound and the multiplex path is live.
-    let deadline = std::time::Instant::now() + TIMEOUT;
-    let mut last = None;
-    while std::time::Instant::now() < deadline {
-        match TcpStream::connect_timeout(
-            &std::net::SocketAddr::from((Ipv4Addr::LOCALHOST, port)),
-            Duration::from_millis(50),
-        ) {
-            Ok(mut stream) => {
-                stream
-                    .set_read_timeout(Some(Duration::from_millis(500)))
-                    .unwrap();
-                stream.set_write_timeout(Some(TIMEOUT)).unwrap();
-                match try_stream_round_trip(&mut stream, payload) {
-                    Ok(()) => return,
-                    Err(error) => last = Some(error),
-                }
-            }
-            Err(error) => last = Some(error),
-        }
-    }
-    panic!(
-        "tunnel round-trip on port {port} failed within {TIMEOUT:?}: {:?}",
-        last
-    );
 }
 
 fn try_stream_round_trip(stream: &mut (impl Read + Write), payload: &[u8]) -> std::io::Result<()> {
@@ -640,13 +585,36 @@ fn reserve_port() -> u16 {
         .port()
 }
 
-fn await_fifo(path: &std::path::Path) -> String {
+fn await_fifo(path: &std::path::Path, child: &mut Child) -> String {
     let path = path.to_owned();
+    let reader_path = path.clone();
     let (sender, receiver) = mpsc::sync_channel(1);
-    thread::spawn(move || {
-        let _ = sender.send(fs::read_to_string(path));
+    let reader = thread::spawn(move || {
+        let _ = sender.send(fs::read_to_string(reader_path));
     });
-    receiver.recv_timeout(TIMEOUT).unwrap().unwrap()
+    match receiver.recv_timeout(TIMEOUT) {
+        Ok(result) => {
+            reader.join().unwrap();
+            result.unwrap()
+        }
+        Err(error) => {
+            let status = child.try_wait().unwrap();
+            if status.is_none() {
+                child.kill().unwrap();
+                let _ = child.wait().unwrap();
+            }
+            let _ = fs::OpenOptions::new().write(true).open(&path);
+            reader.join().unwrap();
+            let mut stderr = String::new();
+            child
+                .stderr
+                .take()
+                .unwrap()
+                .read_to_string(&mut stderr)
+                .unwrap();
+            panic!("client readiness failed: {error}; status={status:?}; stderr={stderr}");
+        }
+    }
 }
 
 fn stop(child: &mut Child) {

--- a/crates/et-bin/tests/tunnels_end_to_end.rs
+++ b/crates/et-bin/tests/tunnels_end_to_end.rs
@@ -134,6 +134,66 @@ gatewayports no
 }
 
 #[test]
+fn cumulative_local_forwards_deduplicate_exact_rows_but_preserve_distinct_destinations() {
+    // Given
+    let mut stack = Stack::start();
+    let destination = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let destination_port = destination.local_addr().unwrap().port();
+    let echo = spawn_tcp_echo_once(destination, b"cumulative");
+    let distinct_destination_port = reserve_port();
+    let source_port = reserve_port();
+    let gate = stack.directory.join("cumulative-local-ready");
+    mkfifo(&gate);
+    let exact = format!("localhost:{source_port}:127.0.0.1:{destination_port}");
+    let config = format!(
+        "hostname 127.0.0.1\nuser tester\ngatewayports no\n\
+         localforward {source_port} [127.0.0.1]:{destination_port}\n\
+         localforward {source_port} [127.0.0.1]:{destination_port}\n\
+         localforward {source_port} [127.0.0.1]:{distinct_destination_port}\n"
+    );
+    let mut client = Command::new(env!("CARGO_BIN_EXE_et"));
+    client
+        .env("PATH", &stack.directory)
+        .env("ET_SSH_COUNT", &stack.ssh_count)
+        .env("ET_SSH_CONFIG", config)
+        .env("ET_SSH_READY", &gate)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .args(["--logtostdout", "--terminal-path"])
+        .arg(&stack.terminal)
+        .args(["--serverfifo"])
+        .arg(&stack.router)
+        .args(["-N", "--tunnel", &exact, "--tunnel", &exact])
+        .arg(format!("tester@127.0.0.1:{}", stack.port));
+
+    // When
+    let mut client = client.spawn().unwrap();
+    assert_eq!(await_fifo(&gate), "ready");
+    assert_ready_tcp_round_trip(source_port, b"cumulative");
+
+    // Then
+    stop(&mut client);
+    let mut output = String::new();
+    client
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut output)
+        .unwrap();
+    assert_eq!(
+        output
+            .lines()
+            .filter(|line| line.contains("WARNING"))
+            .count(),
+        1,
+        "only the distinct same-source row should reach bind-failure policy: {output}"
+    );
+    echo.join().unwrap();
+    stack.shutdown();
+}
+
+#[test]
 fn ssh_config_hardening_explicit_bind_failure_remains_fatal() {
     let mut stack = Stack::start();
     let occupied = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
@@ -274,6 +334,36 @@ fn cli_local_and_reverse_tunnels_relay_real_tcp_payloads() {
     assert_tcp_round_trip(reverse_source_port, b"reverse");
     stop(&mut reverse_client);
     reverse_echo.join().unwrap();
+    stack.shutdown();
+}
+
+#[test]
+fn cli_remote_unix_tunnel_relays_on_a_fresh_source_path() {
+    // Given
+    let mut stack = Stack::start();
+    let source = stack.directory.join("cli-remote-source.sock");
+    let destination_path = stack.directory.join("cli-remote-destination.sock");
+    let destination = UnixListener::bind(&destination_path).unwrap();
+    let echo = spawn_unix_echo(destination, b"cli-remote-unix");
+    let gate = stack.directory.join("cli-remote-unix-ready");
+    mkfifo(&gate);
+    let mut client = spawn_client(
+        &stack,
+        &format!("{}:{}", source.display(), destination_path.display()),
+        true,
+        &gate,
+        None,
+        true,
+        None,
+    );
+
+    // When
+    assert_eq!(await_fifo(&gate), "ready");
+    assert_unix_round_trip(&source, b"cli-remote-unix");
+
+    // Then
+    stop(&mut client);
+    echo.join().unwrap();
     stack.shutdown();
 }
 

--- a/crates/et-net/src/forward.rs
+++ b/crates/et-net/src/forward.rs
@@ -48,6 +48,38 @@ impl From<io::Error> for ForwardError {
 
 pub(crate) type Outbound = Result<Packet, ForwardError>;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ForwardOrigin {
+    Explicit,
+    SshConfig,
+}
+
+pub struct ForwardSource {
+    pub request: PortForwardSourceRequest,
+    pub origin: ForwardOrigin,
+}
+
+impl ForwardSource {
+    pub const fn explicit(request: PortForwardSourceRequest) -> Self {
+        Self {
+            request,
+            origin: ForwardOrigin::Explicit,
+        }
+    }
+
+    pub const fn ssh_config(request: PortForwardSourceRequest) -> Self {
+        Self {
+            request,
+            origin: ForwardOrigin::SshConfig,
+        }
+    }
+}
+
+pub struct SkippedForward {
+    pub request: PortForwardSourceRequest,
+    pub error: io::Error,
+}
+
 pub struct Forwarder {
     commands: mpsc::SyncSender<Command>,
     outbound: mpsc::Receiver<Outbound>,
@@ -62,7 +94,14 @@ pub struct Forwarder {
 
 impl Forwarder {
     pub fn start(sources: Vec<PortForwardSourceRequest>) -> Result<Self, ForwardError> {
-        Self::start_with_user(sources, None).map(|(forwarder, _)| forwarder)
+        let sources = sources.into_iter().map(ForwardSource::explicit).collect();
+        start_forwarder(sources, None).map(|(forwarder, _, _)| forwarder)
+    }
+
+    pub fn start_with_origins(
+        sources: Vec<ForwardSource>,
+    ) -> Result<(Self, Vec<SkippedForward>), ForwardError> {
+        start_forwarder(sources, None).map(|(forwarder, _, skipped)| (forwarder, skipped))
     }
 
     /// Bind all forwarding sources and return the forwarder together with the
@@ -74,54 +113,65 @@ impl Forwarder {
         sources: Vec<PortForwardSourceRequest>,
         owner: Option<(u32, u32)>,
     ) -> Result<(Self, ForwardEnvironment), ForwardError> {
-        let (sources, environment) = bind_sources(sources, owner)?;
-        let session_user = owner;
-        let (commands_tx, commands_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
-        let (outbound_tx, outbound_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
-        #[cfg(unix)]
-        let (wake, wake_writer) = {
-            let (reader, writer) = UnixStream::pair()?;
-            reader.set_nonblocking(true)?;
-            (reader, writer)
-        };
-        #[cfg(unix)]
-        let (listener_stop, listener_stop_reader) = UnixStream::pair()?;
-        #[cfg(windows)]
-        let listener_stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        #[cfg(windows)]
-        let listener_stop_reader = listener_stop.clone();
-        let worker_commands = commands_tx.clone();
-        let worker = std::thread::Builder::new()
-            .name("et-forwarding".to_owned())
-            .spawn(move || {
-                run(
-                    sources,
-                    commands_rx,
-                    worker_commands,
-                    outbound_tx,
-                    #[cfg(unix)]
-                    wake_writer,
-                    listener_stop_reader,
-                    session_user,
-                );
-                #[cfg(unix)]
-                drop(listener_stop);
-                #[cfg(windows)]
-                listener_stop.store(true, std::sync::atomic::Ordering::Release);
-            })
-            .map_err(ForwardError::Io)?;
-        Ok((
-            Self {
-                commands: commands_tx,
-                outbound: outbound_rx,
-                #[cfg(unix)]
-                wake,
-                worker: Some(worker),
-            },
-            environment,
-        ))
+        let sources = sources.into_iter().map(ForwardSource::explicit).collect();
+        start_forwarder(sources, owner).map(|(forwarder, environment, _)| (forwarder, environment))
     }
+}
 
+fn start_forwarder(
+    sources: Vec<ForwardSource>,
+    owner: Option<(u32, u32)>,
+) -> Result<(Forwarder, ForwardEnvironment, Vec<SkippedForward>), ForwardError> {
+    let (sources, environment, skipped) = bind_sources(sources, owner)?;
+    let session_user = owner;
+    let (commands_tx, commands_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
+    let (outbound_tx, outbound_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
+    #[cfg(unix)]
+    let (wake, wake_writer) = {
+        let (reader, writer) = UnixStream::pair()?;
+        reader.set_nonblocking(true)?;
+        (reader, writer)
+    };
+    #[cfg(unix)]
+    let (listener_stop, listener_stop_reader) = UnixStream::pair()?;
+    #[cfg(windows)]
+    let listener_stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    #[cfg(windows)]
+    let listener_stop_reader = listener_stop.clone();
+    let worker_commands = commands_tx.clone();
+    let worker = std::thread::Builder::new()
+        .name("et-forwarding".to_owned())
+        .spawn(move || {
+            run(
+                sources,
+                commands_rx,
+                worker_commands,
+                outbound_tx,
+                #[cfg(unix)]
+                wake_writer,
+                listener_stop_reader,
+                session_user,
+            );
+            #[cfg(unix)]
+            drop(listener_stop);
+            #[cfg(windows)]
+            listener_stop.store(true, std::sync::atomic::Ordering::Release);
+        })
+        .map_err(ForwardError::Io)?;
+    Ok((
+        Forwarder {
+            commands: commands_tx,
+            outbound: outbound_rx,
+            #[cfg(unix)]
+            wake,
+            worker: Some(worker),
+        },
+        environment,
+        skipped,
+    ))
+}
+
+impl Forwarder {
     /// Pollable readiness handle for outbound forwarding packets (Unix only).
     #[cfg(unix)]
     pub fn wake(&self) -> Result<&UnixStream, ForwardError> {
@@ -201,6 +251,8 @@ enum PlannedSource {
     Endpoint {
         source: ResolvedEndpoint,
         destination: et_core::proto::SocketEndpoint,
+        original: PortForwardSourceRequest,
+        origin: ForwardOrigin,
     },
     #[cfg(unix)]
     Environment {
@@ -210,12 +262,16 @@ enum PlannedSource {
 }
 
 fn bind_sources(
-    sources: Vec<PortForwardSourceRequest>,
+    sources: Vec<ForwardSource>,
     owner: Option<(u32, u32)>,
-) -> Result<(Vec<BoundSource>, ForwardEnvironment), ForwardError> {
+) -> Result<(Vec<BoundSource>, ForwardEnvironment, Vec<SkippedForward>), ForwardError> {
     let mut plans = Vec::with_capacity(sources.len());
+    let mut skipped = Vec::new();
     let mut listener_count = 0usize;
-    for request in sources {
+    for source in sources {
+        let origin = source.origin;
+        let original = source.request.clone();
+        let request = source.request;
         // The destination is passed through verbatim in the
         // PORT_FORWARD_DESTINATION_REQUEST and parsed by the remote side.
         let destination = request.destination.unwrap_or_default();
@@ -243,12 +299,26 @@ fn bind_sources(
                 ));
             }
         } else {
-            let source = Endpoint::parse(request.source)?.resolve_for_bind()?;
+            let resolved =
+                Endpoint::parse(request.source).and_then(|source| source.resolve_for_bind());
+            let source = match resolved {
+                Ok(source) => source,
+                Err(error) if origin == ForwardOrigin::SshConfig => {
+                    skipped.push(SkippedForward {
+                        request: original,
+                        error,
+                    });
+                    continue;
+                }
+                Err(error) => return Err(ForwardError::Io(error)),
+            };
             let listener_count = source.listener_count();
             (
                 PlannedSource::Endpoint {
                     source,
                     destination,
+                    original,
+                    origin,
                 },
                 listener_count,
             )
@@ -270,14 +340,25 @@ fn bind_sources(
             PlannedSource::Endpoint {
                 source,
                 destination,
-            } => {
-                for listener in source.bind_with_user(owner)? {
-                    bound.push(BoundSource {
-                        listener,
-                        destination: destination.clone(),
+                original,
+                origin,
+            } => match source.bind_with_user(owner) {
+                Ok(listeners) => {
+                    for listener in listeners {
+                        bound.push(BoundSource {
+                            listener,
+                            destination: destination.clone(),
+                        });
+                    }
+                }
+                Err(error) if origin == ForwardOrigin::SshConfig => {
+                    skipped.push(SkippedForward {
+                        request: original,
+                        error,
                     });
                 }
-            }
+                Err(error) => return Err(ForwardError::Io(error)),
+            },
             #[cfg(unix)]
             PlannedSource::Environment {
                 variable,
@@ -299,7 +380,7 @@ fn bind_sources(
             }
         }
     }
-    Ok((bound, environment))
+    Ok((bound, environment, skipped))
 }
 
 /// Create the private directory for a named-pipe forward and return the

--- a/crates/et-net/src/forward.rs
+++ b/crates/et-net/src/forward.rs
@@ -312,6 +312,23 @@ fn bind_sources(
                 }
                 Err(error) => return Err(ForwardError::Io(error)),
             };
+            if owner.is_some() {
+                match &source {
+                    ResolvedEndpoint::Tcp(addresses)
+                        if addresses
+                            .iter()
+                            .any(|address| address.ip().is_unspecified()) =>
+                    {
+                        return Err(ForwardError::Io(io::Error::new(
+                            io::ErrorKind::PermissionDenied,
+                            "authenticated reverse TCP wildcard bind is not permitted",
+                        )));
+                    }
+                    ResolvedEndpoint::Tcp(_) => {}
+                    #[cfg(unix)]
+                    ResolvedEndpoint::Unix(_) => {}
+                }
+            }
             let listener_count = source.listener_count();
             (
                 PlannedSource::Endpoint {

--- a/crates/et-net/src/forward.rs
+++ b/crates/et-net/src/forward.rs
@@ -10,11 +10,14 @@ use std::time::Duration;
 use et_core::packet::Packet;
 use et_core::proto::{PortForwardSourceRequest, TerminalPacketType};
 
-use crate::forward_endpoint::Endpoint;
+use crate::forward_endpoint::{Endpoint, ResolvedEndpoint};
 use crate::forward_io::BoundSource;
 use crate::forward_worker::{run, Command};
 
 const CHANNEL_CAPACITY: usize = 256;
+/// Maximum reverse listeners owned by one terminal session, after DNS fanout
+/// and address deduplication.
+const MAX_SESSION_LISTENERS: usize = 32;
 
 #[derive(Debug)]
 pub enum ForwardError {
@@ -194,24 +197,29 @@ impl Drop for Forwarder {
 /// Environment variables created for named-pipe forwards.
 pub type ForwardEnvironment = Vec<(String, String)>;
 
+enum PlannedSource {
+    Endpoint {
+        source: ResolvedEndpoint,
+        destination: et_core::proto::SocketEndpoint,
+    },
+    #[cfg(unix)]
+    Environment {
+        variable: String,
+        destination: et_core::proto::SocketEndpoint,
+    },
+}
+
 fn bind_sources(
     sources: Vec<PortForwardSourceRequest>,
     owner: Option<(u32, u32)>,
 ) -> Result<(Vec<BoundSource>, ForwardEnvironment), ForwardError> {
-    let mut bound = Vec::with_capacity(sources.len());
-    #[cfg_attr(windows, allow(unused_mut))]
-    let mut environment = Vec::new();
+    let mut plans = Vec::with_capacity(sources.len());
+    let mut listener_count = 0usize;
     for request in sources {
         // The destination is passed through verbatim in the
-        // PORT_FORWARD_DESTINATION_REQUEST, exactly like upstream: it is only
-        // interpreted (and validated) by the remote side when a connection
-        // arrives.
+        // PORT_FORWARD_DESTINATION_REQUEST and parsed by the remote side.
         let destination = request.destination.unwrap_or_default();
-        if let Some(variable) = request.environmentvariable {
-            // Named-pipe forwarding: upstream creates a private temporary
-            // socket, exports its path through the environment variable, and
-            // rejects requests that also carry an explicit source. Upstream
-            // builds this path only on POSIX systems.
+        let (plan, additional_listeners) = if let Some(variable) = request.environmentvariable {
             if request.source.is_some() {
                 return Err(ForwardError::Protocol(
                     "Do not set a source when forwarding named pipes with environment variables",
@@ -219,10 +227,65 @@ fn bind_sources(
             }
             #[cfg(unix)]
             {
+                (
+                    PlannedSource::Environment {
+                        variable,
+                        destination,
+                    },
+                    1,
+                )
+            }
+            #[cfg(windows)]
+            {
+                let _ = (variable, destination, owner);
+                return Err(ForwardError::Protocol(
+                    "named-pipe forwarding is not supported on Windows",
+                ));
+            }
+        } else {
+            let source = Endpoint::parse(request.source)?.resolve_for_bind()?;
+            let listener_count = source.listener_count();
+            (
+                PlannedSource::Endpoint {
+                    source,
+                    destination,
+                },
+                listener_count,
+            )
+        };
+        listener_count = listener_count
+            .checked_add(additional_listeners)
+            .ok_or(ForwardError::Protocol("reverse listener limit exceeded"))?;
+        if listener_count > MAX_SESSION_LISTENERS {
+            return Err(ForwardError::Protocol("reverse listener limit exceeded"));
+        }
+        plans.push(plan);
+    }
+
+    let mut bound = Vec::with_capacity(listener_count);
+    #[cfg_attr(windows, allow(unused_mut))]
+    let mut environment = Vec::new();
+    for plan in plans {
+        match plan {
+            PlannedSource::Endpoint {
+                source,
+                destination,
+            } => {
+                for listener in source.bind_with_user(owner)? {
+                    bound.push(BoundSource {
+                        listener,
+                        destination: destination.clone(),
+                    });
+                }
+            }
+            #[cfg(unix)]
+            PlannedSource::Environment {
+                variable,
+                destination,
+            } => {
                 let path = create_forward_pipe(owner)?;
-                // Bind as the session user (ET #784). Do not chmod/chown the
-                // client-visible socket path as root after bind.
-                let mut listeners = Endpoint::Unix(path.clone()).bind_with_user(owner)?;
+                let source = Endpoint::Unix(path.clone()).resolve_for_bind()?;
+                let mut listeners = source.bind_with_user(owner)?;
                 environment.push((variable, path.to_string_lossy().into_owned()));
                 for mut listener in listeners.drain(..) {
                     if let Some(directory) = path.parent() {
@@ -233,22 +296,7 @@ fn bind_sources(
                         destination: destination.clone(),
                     });
                 }
-                continue;
             }
-            #[cfg(windows)]
-            {
-                let _ = (&variable, owner);
-                return Err(ForwardError::Protocol(
-                    "named-pipe forwarding is not supported on Windows",
-                ));
-            }
-        }
-        let source = Endpoint::parse(request.source)?;
-        for listener in source.bind_with_user(owner)? {
-            bound.push(BoundSource {
-                listener,
-                destination: destination.clone(),
-            });
         }
     }
     Ok((bound, environment))

--- a/crates/et-net/src/forward.rs
+++ b/crates/et-net/src/forward.rs
@@ -13,6 +13,7 @@ use et_core::proto::{PortForwardSourceRequest, TerminalPacketType};
 use crate::forward_endpoint::{Endpoint, ResolvedEndpoint};
 use crate::forward_io::BoundSource;
 use crate::forward_worker::{run, Command};
+use crate::reverse_report::SkipReason;
 
 const CHANNEL_CAPACITY: usize = 256;
 /// Maximum reverse listeners owned by one terminal session, after DNS fanout
@@ -52,6 +53,7 @@ pub(crate) type Outbound = Result<Packet, ForwardError>;
 pub enum ForwardOrigin {
     Explicit,
     SshConfig,
+    Reported(usize),
 }
 
 pub struct ForwardSource {
@@ -78,6 +80,8 @@ impl ForwardSource {
 pub struct SkippedForward {
     pub request: PortForwardSourceRequest,
     pub error: io::Error,
+    pub reason: SkipReason,
+    pub report_index: Option<usize>,
 }
 
 pub struct Forwarder {
@@ -115,6 +119,21 @@ impl Forwarder {
     ) -> Result<(Self, ForwardEnvironment), ForwardError> {
         let sources = sources.into_iter().map(ForwardSource::explicit).collect();
         start_forwarder(sources, owner).map(|(forwarder, environment, _)| (forwarder, environment))
+    }
+
+    pub fn start_with_user_report(
+        sources: Vec<PortForwardSourceRequest>,
+        owner: Option<(u32, u32)>,
+    ) -> Result<(Self, ForwardEnvironment, Vec<SkippedForward>), ForwardError> {
+        let sources = sources
+            .into_iter()
+            .enumerate()
+            .map(|(index, request)| ForwardSource {
+                request,
+                origin: ForwardOrigin::Reported(index),
+            })
+            .collect();
+        start_forwarder(sources, owner)
     }
 }
 
@@ -299,18 +318,29 @@ fn bind_sources(
                 ));
             }
         } else {
-            let resolved =
-                Endpoint::parse(request.source).and_then(|source| source.resolve_for_bind());
-            let source = match resolved {
-                Ok(source) => source,
-                Err(error) if origin == ForwardOrigin::SshConfig => {
+            let endpoint = Endpoint::parse(request.source).map_err(ForwardError::Io)?;
+            let resolved = endpoint.resolve_for_bind();
+            let source = match (resolved, origin) {
+                (Ok(source), _) => source,
+                (Err(error), ForwardOrigin::SshConfig) => {
                     skipped.push(SkippedForward {
                         request: original,
                         error,
+                        reason: SkipReason::Resolve,
+                        report_index: None,
                     });
                     continue;
                 }
-                Err(error) => return Err(ForwardError::Io(error)),
+                (Err(error), ForwardOrigin::Reported(index)) => {
+                    skipped.push(SkippedForward {
+                        request: original,
+                        error,
+                        reason: SkipReason::Resolve,
+                        report_index: Some(index),
+                    });
+                    continue;
+                }
+                (Err(error), ForwardOrigin::Explicit) => return Err(ForwardError::Io(error)),
             };
             if owner.is_some() {
                 match &source {
@@ -359,8 +389,8 @@ fn bind_sources(
                 destination,
                 original,
                 origin,
-            } => match source.bind_with_user(owner) {
-                Ok(listeners) => {
+            } => match (source.bind_with_user(owner), origin) {
+                (Ok(listeners), _) => {
                     for listener in listeners {
                         bound.push(BoundSource {
                             listener,
@@ -368,13 +398,23 @@ fn bind_sources(
                         });
                     }
                 }
-                Err(error) if origin == ForwardOrigin::SshConfig => {
+                (Err(error), ForwardOrigin::SshConfig) => {
                     skipped.push(SkippedForward {
                         request: original,
                         error,
+                        reason: SkipReason::Bind,
+                        report_index: None,
                     });
                 }
-                Err(error) => return Err(ForwardError::Io(error)),
+                (Err(error), ForwardOrigin::Reported(index)) => {
+                    skipped.push(SkippedForward {
+                        request: original,
+                        error,
+                        reason: SkipReason::Bind,
+                        report_index: Some(index),
+                    });
+                }
+                (Err(error), ForwardOrigin::Explicit) => return Err(ForwardError::Io(error)),
             },
             #[cfg(unix)]
             PlannedSource::Environment {

--- a/crates/et-net/src/forward_endpoint.rs
+++ b/crates/et-net/src/forward_endpoint.rs
@@ -160,33 +160,13 @@ impl Endpoint {
         }
     }
 
-    pub(crate) fn bind_with_user(
-        &self,
-        user: Option<(u32, u32)>,
-    ) -> io::Result<Vec<ForwardListener>> {
-        match (self, user) {
-            #[cfg(unix)]
-            (Self::Unix(path), Some((uid, gid))) => {
-                let listener = crate::user_socket_ops::listen_unix_as_user(path, uid, gid)?;
-                listener.set_nonblocking(true)?;
-                Ok(vec![ForwardListener {
-                    inner: ListenerKind::Unix(listener),
-                    cleanup: Some(path.clone()),
-                    cleanup_dir: None,
-                }])
-            }
-            _ => self.bind(),
-        }
-    }
-
-    pub(crate) fn bind(&self) -> io::Result<Vec<ForwardListener>> {
+    pub(crate) fn resolve_for_bind(&self) -> io::Result<ResolvedEndpoint> {
         match self {
             Self::Tcp { host, port } => {
                 // Mirror upstream `TcpSocketHandler::listen`: resolve the bind
                 // name with getaddrinfo semantics and bind every distinct
-                // address ("localhost" usually yields both ::1 and 127.0.0.1;
-                // an empty name binds the wildcard addresses).
-                let addresses: Vec<std::net::SocketAddr> = if host.is_empty() {
+                // address ("localhost" usually yields both loopback families).
+                let addresses = if host.is_empty() {
                     vec![
                         (std::net::Ipv6Addr::UNSPECIFIED, *port).into(),
                         (std::net::Ipv4Addr::UNSPECIFIED, *port).into(),
@@ -199,11 +179,58 @@ impl Endpoint {
                 } else {
                     (host.as_str(), *port).to_socket_addrs()?.collect()
                 };
-                let addresses = distinct_tcp_addresses(addresses);
-                bind_tcp_addresses(addresses)
+                Ok(ResolvedEndpoint::Tcp(distinct_tcp_addresses(addresses)))
             }
             #[cfg(unix)]
-            Self::Unix(path) => {
+            Self::Unix(path) => Ok(ResolvedEndpoint::Unix(path.clone())),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn bind(&self) -> io::Result<Vec<ForwardListener>> {
+        self.resolve_for_bind()?.bind_with_user(None)
+    }
+}
+
+pub(crate) enum ResolvedEndpoint {
+    Tcp(Vec<std::net::SocketAddr>),
+    #[cfg(unix)]
+    Unix(PathBuf),
+}
+
+impl ResolvedEndpoint {
+    pub(crate) fn listener_count(&self) -> usize {
+        match self {
+            Self::Tcp(addresses) => addresses.len(),
+            #[cfg(unix)]
+            Self::Unix(_) => 1,
+        }
+    }
+
+    pub(crate) fn bind_with_user(
+        &self,
+        user: Option<(u32, u32)>,
+    ) -> io::Result<Vec<ForwardListener>> {
+        match (self, user) {
+            #[cfg(unix)]
+            (Self::Tcp(addresses), Some((uid, gid))) => {
+                bind_tcp_addresses_with(addresses.iter().copied(), |address| {
+                    crate::user_socket_ops::listen_tcp_as_user(address, uid, gid).map(Some)
+                })
+            }
+            (Self::Tcp(addresses), _) => bind_tcp_addresses(addresses.iter().copied()),
+            #[cfg(unix)]
+            (Self::Unix(path), Some((uid, gid))) => {
+                let listener = crate::user_socket_ops::listen_unix_as_user(path, uid, gid)?;
+                listener.set_nonblocking(true)?;
+                Ok(vec![ForwardListener {
+                    inner: ListenerKind::Unix(listener),
+                    cleanup: Some(path.clone()),
+                    cleanup_dir: None,
+                }])
+            }
+            #[cfg(unix)]
+            (Self::Unix(path), None) => {
                 if path.exists() {
                     return Err(io::Error::new(
                         io::ErrorKind::AddrInUse,
@@ -275,7 +302,9 @@ fn distinct_tcp_addresses(
 /// Bind one TCP listener for exactly one address family, mirroring upstream
 /// `TcpSocketHandler::listen` (which sets `IPV6_V6ONLY` and binds each
 /// resolved address separately).
-fn bind_tcp_single_family(address: std::net::SocketAddr) -> io::Result<Option<TcpListener>> {
+pub(crate) fn bind_tcp_single_family(
+    address: std::net::SocketAddr,
+) -> io::Result<Option<TcpListener>> {
     let domain = if address.is_ipv6() {
         socket2::Domain::IPV6
     } else {

--- a/crates/et-net/src/forward_endpoint.rs
+++ b/crates/et-net/src/forward_endpoint.rs
@@ -249,6 +249,7 @@ impl ResolvedEndpoint {
                     None
                 };
                 let listener = UnixListener::bind(path)?;
+                fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
                 listener.set_nonblocking(true)?;
                 Ok(vec![ForwardListener {
                     inner: ListenerKind::Unix(listener),
@@ -464,6 +465,24 @@ impl Drop for ForwardListener {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_source_bind_uses_openssh_default_owner_only_mode() {
+        // Given
+        let path = std::env::temp_dir().join(format!("et-forward-mode-{}", std::process::id()));
+        let endpoint = ResolvedEndpoint::Unix(path.clone());
+
+        // When
+        let listeners = endpoint.bind_with_user(None).unwrap();
+
+        // Then
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        drop(listeners);
+    }
 
     #[test]
     fn localhost_bind_rejects_one_occupied_address_family() {

--- a/crates/et-net/src/forward_endpoint.rs
+++ b/crates/et-net/src/forward_endpoint.rs
@@ -44,9 +44,8 @@ impl Endpoint {
                 }
                 // Upstream sends TCP endpoints with the name unset for the
                 // common `port:port` tunnel form; treat those as localhost.
-                let host = name.filter(|name| !name.is_empty());
                 Ok(Self::Tcp {
-                    host: host.unwrap_or_else(|| "localhost".to_owned()),
+                    host: name.unwrap_or_else(|| "localhost".to_owned()),
                     port,
                 })
             }

--- a/crates/et-net/src/lib.rs
+++ b/crates/et-net/src/lib.rs
@@ -15,5 +15,6 @@ pub mod handshake;
 pub mod listener;
 pub mod local;
 pub mod local_packet;
+pub mod reverse_report;
 #[cfg(unix)]
 pub mod user_socket_ops;

--- a/crates/et-net/src/reverse_report.rs
+++ b/crates/et-net/src/reverse_report.rs
@@ -1,0 +1,148 @@
+const PREFIX: &str = "ETRS-RF-SKIP/1;";
+const RESERVED_PREFIX: &str = "ETRS-RF-SKIP/";
+pub const MAX_REVERSE_ROWS: usize = 128;
+pub const MAX_SKIPPED_ROWS: usize = 32;
+pub const MAX_REPORT_LEN: usize = 256;
+const _: () = assert!(PREFIX.len() + MAX_SKIPPED_ROWS * 6 <= MAX_REPORT_LEN);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SkipReason {
+    Resolve,
+    Bind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SkippedRow {
+    pub index: usize,
+    pub reason: SkipReason,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReportError;
+
+impl std::fmt::Display for ReportError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "malformed reverse forwarding skip report")
+    }
+}
+
+impl std::error::Error for ReportError {}
+
+pub fn encode_skipped_rows(rows: &[SkippedRow]) -> Result<String, ReportError> {
+    if rows.is_empty() || rows.len() > MAX_SKIPPED_ROWS {
+        return Err(ReportError);
+    }
+    let mut encoded = String::from(PREFIX);
+    let mut previous = None;
+    for row in rows {
+        if row.index >= MAX_REVERSE_ROWS || previous.is_some_and(|index| index >= row.index) {
+            return Err(ReportError);
+        }
+        if previous.is_some() {
+            encoded.push(',');
+        }
+        previous = Some(row.index);
+        encoded.push_str(&row.index.to_string());
+        encoded.push(':');
+        encoded.push(match row.reason {
+            SkipReason::Resolve => 'R',
+            SkipReason::Bind => 'B',
+        });
+    }
+    (encoded.len() <= MAX_REPORT_LEN)
+        .then_some(encoded)
+        .ok_or(ReportError)
+}
+
+pub fn decode_skipped_rows(
+    encoded: &str,
+    row_count: usize,
+) -> Result<Option<Vec<SkippedRow>>, ReportError> {
+    if !encoded.starts_with(RESERVED_PREFIX) {
+        return Ok(None);
+    }
+    if encoded.len() > MAX_REPORT_LEN || row_count > MAX_REVERSE_ROWS {
+        return Err(ReportError);
+    }
+    let body = encoded.strip_prefix(PREFIX).ok_or(ReportError)?;
+    if body.is_empty() {
+        return Err(ReportError);
+    }
+    let mut rows = Vec::new();
+    let mut previous = None;
+    for field in body.split(',') {
+        let (raw_index, raw_reason) = field.split_once(':').ok_or(ReportError)?;
+        let index = raw_index.parse::<usize>().map_err(|_| ReportError)?;
+        if raw_index != index.to_string()
+            || index >= row_count
+            || previous.is_some_and(|previous| previous >= index)
+        {
+            return Err(ReportError);
+        }
+        let reason = match raw_reason {
+            "R" => SkipReason::Resolve,
+            "B" => SkipReason::Bind,
+            _ => return Err(ReportError),
+        };
+        rows.push(SkippedRow { index, reason });
+        previous = Some(index);
+    }
+    if rows.is_empty() || rows.len() > MAX_SKIPPED_ROWS {
+        return Err(ReportError);
+    }
+    Ok(Some(rows))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decode_skipped_rows, encode_skipped_rows, SkipReason, SkippedRow, MAX_REPORT_LEN};
+
+    #[test]
+    fn report_round_trips_bounded_machine_codes() {
+        let rows = [
+            SkippedRow {
+                index: 0,
+                reason: SkipReason::Resolve,
+            },
+            SkippedRow {
+                index: 31,
+                reason: SkipReason::Bind,
+            },
+        ];
+
+        let encoded = encode_skipped_rows(&rows).unwrap();
+        let decoded = decode_skipped_rows(&encoded, 32).unwrap().unwrap();
+
+        assert_eq!(decoded, rows);
+        assert!(encoded.is_ascii());
+        assert!(encoded.len() <= MAX_REPORT_LEN);
+    }
+
+    #[test]
+    fn unrelated_error_is_not_a_report() {
+        assert_eq!(decode_skipped_rows("Permission denied", 1).unwrap(), None);
+    }
+
+    #[test]
+    fn malformed_reports_fail_closed() {
+        for report in [
+            "ETRS-RF-SKIP/1;",
+            "ETRS-RF-SKIP/1;0:B,",
+            "ETRS-RF-SKIP/1;0:B,0:R",
+            "ETRS-RF-SKIP/1;1:B",
+            "ETRS-RF-SKIP/2;0:B",
+            "ETRS-RF-SKIP/1;0:X",
+            "ETRS-RF-SKIP/1;00:B",
+            "ETRS-RF-SKIP/1;0:B\n",
+        ] {
+            assert!(decode_skipped_rows(report, 1).is_err(), "{report:?}");
+        }
+    }
+
+    #[test]
+    fn oversized_and_truncated_reports_fail_closed() {
+        let oversized = format!("ETRS-RF-SKIP/1;{}", "0:B,".repeat(MAX_REPORT_LEN));
+        assert!(decode_skipped_rows(&oversized, 128).is_err());
+        assert!(decode_skipped_rows("ETRS-RF-SKIP/1;0", 1).is_err());
+    }
+}

--- a/crates/et-net/src/user_socket_ops.rs
+++ b/crates/et-net/src/user_socket_ops.rs
@@ -98,18 +98,15 @@ pub fn run_helper() -> i32 {
     }
 }
 
-/// unlink/bind/listen/fchmod a UNIX socket path with the current credentials.
+/// Bind/listen a new owner-only UNIX socket path with the current credentials.
 pub fn listen_at_path(path: &Path) -> io::Result<UnixListener> {
     if path_too_long(path) {
         return Err(io::Error::from_raw_os_error(
             rustix::io::Errno::NAMETOOLONG.raw_os_error(),
         ));
     }
-    let _ = fs::remove_file(path);
     let listener = UnixListener::bind(path)?;
-    if rustix::fs::fchmod(&listener, rustix::fs::Mode::from_raw_mode(0o700)).is_err() {
-        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o700));
-    }
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
     Ok(listener)
 }
 
@@ -123,7 +120,7 @@ pub fn connect_at_path(path: &Path) -> io::Result<UnixStream> {
     UnixStream::connect(path)
 }
 
-/// unlink/bind/listen as `uid`/`gid`, returning the listening socket.
+/// Bind/listen as `uid`/`gid`, returning the listening socket.
 pub fn listen_unix_as_user(path: impl AsRef<Path>, uid: u32, gid: u32) -> io::Result<UnixListener> {
     let path = path.as_ref();
     if already_session_user(uid, gid) {
@@ -365,6 +362,7 @@ mod tests {
         let listener = listen_at_path(&path).unwrap();
         let metadata = fs::metadata(&path).unwrap();
         assert!(metadata.file_type().is_socket());
+        assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
         let mut client = connect_at_path(&path).unwrap();
         let (mut accepted, _) = listener.accept().unwrap();
         client.write_all(b"ok").unwrap();
@@ -450,13 +448,19 @@ mod tests {
     }
 
     #[test]
-    fn listen_at_path_replaces_an_existing_socket() {
+    fn listen_at_path_refuses_to_unlink_an_existing_socket() {
+        // Given
         let dir = temp_dir();
         let path = dir.join("sock");
         let first = listen_at_path(&path).unwrap();
+
+        // When
+        let error = listen_at_path(&path).unwrap_err();
+
+        // Then
+        assert_eq!(error.kind(), io::ErrorKind::AddrInUse);
+        assert!(fs::metadata(&path).unwrap().file_type().is_socket());
         drop(first);
-        let second = listen_at_path(&path).unwrap();
-        drop(second);
         let _ = fs::remove_file(&path);
         let _ = fs::remove_dir(&dir);
     }

--- a/crates/et-net/src/user_socket_ops.rs
+++ b/crates/et-net/src/user_socket_ops.rs
@@ -7,9 +7,11 @@
 //! `unsafe`); it re-execs a helper, drops with [`nix`] in that
 //! single-threaded process, and uses the same fd-passing protocol.
 
+use std::ffi::OsStr;
 use std::fs;
 use std::io::{self, IoSlice, IoSliceMut};
 use std::mem::MaybeUninit;
+use std::net::{SocketAddr, TcpListener};
 use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::{UnixListener, UnixStream};
@@ -34,6 +36,7 @@ const UNIX_PATH_MAX: usize = 108;
 enum Op {
     Listen,
     Connect,
+    ListenTcp,
 }
 
 impl Op {
@@ -41,6 +44,7 @@ impl Op {
         match self {
             Self::Listen => "listen",
             Self::Connect => "connect",
+            Self::ListenTcp => "listen-tcp",
         }
     }
 
@@ -48,6 +52,7 @@ impl Op {
         match value {
             "listen" => Some(Self::Listen),
             "connect" => Some(Self::Connect),
+            "listen-tcp" => Some(Self::ListenTcp),
             _ => None,
         }
     }
@@ -70,17 +75,26 @@ pub fn run_helper() -> i32 {
     let op = std::env::var(OP_ENV)
         .ok()
         .and_then(|value| Op::parse(&value));
-    let path = std::env::var(PATH_ENV).unwrap_or_default();
-    match (op, path.is_empty()) {
-        (Some(Op::Listen), false) => match listen_at_path(Path::new(&path)) {
+    let argument = std::env::var(PATH_ENV).unwrap_or_default();
+    match op {
+        Some(Op::Listen) if !argument.is_empty() => match listen_at_path(Path::new(&argument)) {
             Ok(listener) => send_result(channel, Some(listener.as_fd()), 0, 0),
             Err(error) => send_error(channel, &error),
         },
-        (Some(Op::Connect), false) => match connect_at_path(Path::new(&path)) {
+        Some(Op::Connect) if !argument.is_empty() => match connect_at_path(Path::new(&argument)) {
             Ok(stream) => send_result(channel, Some(stream.as_fd()), 0, 0),
             Err(error) => send_error(channel, &error),
         },
-        _ => send_result(channel, None, -1, rustix::io::Errno::INVAL.raw_os_error()),
+        Some(Op::ListenTcp) => match argument.parse() {
+            Ok(address) => match listen_tcp_at_address(address) {
+                Ok(listener) => send_result(channel, Some(listener.as_fd()), 0, 0),
+                Err(error) => send_error(channel, &error),
+            },
+            Err(_) => send_result(channel, None, -1, rustix::io::Errno::INVAL.raw_os_error()),
+        },
+        Some(Op::Listen | Op::Connect) | None => {
+            send_result(channel, None, -1, rustix::io::Errno::INVAL.raw_os_error())
+        }
     }
 }
 
@@ -115,7 +129,12 @@ pub fn listen_unix_as_user(path: impl AsRef<Path>, uid: u32, gid: u32) -> io::Re
     if already_session_user(uid, gid) {
         return listen_at_path(path);
     }
-    Ok(UnixListener::from(run_as_user(Op::Listen, path, uid, gid)?))
+    Ok(UnixListener::from(run_as_user(
+        Op::Listen,
+        path.as_os_str(),
+        uid,
+        gid,
+    )?))
 }
 
 /// connect() as `uid`/`gid`, returning the connected socket.
@@ -124,25 +143,44 @@ pub fn connect_unix_as_user(path: impl AsRef<Path>, uid: u32, gid: u32) -> io::R
     if already_session_user(uid, gid) {
         return connect_at_path(path);
     }
-    Ok(UnixStream::from(run_as_user(Op::Connect, path, uid, gid)?))
+    Ok(UnixStream::from(run_as_user(
+        Op::Connect,
+        path.as_os_str(),
+        uid,
+        gid,
+    )?))
+}
+
+/// Bind one TCP address as `uid`/`gid`, returning the listening socket.
+pub fn listen_tcp_as_user(address: SocketAddr, uid: u32, gid: u32) -> io::Result<TcpListener> {
+    if already_session_user(uid, gid) {
+        return listen_tcp_at_address(address);
+    }
+    let argument = address.to_string();
+    Ok(TcpListener::from(run_as_user(
+        Op::ListenTcp,
+        OsStr::new(&argument),
+        uid,
+        gid,
+    )?))
+}
+
+fn listen_tcp_at_address(address: SocketAddr) -> io::Result<TcpListener> {
+    crate::forward_endpoint::bind_tcp_single_family(address)?
+        .ok_or_else(|| io::Error::from_raw_os_error(rustix::io::Errno::AFNOSUPPORT.raw_os_error()))
 }
 
 fn already_session_user(uid: u32, gid: u32) -> bool {
     rustix::process::geteuid().as_raw() == uid && rustix::process::getegid().as_raw() == gid
 }
 
-fn run_as_user(op: Op, path: &Path, uid: u32, gid: u32) -> io::Result<OwnedFd> {
-    if path_too_long(path) {
-        return Err(io::Error::from_raw_os_error(
-            rustix::io::Errno::NAMETOOLONG.raw_os_error(),
-        ));
-    }
+fn run_as_user(op: Op, argument: &OsStr, uid: u32, gid: u32) -> io::Result<OwnedFd> {
     let helper = helper_exe()?;
     let (parent, child) = UnixStream::pair()?;
     let mut command = Command::new(helper);
     command
         .env(OP_ENV, op.as_env())
-        .env(PATH_ENV, path)
+        .env(PATH_ENV, argument)
         .env(UID_ENV, uid.to_string())
         .env(GID_ENV, gid.to_string())
         .stdin(Stdio::from(OwnedFd::from(child)))

--- a/crates/et-net/tests/forward.rs
+++ b/crates/et-net/tests/forward.rs
@@ -179,6 +179,23 @@ fn authenticated_reverse_tcp_wildcard_bind_exposes_session_to_external_network()
         owner,
     );
 
+    let reservation = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let port = reservation.local_addr().unwrap().port();
+    let error = match Forwarder::start_with_user_report(
+        vec![request_on(&Ipv4Addr::UNSPECIFIED.to_string(), port, 1)],
+        Some(owner),
+    ) {
+        Ok((forwarder, _, _)) => {
+            forwarder.shutdown().unwrap();
+            panic!("authority failure was downgraded to a row report")
+        }
+        Err(error) => error,
+    };
+    match error {
+        ForwardError::Io(error) => assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied),
+        other => panic!("unexpected wildcard report result: {other}"),
+    }
+
     if let Ok(ipv6_probe) = TcpListener::bind((Ipv6Addr::LOCALHOST, 0)) {
         drop(ipv6_probe);
         assert_authenticated_wildcard_rejected(

--- a/crates/et-net/tests/forward.rs
+++ b/crates/et-net/tests/forward.rs
@@ -9,7 +9,7 @@ use et_core::packet::Packet;
 use et_core::proto::{
     PortForwardDestinationRequest, PortForwardSourceRequest, SocketEndpoint, TerminalPacketType,
 };
-use et_net::forward::Forwarder;
+use et_net::forward::{ForwardError, Forwarder};
 use prost::Message;
 
 const TIMEOUT: Duration = Duration::from_secs(3);
@@ -141,6 +141,55 @@ fn try_receive_reports_backpressure_and_outbound_drain_recovers() {
         outbound += 1;
     }
     forwarder.shutdown().unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn reverse_tcp_bind_uses_session_identity() {
+    let root = rustix::process::geteuid().as_raw() == 0;
+    let source_port = if root { 1 } else { reserve_port() };
+    let owner = (65_534, 65_534);
+
+    let error = match Forwarder::start_with_user(vec![request(source_port, 1)], Some(owner)) {
+        Ok((forwarder, _)) => {
+            forwarder.shutdown().unwrap();
+            panic!("TCP bind retained daemon authority");
+        }
+        Err(error) => error,
+    };
+
+    match error {
+        ForwardError::Io(error) => assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied),
+        other => panic!("unexpected TCP bind result: {other}"),
+    }
+}
+
+#[test]
+fn reverse_listener_limit_is_transactional() {
+    let reservations: Vec<TcpListener> = (0..33)
+        .map(|_| TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap())
+        .collect();
+    let ports: Vec<u16> = reservations
+        .iter()
+        .map(|listener| listener.local_addr().unwrap().port())
+        .collect();
+    drop(reservations);
+    let requests = ports.iter().map(|port| request(*port, 1)).collect();
+
+    let error = match Forwarder::start(requests) {
+        Ok(forwarder) => {
+            forwarder.shutdown().unwrap();
+            panic!("listener cap was not enforced");
+        }
+        Err(error) => error,
+    };
+
+    assert!(error.to_string().contains("listener limit"));
+    let rebound: Vec<TcpListener> = ports
+        .iter()
+        .map(|port| TcpListener::bind((Ipv4Addr::LOCALHOST, *port)).unwrap())
+        .collect();
+    assert_eq!(rebound.len(), 33);
 }
 
 fn reserve_port() -> u16 {

--- a/crates/et-net/tests/forward.rs
+++ b/crates/et-net/tests/forward.rs
@@ -11,7 +11,7 @@ use et_core::packet::Packet;
 use et_core::proto::{
     PortForwardDestinationRequest, PortForwardSourceRequest, SocketEndpoint, TerminalPacketType,
 };
-use et_net::forward::{ForwardError, Forwarder};
+use et_net::forward::{ForwardError, ForwardOrigin, ForwardSource, Forwarder};
 use prost::Message;
 
 const TIMEOUT: Duration = Duration::from_secs(3);
@@ -187,6 +187,37 @@ fn authenticated_reverse_tcp_wildcard_bind_exposes_session_to_external_network()
             owner,
         );
     }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn imported_local_wildcard_is_externally_reachable_while_loopback_is_not() {
+    let probe = std::net::UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).unwrap();
+    probe.connect((Ipv4Addr::new(192, 0, 2, 1), 9)).unwrap();
+    let external = match probe.local_addr().unwrap().ip() {
+        std::net::IpAddr::V4(address) if !address.is_loopback() => address,
+        address => panic!("route probe did not select a non-loopback IPv4 address: {address}"),
+    };
+
+    let loopback_port = reserve_port();
+    let loopback = Forwarder::start(vec![request(loopback_port, 1)]).unwrap();
+    assert!(
+        TcpStream::connect_timeout(&SocketAddr::from((external, loopback_port)), TIMEOUT,).is_err()
+    );
+    loopback.shutdown().unwrap();
+
+    let wildcard_port = reserve_port();
+    let request = request_on("", wildcard_port, 1);
+    let (wildcard, skipped) = Forwarder::start_with_origins(vec![ForwardSource {
+        request,
+        origin: ForwardOrigin::SshConfig,
+    }])
+    .unwrap();
+    assert!(skipped.is_empty());
+    let connection =
+        TcpStream::connect_timeout(&SocketAddr::from((external, wildcard_port)), TIMEOUT).unwrap();
+    drop(connection);
+    wildcard.shutdown().unwrap();
 }
 
 #[test]

--- a/crates/et-net/tests/forward.rs
+++ b/crates/et-net/tests/forward.rs
@@ -220,16 +220,36 @@ fn imported_local_wildcard_is_externally_reachable_while_loopback_is_not() {
     wildcard.shutdown().unwrap();
 }
 
+#[cfg(unix)]
 #[test]
 fn reverse_listener_limit_is_transactional() {
-    let reservations: Vec<TcpListener> = (0..33)
-        .map(|_| TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap())
+    struct RemoveDir(std::path::PathBuf);
+    impl Drop for RemoveDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    let directory = std::env::temp_dir().join(format!("etrl-{}", std::process::id()));
+    std::fs::create_dir(&directory).unwrap();
+    let _cleanup = RemoveDir(directory.clone());
+    let paths: Vec<_> = (0..33)
+        .map(|index| directory.join(format!("source-{index}.sock")))
         .collect();
-    let ports: Vec<u16> = reservations
+    let requests = paths
         .iter()
-        .map(|listener| listener.local_addr().unwrap().port())
+        .map(|path| PortForwardSourceRequest {
+            source: Some(SocketEndpoint {
+                name: Some(path.to_string_lossy().into_owned()),
+                port: None,
+            }),
+            destination: Some(SocketEndpoint {
+                name: Some("/tmp/destination.sock".to_owned()),
+                port: None,
+            }),
+            environmentvariable: None,
+        })
         .collect();
-    let requests = ports.iter().map(|port| request(*port, 1)).collect();
 
     let error = match Forwarder::start(requests) {
         Ok(forwarder) => {
@@ -239,13 +259,11 @@ fn reverse_listener_limit_is_transactional() {
         Err(error) => error,
     };
 
-    assert!(error.to_string().contains("listener limit"));
-    drop(reservations);
-    let rebound: Vec<TcpListener> = ports
-        .iter()
-        .map(|port| TcpListener::bind((Ipv4Addr::LOCALHOST, *port)).unwrap())
-        .collect();
-    assert_eq!(rebound.len(), 33);
+    assert!(
+        error.to_string().contains("listener limit"),
+        "unexpected error: {error}"
+    );
+    assert!(paths.iter().all(|path| !path.exists()));
 }
 
 fn reserve_port() -> u16 {
@@ -275,7 +293,6 @@ fn assert_authenticated_wildcard_rejected(loopback: IpAddr, wildcard: IpAddr, ow
         .iter()
         .map(|listener| listener.local_addr().unwrap().port())
         .collect();
-    drop(reservations);
     let error = match Forwarder::start_with_user(
         vec![
             request_on(&loopback.to_string(), ports[0], 1),
@@ -293,14 +310,7 @@ fn assert_authenticated_wildcard_rejected(loopback: IpAddr, wildcard: IpAddr, ow
         ForwardError::Io(error) => assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied),
         other => panic!("unexpected wildcard bind result: {other}"),
     }
-    let rebound: Vec<TcpListener> = [
-        SocketAddr::new(loopback, ports[0]),
-        SocketAddr::new(wildcard, ports[1]),
-    ]
-    .into_iter()
-    .map(|address| TcpListener::bind(address).unwrap())
-    .collect();
-    assert_eq!(rebound.len(), ports.len());
+    assert_eq!(reservations.len(), ports.len());
 }
 
 fn request(source: u16, destination: u16) -> PortForwardSourceRequest {

--- a/crates/et-net/tests/forward.rs
+++ b/crates/et-net/tests/forward.rs
@@ -1,6 +1,8 @@
 #![forbid(unsafe_code)]
 
 use std::io::{Read, Write};
+#[cfg(unix)]
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::net::{Ipv4Addr, TcpListener, TcpStream};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -164,6 +166,29 @@ fn reverse_tcp_bind_uses_session_identity() {
     }
 }
 
+#[cfg(unix)]
+#[test]
+fn authenticated_reverse_tcp_wildcard_bind_exposes_session_to_external_network() {
+    let owner = (
+        rustix::process::geteuid().as_raw(),
+        rustix::process::getegid().as_raw(),
+    );
+    assert_authenticated_wildcard_rejected(
+        Ipv4Addr::LOCALHOST.into(),
+        Ipv4Addr::UNSPECIFIED.into(),
+        owner,
+    );
+
+    if let Ok(ipv6_probe) = TcpListener::bind((Ipv6Addr::LOCALHOST, 0)) {
+        drop(ipv6_probe);
+        assert_authenticated_wildcard_rejected(
+            Ipv6Addr::LOCALHOST.into(),
+            Ipv6Addr::UNSPECIFIED.into(),
+            owner,
+        );
+    }
+}
+
 #[test]
 fn reverse_listener_limit_is_transactional() {
     let reservations: Vec<TcpListener> = (0..33)
@@ -200,10 +225,61 @@ fn reserve_port() -> u16 {
         .port()
 }
 
+#[cfg(unix)]
+fn assert_authenticated_wildcard_rejected(loopback: IpAddr, wildcard: IpAddr, owner: (u32, u32)) {
+    let reservation = TcpListener::bind((loopback, 0)).unwrap();
+    let allowed_port = reservation.local_addr().unwrap().port();
+    drop(reservation);
+    let (allowed, _) = Forwarder::start_with_user(
+        vec![request_on(&loopback.to_string(), allowed_port, 1)],
+        Some(owner),
+    )
+    .unwrap();
+    allowed.shutdown().unwrap();
+
+    let reservations: Vec<TcpListener> = (0..2)
+        .map(|_| TcpListener::bind((loopback, 0)).unwrap())
+        .collect();
+    let ports: Vec<u16> = reservations
+        .iter()
+        .map(|listener| listener.local_addr().unwrap().port())
+        .collect();
+    drop(reservations);
+    let error = match Forwarder::start_with_user(
+        vec![
+            request_on(&loopback.to_string(), ports[0], 1),
+            request_on(&wildcard.to_string(), ports[1], 1),
+        ],
+        Some(owner),
+    ) {
+        Ok((forwarder, _)) => {
+            forwarder.shutdown().unwrap();
+            panic!("authenticated wildcard reverse bind was exposed")
+        }
+        Err(error) => error,
+    };
+    match error {
+        ForwardError::Io(error) => assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied),
+        other => panic!("unexpected wildcard bind result: {other}"),
+    }
+    let rebound: Vec<TcpListener> = [
+        SocketAddr::new(loopback, ports[0]),
+        SocketAddr::new(wildcard, ports[1]),
+    ]
+    .into_iter()
+    .map(|address| TcpListener::bind(address).unwrap())
+    .collect();
+    assert_eq!(rebound.len(), ports.len());
+}
+
 fn request(source: u16, destination: u16) -> PortForwardSourceRequest {
+    request_on("127.0.0.1", source, destination)
+}
+
+fn request_on(host: &str, source: u16, destination: u16) -> PortForwardSourceRequest {
     PortForwardSourceRequest {
         source: Some(SocketEndpoint {
-            name: Some("127.0.0.1".to_owned()),
+            name: Some(host.to_owned()),
             port: Some(i32::from(source)),
         }),
         destination: Some(SocketEndpoint {

--- a/crates/et-net/tests/forward.rs
+++ b/crates/et-net/tests/forward.rs
@@ -173,7 +173,6 @@ fn reverse_listener_limit_is_transactional() {
         .iter()
         .map(|listener| listener.local_addr().unwrap().port())
         .collect();
-    drop(reservations);
     let requests = ports.iter().map(|port| request(*port, 1)).collect();
 
     let error = match Forwarder::start(requests) {
@@ -185,6 +184,7 @@ fn reverse_listener_limit_is_transactional() {
     };
 
     assert!(error.to_string().contains("listener limit"));
+    drop(reservations);
     let rebound: Vec<TcpListener> = ports
         .iter()
         .map(|port| TcpListener::bind((Ipv4Addr::LOCALHOST, *port)).unwrap())

--- a/crates/et-server/Cargo.toml
+++ b/crates/et-server/Cargo.toml
@@ -17,4 +17,5 @@ et-net = { path = "../et-net" }
 prost = "0.13"
 
 [target.'cfg(unix)'.dependencies]
+nix = { version = "0.31.3", default-features = false, features = ["socket", "user"] }
 rustix = { version = "1.1.4", features = ["event", "net", "process", "time"] }

--- a/crates/et-server/src/registry.rs
+++ b/crates/et-server/src/registry.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use et_core::crypto::KEY_LEN;
 use et_core::proto::TerminalUserInfo;
 
-use crate::registry_validation::validate;
+use crate::registry_validation::{validate, PeerIdentity};
 
 #[derive(Clone, Debug)]
 pub struct Registration {
@@ -103,8 +103,9 @@ impl Registry {
         &self,
         user_info: TerminalUserInfo,
         stream: LocalStream,
+        peer: PeerIdentity,
     ) -> Result<RegisteredTerminal, RegistrationError> {
-        let registration = validate(user_info)?;
+        let registration = validate(user_info, peer)?;
         let watcher = stream.try_clone().map_err(RegistrationError::Io)?;
         // The Windows router peeks this handle for EOF, which requires
         // non-blocking mode so a live session never stalls the loop.

--- a/crates/et-server/src/registry_validation.rs
+++ b/crates/et-server/src/registry_validation.rs
@@ -1,4 +1,7 @@
+use std::io;
 use std::sync::Arc;
+
+use et_net::local::LocalStream;
 
 use et_core::keys::passkey_to_key;
 use et_core::proto::TerminalUserInfo;
@@ -7,7 +10,55 @@ use crate::registry::{Registration, RegistrationError};
 
 const ID_LEN: usize = 16;
 
-pub(crate) fn validate(user_info: TerminalUserInfo) -> Result<Registration, RegistrationError> {
+#[derive(Clone, Copy)]
+pub(crate) enum PeerIdentity {
+    #[cfg(unix)]
+    Unix { uid: u32, gid: u32 },
+    #[cfg(windows)]
+    AuthenticatedWindowsToken,
+}
+
+impl PeerIdentity {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub(crate) fn from_stream(stream: &LocalStream) -> io::Result<Self> {
+        let credentials = rustix::net::sockopt::socket_peercred(stream)?;
+        Ok(Self::Unix {
+            uid: credentials.uid.as_raw(),
+            gid: credentials.gid.as_raw(),
+        })
+    }
+
+    #[cfg(target_vendor = "apple")]
+    pub(crate) fn from_stream(stream: &LocalStream) -> io::Result<Self> {
+        let (uid, gid) = nix::unistd::getpeereid(stream)
+            .map_err(|error| io::Error::from_raw_os_error(error as i32))?;
+        Ok(Self::Unix {
+            uid: uid.as_raw(),
+            gid: gid.as_raw(),
+        })
+    }
+
+    #[cfg(all(
+        unix,
+        not(any(target_os = "linux", target_os = "android", target_vendor = "apple"))
+    ))]
+    pub(crate) fn from_stream(_stream: &LocalStream) -> io::Result<Self> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "router peer credentials are unavailable on this Unix platform",
+        ))
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn from_stream(_stream: &LocalStream) -> io::Result<Self> {
+        Ok(Self::AuthenticatedWindowsToken)
+    }
+}
+
+pub(crate) fn validate(
+    user_info: TerminalUserInfo,
+    peer: PeerIdentity,
+) -> Result<Registration, RegistrationError> {
     let id = user_info.id.ok_or(RegistrationError::Invalid)?;
     if id.len() != ID_LEN || !id.bytes().all(|byte| byte.is_ascii_alphanumeric()) {
         return Err(RegistrationError::Invalid);
@@ -22,6 +73,17 @@ pub(crate) fn validate(user_info: TerminalUserInfo) -> Result<Registration, Regi
         .gid
         .and_then(|value| u32::try_from(value).ok())
         .ok_or(RegistrationError::Invalid)?;
+    match peer {
+        #[cfg(unix)]
+        PeerIdentity::Unix {
+            uid: peer_uid,
+            gid: peer_gid,
+        } if uid != peer_uid || gid != peer_gid => return Err(RegistrationError::Invalid),
+        #[cfg(unix)]
+        PeerIdentity::Unix { .. } => {}
+        #[cfg(windows)]
+        PeerIdentity::AuthenticatedWindowsToken => {}
+    }
     Ok(Registration {
         id,
         key,
@@ -47,8 +109,12 @@ mod tests {
 
     #[test]
     fn identical_material_has_distinct_registration_generations() {
-        let first = validate(info()).unwrap();
-        let second = validate(info()).unwrap();
+        #[cfg(unix)]
+        let peer = PeerIdentity::Unix { uid: 501, gid: 20 };
+        #[cfg(windows)]
+        let peer = PeerIdentity::AuthenticatedWindowsToken;
+        let first = validate(info(), peer).unwrap();
+        let second = validate(info(), peer).unwrap();
         assert_eq!(first, second);
         assert!(!first.same_generation(&second));
         assert!(!first.identity().same_generation(&second.identity()));

--- a/crates/et-server/src/router_loop.rs
+++ b/crates/et-server/src/router_loop.rs
@@ -12,6 +12,7 @@ use rustix::event::{poll, PollFd, PollFlags};
 use rustix::net::{recv, RecvFlags};
 
 use crate::registry::{RegistrationIdentity, Registry};
+use crate::registry_validation::PeerIdentity;
 use crate::router::{RouterError, RouterEvent, RouterReject};
 use crate::router_registration;
 use crate::runtime_lifecycle::LifecycleEvent;
@@ -23,6 +24,7 @@ use crate::socket_path_windows::OwnedRouterListener;
 struct PendingConnection {
     stream: LocalStream,
     decoder: LocalPacketDecoder,
+    peer: PeerIdentity,
 }
 
 struct WatchedRegistration {
@@ -140,7 +142,12 @@ fn run_poll(
                 ReadOutcome::Pending => {}
                 ReadOutcome::Packet(packet) => {
                     let connection = pending.swap_remove(index);
-                    match router_registration::process(packet, connection.stream, &registry) {
+                    match router_registration::process(
+                        packet,
+                        connection.stream,
+                        &registry,
+                        connection.peer,
+                    ) {
                         Ok(terminal) => {
                             let id = terminal.identity.id().to_owned();
                             terminal
@@ -234,7 +241,12 @@ fn run_windows(
                 ReadOutcome::Packet(packet) => {
                     progress = true;
                     let connection = pending.swap_remove(index);
-                    match router_registration::process(packet, connection.stream, &registry) {
+                    match router_registration::process(
+                        packet,
+                        connection.stream,
+                        &registry,
+                        connection.peer,
+                    ) {
                         Ok(terminal) => {
                             let id = terminal.identity.id().to_owned();
                             watched.push(WatchedRegistration {
@@ -303,10 +315,12 @@ fn accept_ready(
     loop {
         match listener.accept() {
             Ok((stream, _)) => {
+                let peer = PeerIdentity::from_stream(&stream).map_err(RouterError::Io)?;
                 stream.set_nonblocking(true).map_err(RouterError::Io)?;
                 pending.push(PendingConnection {
                     stream,
                     decoder: LocalPacketDecoder::new(),
+                    peer,
                 });
             }
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(()),

--- a/crates/et-server/src/router_registration.rs
+++ b/crates/et-server/src/router_registration.rs
@@ -5,12 +5,14 @@ use et_core::proto::{TerminalPacketType, TerminalUserInfo};
 use prost::Message;
 
 use crate::registry::{RegisteredTerminal, RegistrationError, Registry};
+use crate::registry_validation::PeerIdentity;
 use crate::router::RouterReject;
 
 pub(crate) fn process(
     packet: Packet,
     stream: LocalStream,
     registry: &Registry,
+    peer: PeerIdentity,
 ) -> Result<RegisteredTerminal, RouterReject> {
     if packet.is_encrypted() {
         return Err(RouterReject::Encrypted);
@@ -20,7 +22,7 @@ pub(crate) fn process(
     }
     let info =
         TerminalUserInfo::decode(packet.payload()).map_err(|_| RouterReject::MalformedUserInfo)?;
-    registry.register(info, stream).map_err(map_error)
+    registry.register(info, stream, peer).map_err(map_error)
 }
 
 fn map_error(error: RegistrationError) -> RouterReject {

--- a/crates/et-server/src/runtime.rs
+++ b/crates/et-server/src/runtime.rs
@@ -314,13 +314,15 @@ mod tests {
         handle: &crate::runtime_handle::RuntimeHandle,
     ) -> et_net::local::LocalStream {
         let mut stream = et_net::local::connect(path).unwrap();
+        let uid = i64::from(rustix::process::getuid().as_raw());
+        let gid = i64::from(rustix::process::getgid().as_raw());
         let packet = Packet::new(
             TerminalPacketType::TerminalUserInfo as u8,
             TerminalUserInfo {
                 id: Some(ID.to_owned()),
                 passkey: Some(KEY.to_owned()),
-                uid: Some(501),
-                gid: Some(20),
+                uid: Some(uid),
+                gid: Some(gid),
                 fd: None,
             }
             .encode_to_vec(),

--- a/crates/et-server/src/runtime_handler.rs
+++ b/crates/et-server/src/runtime_handler.rs
@@ -17,6 +17,7 @@ use crate::session::ActiveSession;
 use crate::session_table::SessionClaim;
 
 const LEGACY_UNTRUSTED_ORIGIN_MARKER: &str = "ET_RS_SSH_CONFIG_REMOTE_FORWARD";
+const JUMPHOST_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
 pub(crate) fn handle(
     stream: TcpStream,
@@ -341,18 +342,6 @@ fn run_jumphost(
     id: &str,
     peer: &str,
 ) {
-    if connection
-        .write_packet(
-            EtPacketType::InitialResponse as u8,
-            &InitialResponse { error: None }.encode_to_vec(),
-        )
-        .is_err()
-    {
-        crate::diag::info(format!(
-            "id={id}: jumphost failed writing INITIAL_RESPONSE to {peer}"
-        ));
-        return;
-    }
     let mut terminal = match core.registry.clone_stream(start.registration()) {
         Ok(terminal) => terminal,
         Err(error) => {
@@ -366,8 +355,70 @@ fn run_jumphost(
         TerminalPacketType::JumphostInit as u8,
         payload.encode_to_vec(),
     );
-    if write_local_packet(&mut terminal, &init_packet).is_err() {
+    if terminal
+        .set_nonblocking(false)
+        .and_then(|()| terminal.set_read_timeout(Some(JUMPHOST_RESPONSE_TIMEOUT)))
+        .and_then(|()| terminal.set_write_timeout(Some(JUMPHOST_RESPONSE_TIMEOUT)))
+        .is_err()
+        || write_local_packet(&mut terminal, &init_packet).is_err()
+    {
         crate::diag::info(format!("id={id}: jumphost failed sending JUMPHOST_INIT"));
+        return;
+    }
+    let response_packet = match et_net::local_packet::read_local_packet(&mut terminal) {
+        Ok(packet)
+            if !packet.is_encrypted()
+                && packet.header() == TerminalPacketType::JumphostInit as u8 =>
+        {
+            packet
+        }
+        Ok(_) | Err(_) => {
+            crate::diag::info(format!(
+                "id={id}: jumphost received invalid destination response"
+            ));
+            return;
+        }
+    };
+    let response = InitialResponse::decode(response_packet.payload()).ok();
+    if connection
+        .write_packet(
+            EtPacketType::InitialResponse as u8,
+            response_packet.payload(),
+        )
+        .is_err()
+    {
+        crate::diag::info(format!(
+            "id={id}: jumphost failed writing destination INITIAL_RESPONSE to {peer}"
+        ));
+        return;
+    }
+    let Some(response) = response else {
+        let _ = terminal.shutdown(std::net::Shutdown::Both);
+        return;
+    };
+    if response.error.is_some() {
+        if connection.set_io_timeout(Some(HANDSHAKE_TIMEOUT)).is_err() {
+            return;
+        }
+        let acknowledged = connection.read_packet().is_ok_and(|packet| {
+            packet.header() == EtPacketType::Heartbeat as u8 && packet.payload().is_empty()
+        });
+        if !acknowledged
+            || write_local_packet(
+                &mut terminal,
+                &et_core::packet::Packet::new(EtPacketType::Heartbeat as u8, Vec::new()),
+            )
+            .is_err()
+            || connection.set_io_timeout(None).is_err()
+        {
+            let _ = terminal.shutdown(std::net::Shutdown::Both);
+            return;
+        }
+    }
+    if terminal.set_read_timeout(None).is_err()
+        || terminal.set_write_timeout(None).is_err()
+        || terminal.set_nonblocking(true).is_err()
+    {
         return;
     }
     let active = match ActiveSession::new(connection, &terminal) {

--- a/crates/et-server/src/runtime_handler.rs
+++ b/crates/et-server/src/runtime_handler.rs
@@ -16,6 +16,8 @@ use crate::runtime_state::{PreAuthGuard, RawSocketGuard, RuntimeCore};
 use crate::session::ActiveSession;
 use crate::session_table::SessionClaim;
 
+const LEGACY_UNTRUSTED_ORIGIN_MARKER: &str = "ET_RS_SSH_CONFIG_REMOTE_FORWARD";
+
 pub(crate) fn handle(
     stream: TcpStream,
     core: Arc<RuntimeCore>,
@@ -206,27 +208,63 @@ fn handle_new(
         run_jumphost(connection, start, core, payload, id, peer);
         return;
     }
+    if payload.reversetunnels.len() > et_net::reverse_report::MAX_REVERSE_ROWS {
+        send_initial_error(&mut connection, "too many reverse forwarding rows");
+        return;
+    }
     let owner = {
         let registration = start.registration();
         (registration.uid, registration.gid)
     };
-    let (forwarder, forward_environment) = match et_net::forward::Forwarder::start_with_user(
-        payload.reversetunnels.clone(),
-        Some(owner),
-    ) {
-        Ok(started) => started,
-        Err(error) => {
-            crate::diag::info(format!(
-                "id={id}: reverse-tunnel setup failed for {peer}: {error}"
-            ));
-            send_initial_error(&mut connection, &error.to_string());
-            return;
+    let mut reverse_tunnels = payload.reversetunnels.clone();
+    for request in &mut reverse_tunnels {
+        if request.environmentvariable.as_deref() == Some(LEGACY_UNTRUSTED_ORIGIN_MARKER) {
+            request.environmentvariable = None;
+        }
+    }
+    let (forwarder, forward_environment, skipped) =
+        match et_net::forward::Forwarder::start_with_user_report(reverse_tunnels, Some(owner)) {
+            Ok(started) => started,
+            Err(error) => {
+                crate::diag::info(format!(
+                    "id={id}: reverse-tunnel setup failed for {peer}: {error}"
+                ));
+                send_initial_error(&mut connection, &error.to_string());
+                return;
+            }
+        };
+    let response_error = if skipped.is_empty() {
+        None
+    } else {
+        let mut rows: Vec<_> = skipped
+            .iter()
+            .filter_map(|skipped| {
+                skipped
+                    .report_index
+                    .map(|index| et_net::reverse_report::SkippedRow {
+                        index,
+                        reason: skipped.reason,
+                    })
+            })
+            .collect();
+        rows.sort_unstable_by_key(|row| row.index);
+        match et_net::reverse_report::encode_skipped_rows(&rows) {
+            Ok(report) => Some(report),
+            Err(_) => {
+                drop(forwarder);
+                send_initial_error(&mut connection, "too many skipped reverse forwarding rows");
+                return;
+            }
         }
     };
+    let requires_ack = response_error.is_some();
     if connection
         .write_packet(
             EtPacketType::InitialResponse as u8,
-            &InitialResponse { error: None }.encode_to_vec(),
+            &InitialResponse {
+                error: response_error,
+            }
+            .encode_to_vec(),
         )
         .is_err()
     {
@@ -234,6 +272,17 @@ fn handle_new(
             "id={id}: failed writing INITIAL_RESPONSE to {peer}"
         ));
         return;
+    }
+    if requires_ack {
+        if connection.set_io_timeout(Some(HANDSHAKE_TIMEOUT)).is_err() {
+            return;
+        }
+        let acknowledged = connection.read_packet().is_ok_and(|packet| {
+            packet.header() == EtPacketType::Heartbeat as u8 && packet.payload().is_empty()
+        });
+        if !acknowledged || connection.set_io_timeout(None).is_err() {
+            return;
+        }
     }
     let mut terminal = match core.registry.clone_stream(start.registration()) {
         Ok(terminal) => terminal,

--- a/crates/et-server/tests/router_concurrency.rs
+++ b/crates/et-server/tests/router_concurrency.rs
@@ -16,14 +16,20 @@ use prost::Message;
 use support::TestDir;
 
 const KEY: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef";
+const OTHER_KEY: &str = "0123456789abcdefghijklmnopqrstuv";
 
-fn register(path: &std::path::Path, id: String, uid: i64, barrier: Arc<Barrier>) -> UnixStream {
+fn register(
+    path: &std::path::Path,
+    id: String,
+    passkey: &str,
+    barrier: Arc<Barrier>,
+) -> UnixStream {
     let mut stream = UnixStream::connect(path).unwrap();
     let info = TerminalUserInfo {
         id: Some(id),
-        passkey: Some(KEY.to_owned()),
-        uid: Some(uid),
-        gid: Some(uid),
+        passkey: Some(passkey.to_owned()),
+        uid: Some(i64::from(rustix::process::getuid().as_raw())),
+        gid: Some(i64::from(rustix::process::getgid().as_raw())),
         fd: None,
     };
     let packet = Packet::new(
@@ -40,19 +46,20 @@ fn concurrent_distinct_registrations_are_all_retained() {
     let dir = TestDir::new();
     let path = dir.socket();
     let registry = Registry::new();
-    let selected = select_router_path_for(1000, Some(&path), None, None).unwrap();
+    let selected =
+        select_router_path_for(rustix::process::getuid().as_raw(), Some(&path), None, None)
+            .unwrap();
     let mut router = Router::start(selected, registry.clone()).unwrap();
     let ids = ["aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb", "cccccccccccccccc"];
     let barrier = Arc::new(Barrier::new(ids.len()));
 
     let workers: Vec<_> = ids
         .iter()
-        .enumerate()
-        .map(|(index, id)| {
+        .map(|id| {
             let path = path.clone();
             let barrier = barrier.clone();
             let id = (*id).to_owned();
-            thread::spawn(move || register(&path, id, index as i64, barrier))
+            thread::spawn(move || register(&path, id, KEY, barrier))
         })
         .collect();
     let terminals: Vec<_> = workers
@@ -75,17 +82,19 @@ fn concurrent_same_id_has_one_winner_and_never_overwrites_it() {
     let dir = TestDir::new();
     let path = dir.socket();
     let registry = Registry::new();
-    let selected = select_router_path_for(1000, Some(&path), None, None).unwrap();
+    let selected =
+        select_router_path_for(rustix::process::getuid().as_raw(), Some(&path), None, None)
+            .unwrap();
     let mut router = Router::start(selected, registry.clone()).unwrap();
     let barrier = Arc::new(Barrier::new(2));
     let mut workers = Vec::new();
     let id = "sameidentifier00";
     assert_eq!(id.len(), 16);
-    for uid in [101, 202] {
+    for passkey in [KEY, OTHER_KEY] {
         let path = path.clone();
         let barrier = barrier.clone();
         workers.push(thread::spawn(move || {
-            register(&path, id.to_owned(), uid, barrier)
+            register(&path, id.to_owned(), passkey, barrier)
         }));
     }
     let terminals: Vec<_> = workers
@@ -111,8 +120,10 @@ fn concurrent_same_id_has_one_winner_and_never_overwrites_it() {
             .count(),
         1
     );
-    let winner = registry.get(id).unwrap().unwrap().uid;
-    assert!(winner == 101 || winner == 202);
+    assert_eq!(
+        registry.get(id).unwrap().unwrap().uid,
+        rustix::process::getuid().as_raw()
+    );
     assert_eq!(registry.len().unwrap(), 1);
     router.shutdown().unwrap();
     drop(terminals);
@@ -121,7 +132,13 @@ fn concurrent_same_id_has_one_winner_and_never_overwrites_it() {
 #[test]
 fn shutdown_wakes_an_idle_router_without_timing_luck() {
     let dir = TestDir::new();
-    let selected = select_router_path_for(1000, Some(&dir.socket()), None, None).unwrap();
+    let selected = select_router_path_for(
+        rustix::process::getuid().as_raw(),
+        Some(&dir.socket()),
+        None,
+        None,
+    )
+    .unwrap();
     let router = Router::start(selected, Registry::new()).unwrap();
     let (done_tx, done_rx) = std::sync::mpsc::channel();
     thread::spawn(move || {

--- a/crates/et-server/tests/router_registration.rs
+++ b/crates/et-server/tests/router_registration.rs
@@ -18,6 +18,13 @@ use support::TestDir;
 const ID: &str = "abcdefghijklmnop";
 const KEY: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef";
 
+fn peer_identity() -> (i64, i64) {
+    (
+        i64::from(rustix::process::geteuid().as_raw()),
+        i64::from(rustix::process::getegid().as_raw()),
+    )
+}
+
 fn info(
     id: Option<&str>,
     key: Option<&str>,
@@ -58,9 +65,10 @@ fn valid_plaintext_registration_is_retained() {
     let selected = select_router_path_for(1000, Some(&path), None, None).unwrap();
     let mut router = Router::start(selected, registry.clone()).unwrap();
 
+    let (uid, gid) = peer_identity();
     let packet = Packet::new(
         TerminalPacketType::TerminalUserInfo as u8,
-        info(Some(ID), Some(KEY), Some(501), Some(20)).encode_to_vec(),
+        info(Some(ID), Some(KEY), Some(uid), Some(gid)).encode_to_vec(),
     );
     let _terminal = connect_packet(&path, &packet);
     assert_eq!(
@@ -69,9 +77,35 @@ fn valid_plaintext_registration_is_retained() {
     );
 
     let registered = registry.get(ID).unwrap().unwrap();
-    assert_eq!(registered.uid, 501);
-    assert_eq!(registered.gid, 20);
+    assert_eq!(registered.uid, u32::try_from(uid).unwrap());
+    assert_eq!(registered.gid, u32::try_from(gid).unwrap());
     assert_eq!(&registered.key, KEY.as_bytes());
+    router.shutdown().unwrap();
+}
+
+#[test]
+fn router_registration_rejects_forged_identity() {
+    let dir = TestDir::new();
+    let path = dir.socket();
+    let registry = Registry::new();
+    let selected = select_router_path_for(0, Some(&path), None, None).unwrap();
+    let mut router = Router::start(selected, registry.clone()).unwrap();
+    let (forged_uid, forged_gid) = if rustix::process::geteuid().as_raw() == 0 {
+        (1, 1)
+    } else {
+        (0, 0)
+    };
+
+    send_packet(
+        &path,
+        &Packet::new(
+            TerminalPacketType::TerminalUserInfo as u8,
+            info(Some(ID), Some(KEY), Some(forged_uid), Some(forged_gid)).encode_to_vec(),
+        ),
+    );
+
+    expect_rejected(&router, RouterReject::InvalidRegistration);
+    assert!(registry.is_empty().unwrap());
     router.shutdown().unwrap();
 }
 
@@ -153,9 +187,10 @@ fn duplicate_rejection_preserves_the_original_registration() {
     let selected = select_router_path_for(1000, Some(&path), None, None).unwrap();
     let mut router = Router::start(selected, registry.clone()).unwrap();
 
+    let (uid, gid) = peer_identity();
     let first = Packet::new(
         TerminalPacketType::TerminalUserInfo as u8,
-        info(Some(ID), Some(KEY), Some(10), Some(1)).encode_to_vec(),
+        info(Some(ID), Some(KEY), Some(uid), Some(gid)).encode_to_vec(),
     );
     let _terminal = connect_packet(&path, &first);
     assert_eq!(
@@ -165,11 +200,14 @@ fn duplicate_rejection_preserves_the_original_registration() {
 
     let duplicate = Packet::new(
         TerminalPacketType::TerminalUserInfo as u8,
-        info(Some(ID), Some(KEY), Some(20), Some(1)).encode_to_vec(),
+        info(Some(ID), Some(KEY), Some(uid), Some(gid)).encode_to_vec(),
     );
     send_packet(&path, &duplicate);
     expect_rejected(&router, RouterReject::Duplicate);
-    assert_eq!(registry.get(ID).unwrap().unwrap().uid, 10);
+    assert_eq!(
+        registry.get(ID).unwrap().unwrap().uid,
+        u32::try_from(uid).unwrap()
+    );
     assert_eq!(registry.len().unwrap(), 1);
     router.shutdown().unwrap();
 }
@@ -181,9 +219,10 @@ fn terminal_disconnect_is_typed_and_same_id_can_register_again() {
     let registry = Registry::new();
     let selected = select_router_path_for(1000, Some(&path), None, None).unwrap();
     let mut router = Router::start(selected, registry.clone()).unwrap();
+    let (uid, gid) = peer_identity();
     let packet = Packet::new(
         TerminalPacketType::TerminalUserInfo as u8,
-        info(Some(ID), Some(KEY), Some(501), Some(20)).encode_to_vec(),
+        info(Some(ID), Some(KEY), Some(uid), Some(gid)).encode_to_vec(),
     );
 
     let terminal = connect_packet(&path, &packet);

--- a/crates/et-server/tests/runtime_adversarial.rs
+++ b/crates/et-server/tests/runtime_adversarial.rs
@@ -307,16 +307,26 @@ fn jumphost_payload_is_relayed_to_the_registered_terminal() {
     };
     let (stream, response) = server.handshake(ID_A);
     assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    let terminal_handshake = std::thread::spawn(move || {
+        let packet = et_net::local_packet::read_local_packet(&mut terminal).unwrap();
+        assert_eq!(
+            packet.header(),
+            et_core::proto::TerminalPacketType::JumphostInit as u8
+        );
+        let relayed = InitialPayload::decode(packet.payload()).unwrap();
+        et_net::local_packet::write_local_packet(
+            &mut terminal,
+            &et_core::packet::Packet::new(
+                et_core::proto::TerminalPacketType::JumphostInit as u8,
+                InitialResponse { error: None }.encode_to_vec(),
+            ),
+        )
+        .unwrap();
+        relayed
+    });
     let (_client, initial) = runtime_support::initialize(stream, &key, payload);
-    // Jumphost sessions succeed: upstream `runJumpHost` answers with an empty
-    // InitialResponse and forwards JUMPHOST_INIT to the jump terminal.
     assert!(initial.error.is_none(), "{:?}", initial.error);
-    let packet = et_net::local_packet::read_local_packet(&mut terminal).unwrap();
-    assert_eq!(
-        packet.header(),
-        et_core::proto::TerminalPacketType::JumphostInit as u8
-    );
-    let relayed = InitialPayload::decode(packet.payload()).unwrap();
+    let relayed = terminal_handshake.join().unwrap();
     assert_eq!(relayed.jumphost, Some(true));
     server.runtime.shutdown().unwrap();
 }

--- a/crates/et-server/tests/runtime_adversarial.rs
+++ b/crates/et-server/tests/runtime_adversarial.rs
@@ -77,6 +77,36 @@ fn unbindable_reverse_tunnel_reports_an_error_and_resets_the_slot() {
 }
 
 #[test]
+fn forged_import_origin_cannot_turn_explicit_conflict_into_skip() {
+    let mut server = TestRuntime::start();
+    let _terminal = server.register(ID_A, KEY_A);
+    let key = passkey_to_key(KEY_A).unwrap();
+    let occupied_path = server.dir.path().join("forged-origin.sock");
+    let _occupied = std::os::unix::net::UnixListener::bind(&occupied_path).unwrap();
+    let payload = InitialPayload {
+        jumphost: Some(false),
+        reversetunnels: vec![et_core::proto::PortForwardSourceRequest {
+            source: Some(et_core::proto::SocketEndpoint {
+                name: Some(occupied_path.to_string_lossy().into_owned()),
+                port: None,
+            }),
+            destination: Some(et_core::proto::SocketEndpoint {
+                name: Some("/tmp/destination.sock".to_owned()),
+                port: None,
+            }),
+            environmentvariable: Some("ET_RS_SSH_CONFIG_REMOTE_FORWARD".to_owned()),
+        }],
+        environmentvariables: HashMap::new(),
+    };
+
+    let (stream, _) = server.handshake(ID_A);
+    let (_, initial) = runtime_support::initialize(stream, &key, payload);
+
+    assert!(initial.error.is_some());
+    server.runtime.shutdown().unwrap();
+}
+
+#[test]
 fn jumphost_payload_is_relayed_to_the_registered_terminal() {
     let mut server = TestRuntime::start();
     let mut terminal = server.register(ID_A, KEY_A);

--- a/crates/et-server/tests/runtime_adversarial.rs
+++ b/crates/et-server/tests/runtime_adversarial.rs
@@ -77,33 +77,222 @@ fn unbindable_reverse_tunnel_reports_an_error_and_resets_the_slot() {
 }
 
 #[test]
-fn forged_import_origin_cannot_turn_explicit_conflict_into_skip() {
+fn occupied_reverse_row_is_reported_while_usable_row_stays_live() {
     let mut server = TestRuntime::start();
     let _terminal = server.register(ID_A, KEY_A);
     let key = passkey_to_key(KEY_A).unwrap();
-    let occupied_path = server.dir.path().join("forged-origin.sock");
+    let occupied_path = server.dir.path().join("reported-occupied.sock");
+    let usable_path = server.dir.path().join("reported-usable.sock");
     let _occupied = std::os::unix::net::UnixListener::bind(&occupied_path).unwrap();
+    let request = |path: &std::path::Path| et_core::proto::PortForwardSourceRequest {
+        source: Some(et_core::proto::SocketEndpoint {
+            name: Some(path.to_string_lossy().into_owned()),
+            port: None,
+        }),
+        destination: Some(et_core::proto::SocketEndpoint {
+            name: Some("/tmp/destination.sock".to_owned()),
+            port: None,
+        }),
+        environmentvariable: None,
+    };
     let payload = InitialPayload {
         jumphost: Some(false),
-        reversetunnels: vec![et_core::proto::PortForwardSourceRequest {
-            source: Some(et_core::proto::SocketEndpoint {
-                name: Some(occupied_path.to_string_lossy().into_owned()),
-                port: None,
-            }),
-            destination: Some(et_core::proto::SocketEndpoint {
-                name: Some("/tmp/destination.sock".to_owned()),
-                port: None,
-            }),
-            environmentvariable: Some("ET_RS_SSH_CONFIG_REMOTE_FORWARD".to_owned()),
-        }],
+        reversetunnels: vec![request(&occupied_path), request(&usable_path)],
+        environmentvariables: HashMap::new(),
+    };
+
+    let (stream, _) = server.handshake(ID_A);
+    let (mut client, initial) = runtime_support::initialize(stream, &key, payload);
+    let report = et_net::reverse_report::decode_skipped_rows(initial.error.as_deref().unwrap(), 2)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        report,
+        [et_net::reverse_report::SkippedRow {
+            index: 0,
+            reason: et_net::reverse_report::SkipReason::Bind,
+        }]
+    );
+    runtime_support::acknowledge_skip_report(&mut client);
+    let usable = std::os::unix::net::UnixStream::connect(&usable_path).unwrap();
+    drop(usable);
+    drop(client);
+    server.runtime.shutdown().unwrap();
+}
+
+#[test]
+fn unacknowledged_report_releases_sibling_before_activation() {
+    let mut server = TestRuntime::start();
+    let _terminal = server.register(ID_A, KEY_A);
+    let key = passkey_to_key(KEY_A).unwrap();
+    let occupied_path = server.dir.path().join("unacked-occupied.sock");
+    let sibling_path = server.dir.path().join("unacked-sibling.sock");
+    let _occupied = std::os::unix::net::UnixListener::bind(&occupied_path).unwrap();
+    let request = |path: &std::path::Path| et_core::proto::PortForwardSourceRequest {
+        source: Some(et_core::proto::SocketEndpoint {
+            name: Some(path.to_string_lossy().into_owned()),
+            port: None,
+        }),
+        destination: Some(et_core::proto::SocketEndpoint {
+            name: Some("/tmp/destination.sock".to_owned()),
+            port: None,
+        }),
+        environmentvariable: None,
+    };
+    let payload = InitialPayload {
+        jumphost: Some(false),
+        reversetunnels: vec![request(&occupied_path), request(&sibling_path)],
+        environmentvariables: HashMap::new(),
+    };
+
+    let (stream, _) = server.handshake(ID_A);
+    let (client, initial) = runtime_support::initialize(stream, &key, payload);
+    assert!(initial.error.is_some());
+    drop(client);
+
+    server
+        .handle
+        .wait_for_state(ID_A, SessionState::Registered, TIMEOUT)
+        .unwrap();
+    assert!(!sibling_path.exists());
+    server.runtime.shutdown().unwrap();
+}
+
+#[test]
+fn reverse_row_and_report_bounds_are_global_fatal() {
+    let cases = [
+        vec![Default::default(); et_net::reverse_report::MAX_REVERSE_ROWS + 1],
+        vec![
+            et_core::proto::PortForwardSourceRequest {
+                source: Some(et_core::proto::SocketEndpoint {
+                    name: Some("a".repeat(256)),
+                    port: Some(1),
+                }),
+                destination: Some(et_core::proto::SocketEndpoint {
+                    name: Some("127.0.0.1".to_owned()),
+                    port: Some(1),
+                }),
+                environmentvariable: None,
+            };
+            et_net::reverse_report::MAX_REVERSE_ROWS
+        ],
+    ];
+    for requests in cases {
+        let count = requests.len();
+        let mut server = TestRuntime::start();
+        let _terminal = server.register(ID_A, KEY_A);
+        let key = passkey_to_key(KEY_A).unwrap();
+        let payload = InitialPayload {
+            jumphost: Some(false),
+            reversetunnels: requests,
+            environmentvariables: HashMap::new(),
+        };
+
+        let (stream, _) = server.handshake(ID_A);
+        let (_, initial) = runtime_support::initialize(stream, &key, payload);
+
+        let error = initial.error.unwrap();
+        assert_eq!(
+            et_net::reverse_report::decode_skipped_rows(&error, count).unwrap(),
+            None
+        );
+        server.runtime.shutdown().unwrap();
+    }
+}
+
+#[test]
+fn reverse_listener_cap_is_prebind_transactional_on_server() {
+    let mut server = TestRuntime::start();
+    let _terminal = server.register(ID_A, KEY_A);
+    let key = passkey_to_key(KEY_A).unwrap();
+    let paths: Vec<_> = (0..33)
+        .map(|index| server.dir.path().join(format!("cap-{index}.sock")))
+        .collect();
+    let payload = InitialPayload {
+        jumphost: Some(false),
+        reversetunnels: paths
+            .iter()
+            .map(|path| et_core::proto::PortForwardSourceRequest {
+                source: Some(et_core::proto::SocketEndpoint {
+                    name: Some(path.to_string_lossy().into_owned()),
+                    port: None,
+                }),
+                destination: Some(et_core::proto::SocketEndpoint {
+                    name: Some("/tmp/destination.sock".to_owned()),
+                    port: None,
+                }),
+                environmentvariable: None,
+            })
+            .collect(),
         environmentvariables: HashMap::new(),
     };
 
     let (stream, _) = server.handshake(ID_A);
     let (_, initial) = runtime_support::initialize(stream, &key, payload);
 
-    assert!(initial.error.is_some());
+    assert!(initial
+        .error
+        .is_some_and(|error| error.contains("listener limit")));
+    assert!(paths.iter().all(|path| !path.exists()));
     server.runtime.shutdown().unwrap();
+}
+
+#[test]
+fn hostile_origin_marker_does_not_change_origin_independent_report() {
+    fn run(marker: Option<&str>) -> String {
+        let mut server = TestRuntime::start();
+        let _terminal = server.register(ID_A, KEY_A);
+        let key = passkey_to_key(KEY_A).unwrap();
+        let occupied_path = server.dir.path().join("hostile-origin.sock");
+        let usable_path = server.dir.path().join("hostile-usable.sock");
+        let _occupied = std::os::unix::net::UnixListener::bind(&occupied_path).unwrap();
+        let request = |path: &std::path::Path, environmentvariable: Option<String>| {
+            et_core::proto::PortForwardSourceRequest {
+                source: Some(et_core::proto::SocketEndpoint {
+                    name: Some(path.to_string_lossy().into_owned()),
+                    port: None,
+                }),
+                destination: Some(et_core::proto::SocketEndpoint {
+                    name: Some("/tmp/destination.sock".to_owned()),
+                    port: None,
+                }),
+                environmentvariable,
+            }
+        };
+        let payload = InitialPayload {
+            jumphost: Some(false),
+            reversetunnels: vec![
+                request(&occupied_path, marker.map(str::to_owned)),
+                request(&usable_path, None),
+            ],
+            environmentvariables: HashMap::new(),
+        };
+
+        let (stream, _) = server.handshake(ID_A);
+        let (mut client, initial) = runtime_support::initialize(stream, &key, payload);
+        let report = initial.error.unwrap();
+        runtime_support::acknowledge_skip_report(&mut client);
+        let usable = std::os::unix::net::UnixStream::connect(&usable_path).unwrap();
+        drop(usable);
+        drop(client);
+        server.runtime.shutdown().unwrap();
+        report
+    }
+
+    let ordinary = run(None);
+    let hostile = run(Some("ET_RS_SSH_CONFIG_REMOTE_FORWARD"));
+
+    assert_eq!(hostile, ordinary);
+    assert_eq!(
+        et_net::reverse_report::decode_skipped_rows(&hostile, 2)
+            .unwrap()
+            .unwrap(),
+        [et_net::reverse_report::SkippedRow {
+            index: 0,
+            reason: et_net::reverse_report::SkipReason::Bind,
+        }]
+    );
 }
 
 #[test]

--- a/crates/et-server/tests/runtime_recovery.rs
+++ b/crates/et-server/tests/runtime_recovery.rs
@@ -8,6 +8,7 @@ use std::thread;
 
 use et_core::keys::passkey_to_key;
 use et_core::proto::{ConnectResponse, ConnectStatus, TerminalPacketType};
+use et_net::connection::DEFAULT_LIVE_WRITE_TIMEOUT;
 use et_net::framing_io::{read_proto_limited, write_proto};
 use et_net::handshake::client_request;
 use et_net::local_packet::read_local_packet;
@@ -253,18 +254,28 @@ fn recover_succeeds_while_old_peer_blackholes_writes() {
     let _live = client.try_clone_stream().unwrap();
 
     let payload = vec![b'x'; 32 * 1024];
+    let mut timed_out_live_write = false;
     for round in 0..1_024u32 {
         let send_started = Instant::now();
         server
             .handle
             .send_packet(ID_A, 40, &payload)
             .unwrap_or_else(|error| panic!("flood round {round}: {error}"));
+        let elapsed = send_started.elapsed();
         assert!(
-            send_started.elapsed() < std::time::Duration::from_secs(8),
+            elapsed < std::time::Duration::from_secs(8),
             "send_packet round {round} blocked for {:?} — live write timeout not applied",
-            send_started.elapsed()
+            elapsed
         );
+        if elapsed >= DEFAULT_LIVE_WRITE_TIMEOUT / 2 {
+            timed_out_live_write = true;
+            break;
+        }
     }
+    assert!(
+        timed_out_live_write,
+        "socket flood never reached the bounded live-write timeout"
+    );
 
     let recover_started = Instant::now();
     let (returning, response) = server.handshake(ID_A);

--- a/crates/et-server/tests/runtime_support/mod.rs
+++ b/crates/et-server/tests/runtime_support/mod.rs
@@ -36,7 +36,8 @@ impl TestRuntime {
     pub fn start() -> Self {
         let dir = TestDir::new();
         let path = dir.socket();
-        let selected = select_router_path_for(1000, Some(&path), None, None).unwrap();
+        let uid = rustix::process::getuid().as_raw();
+        let selected = select_router_path_for(uid, Some(&path), None, None).unwrap();
         let runtime = Runtime::start(IpAddr::V4(Ipv4Addr::LOCALHOST), 0, selected).unwrap();
         let handle = runtime.handle();
         let address = runtime.tcp_addresses()[0];
@@ -50,11 +51,13 @@ impl TestRuntime {
 
     pub fn register(&self, id: &str, passkey: &str) -> UnixStream {
         let mut stream = UnixStream::connect(self.dir.socket()).unwrap();
+        let uid = i64::from(rustix::process::getuid().as_raw());
+        let gid = i64::from(rustix::process::getgid().as_raw());
         let user = TerminalUserInfo {
             id: Some(id.to_owned()),
             passkey: Some(passkey.to_owned()),
-            uid: Some(501),
-            gid: Some(20),
+            uid: Some(uid),
+            gid: Some(gid),
             fd: None,
         };
         let packet = Packet::new(

--- a/crates/et-server/tests/runtime_support/mod.rs
+++ b/crates/et-server/tests/runtime_support/mod.rs
@@ -91,6 +91,12 @@ pub fn default_payload() -> InitialPayload {
     }
 }
 
+pub fn acknowledge_skip_report(connection: &mut Connection) {
+    connection
+        .write_packet(et_core::proto::EtPacketType::Heartbeat as u8, &[])
+        .unwrap();
+}
+
 pub fn initialize(
     stream: TcpStream,
     key: &[u8; 32],


### PR DESCRIPTION
## Summary

- bind router registration identity to Unix peer credentials and run reverse TCP listeners under the authenticated session identity
- reject privileged/wildcard authority escalation and enforce a transactional per-session listener limit
- preserve OpenSSH suppression, destination, GatewayPorts, unsupported-record, bind-failure, and cumulative exact-dedup semantics
- proxy bounded reverse bind reports through native ET jumphosts without changing protocol-v6 bytes

Follow-up to https://github.com/minpeter/et.rs/pull/66.
Addresses upstream https://github.com/MisterTea/EternalTerminal/issues/90.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `cargo build -p et --target x86_64-pc-windows-gnu`
- root-server/non-root runtime security QA: 5/5 PASS
- real OpenSSH/two-sshd runtime QA: 45/45 PASS
- native-jumphost tunnel E2E: 13/13 PASS
- protocol-v6 fixture/proto/version unchanged
- same ultrabrain reviewer: unconditional APPROVE at `07c435f`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens SSH-configured forwarding so reverse tunnel binds run under the authenticated session identity and SSH-config rows cannot escalate authority.

- Router uid/gid now comes from Unix peer credentials rather than client-supplied values.
- Operational SSH commands force `ClearAllForwardings=yes`; `ssh -G` querying still imports supported forwarding rows.

**Forwarding security**
- Reverse listeners bind with the session identity and reject wildcard, privileged, or over-budget binds under a 32-listener per-session cap.
- Bind-failure reports are bounded and proxy through ET jumphosts without changing protocol-v6 bytes.

**SSH config handling**
- Imported rows are limited to loopback destinations; non-local and unsupported records warn and are skipped.
- A skipped SSH-config-only reverse row warns and the session continues; an unavailable explicit reverse row aborts the client and releases sibling listeners.
- Preserves GatewayPorts loopback/wildcard behavior and exact-dedup semantics.

<sup>Written for commit 07c435f27b86e4b22ecefb0cb2d5a931bb2908cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

