### PR TITLE
Complete SSH forwarding compatibility hardening

### DIFF
--- a/.tegami/fix-ssh-config-forwarding-postmerge-audit.md
+++ b/.tegami/fix-ssh-config-forwarding-postmerge-audit.md
@@ -1,0 +1,16 @@
+---
+packages:
+  et:
+    type: patch
+---
+
+## Complete SSH forwarding compatibility and authority hardening
+
+SSH-config forwarding now preserves explicit bind and destination addresses,
+honors `ExitOnForwardFailure`, and keeps setup failures transactional across
+direct and native-jumphost sessions.
+
+Reverse listeners remain bound to authenticated loopback authority, helper
+processes drop supplementary privileges portably, forwarding listener limits
+apply only to server-side reverse tunnels, and failed Unix listener setup no
+longer leaves filesystem residue.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ name = "et-net"
 version = "0.0.18"
 dependencies = [
  "et-core",
- "nix 0.31.3",
+ "privdrop",
  "prost",
  "rustix",
  "socket2",
@@ -659,6 +659,18 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases 0.2.2",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
@@ -819,6 +831,16 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "privdrop"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70722a5a3728c9603c8d9469b64b8d1ee54dae6d74e24146da7f501b4c76540f"
+dependencies = [
+ "libc",
+ "nix 0.30.1",
 ]
 
 [[package]]

--- a/crates/et-bin/src/forward_config.rs
+++ b/crates/et-bin/src/forward_config.rs
@@ -92,8 +92,10 @@ impl ForwardConfig {
         for request in &resolved.local_forwards {
             if !local_requests.contains(request) {
                 local_requests.push(request.clone());
-                self.local_sources
-                    .push(ForwardSource::ssh_config(request.clone()));
+                self.local_sources.push(ForwardSource::ssh_config(
+                    request.clone(),
+                    resolved.exit_on_forward_failure,
+                ));
             }
         }
 
@@ -116,7 +118,9 @@ impl ForwardConfig {
             if !remote_requests.contains(request) {
                 remote_requests.push(request.clone());
                 deduplicated.push(request.clone());
-                origins.push(et_net::forward::ForwardOrigin::SshConfig);
+                origins.push(et_net::forward::ForwardOrigin::SshConfig {
+                    strict: resolved.exit_on_forward_failure,
+                });
             }
         }
         self.initial_payload.reversetunnels = deduplicated;

--- a/crates/et-bin/src/forward_config_tests.rs
+++ b/crates/et-bin/src/forward_config_tests.rs
@@ -72,6 +72,7 @@ fn ssh_config_reverse_forwards_follow_cli_agent_forwarding() {
             }),
             environmentvariable: None,
         }],
+        exit_on_forward_failure: false,
     };
 
     // When
@@ -149,6 +150,7 @@ fn ssh_config_forwards_are_cumulative_stable_and_exactly_deduplicated() {
                 environmentvariable: None,
             },
         ],
+        exit_on_forward_failure: true,
     };
 
     // When
@@ -176,14 +178,14 @@ fn ssh_config_forwards_are_cumulative_stable_and_exactly_deduplicated() {
     );
     assert_eq!(
         config.local_sources[2].origin,
-        et_net::forward::ForwardOrigin::SshConfig
+        et_net::forward::ForwardOrigin::SshConfig { strict: true }
     );
     assert_eq!(config.initial_payload.reversetunnels.len(), 2);
     assert_eq!(
         config.remote_origins,
         [
             et_net::forward::ForwardOrigin::Explicit,
-            et_net::forward::ForwardOrigin::SshConfig,
+            et_net::forward::ForwardOrigin::SshConfig { strict: true },
         ]
     );
     assert_eq!(

--- a/crates/et-bin/src/initial_connect.rs
+++ b/crates/et-bin/src/initial_connect.rs
@@ -73,7 +73,7 @@ pub fn connect_initial(
     ensure_deadline(deadline, "sending INITIAL_PAYLOAD")?;
     let mut connection = Connection::new_client(stream, &key);
     connection
-        .write_packet(
+        .write_packet_strict(
             EtPacketType::InitialPayload as u8,
             &initial_payload.encode_to_vec(),
         )
@@ -89,7 +89,7 @@ pub fn connect_initial(
         InitialResponse::decode(packet.payload()).map_err(ClientError::MalformedInitialResponse)?;
     if accept_initial_response(response, remote_origins)? {
         connection
-            .write_packet(EtPacketType::Heartbeat as u8, &[])
+            .write_packet_strict(EtPacketType::Heartbeat as u8, &[])
             .map_err(|error| {
                 transport_error(deadline, "acknowledging reverse forwarding skips", error)
             })?;

--- a/crates/et-bin/src/initial_connect.rs
+++ b/crates/et-bin/src/initial_connect.rs
@@ -190,10 +190,12 @@ fn accept_initial_response(
     };
     for row in &rows {
         match remote_origins[row.index] {
-            ForwardOrigin::SshConfig => {}
-            ForwardOrigin::Explicit | ForwardOrigin::Reported(_) => {
+            ForwardOrigin::SshConfig { strict: false } => {}
+            ForwardOrigin::Explicit
+            | ForwardOrigin::SshConfig { strict: true }
+            | ForwardOrigin::Reported(_) => {
                 return Err(ClientError::InitialResponseRejected(
-                    "explicit reverse forwarding row could not bind".to_owned(),
+                    "required reverse forwarding row could not bind".to_owned(),
                 ));
             }
         }

--- a/crates/et-bin/src/initial_connect_tests.rs
+++ b/crates/et-bin/src/initial_connect_tests.rs
@@ -29,10 +29,14 @@ fn config_only_skip_report_continues_but_explicit_report_is_fatal() {
         InitialResponse {
             error: Some(report.clone()),
         },
-        &[ForwardOrigin::SshConfig],
+        &[ForwardOrigin::SshConfig { strict: false }],
     )
     .is_ok());
-    for origin in [ForwardOrigin::Explicit, ForwardOrigin::Reported(0)] {
+    for origin in [
+        ForwardOrigin::Explicit,
+        ForwardOrigin::SshConfig { strict: true },
+        ForwardOrigin::Reported(0),
+    ] {
         assert!(matches!(
             accept_initial_response(
                 InitialResponse {
@@ -41,7 +45,7 @@ fn config_only_skip_report_continues_but_explicit_report_is_fatal() {
                 &[origin],
             ),
             Err(ClientError::InitialResponseRejected(message))
-                if message == "explicit reverse forwarding row could not bind"
+                if message == "required reverse forwarding row could not bind"
         ));
     }
 }
@@ -53,7 +57,7 @@ fn old_server_error_and_malformed_reserved_report_fail_closed() {
             InitialResponse {
                 error: Some("port forwarding I/O: address in use".to_owned()),
             },
-            &[ForwardOrigin::SshConfig],
+            &[ForwardOrigin::SshConfig { strict: false }],
         ),
         Err(ClientError::InitialResponseRejected(_))
     ));
@@ -62,7 +66,7 @@ fn old_server_error_and_malformed_reserved_report_fail_closed() {
             InitialResponse {
                 error: Some("ETRS-RF-SKIP/2;0:B".to_owned()),
             },
-            &[ForwardOrigin::SshConfig],
+            &[ForwardOrigin::SshConfig { strict: false }],
         ),
         Err(ClientError::InitialResponseRejected(message))
             if message == "malformed reverse forwarding skip report"

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -97,6 +97,13 @@ fn parse_ssh_config(
     let mut user = None;
     let mut local_forwards = Vec::new();
     let mut remote_forwards = Vec::new();
+    if parse_local_forwards {
+        for _ in unsupported_dynamic_forwards(text) {
+            et_cli::logging::warn(
+                "SSH dynamicforward is unsupported by ET protocol v6; skipping forwarding row",
+            );
+        }
+    }
     for line in text.lines() {
         let mut fields = line.split_whitespace();
         match fields.next() {
@@ -106,11 +113,7 @@ fn parse_ssh_config(
             Some(key) if key.eq_ignore_ascii_case("user") => {
                 user = fields.next().map(str::to_string);
             }
-            Some(key) if parse_local_forwards && key.eq_ignore_ascii_case("dynamicforward") => {
-                et_cli::logging::warn(
-                    "SSH dynamicforward is unsupported by ET protocol v6; skipping forwarding row",
-                );
-            }
+            Some(key) if parse_local_forwards && key.eq_ignore_ascii_case("dynamicforward") => {}
             Some(key) if parse_local_forwards && key.eq_ignore_ascii_case("localforward") => {
                 match parse_forward(fields, "localforward", policies)? {
                     ForwardRecord::Supported(forward) => local_forwards.push(forward),
@@ -139,6 +142,37 @@ fn parse_ssh_config(
         local_forwards,
         remote_forwards,
     })
+}
+
+fn unsupported_dynamic_forwards(text: &str) -> Vec<&str> {
+    let mut dynamic: Vec<&str> = text
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            fields
+                .next()
+                .is_some_and(|key| key.eq_ignore_ascii_case("dynamicforward"))
+                .then(|| fields.next())
+                .flatten()
+        })
+        .collect();
+    for line in text.lines() {
+        let mut fields = line.split_whitespace();
+        let is_local = fields
+            .next()
+            .is_some_and(|key| key.eq_ignore_ascii_case("localforward"));
+        let source = fields.next();
+        let destination = fields.next();
+        if is_local && destination.is_some_and(|value| value.starts_with('/')) {
+            if let Some(index) = dynamic
+                .iter()
+                .position(|candidate| Some(*candidate) == source)
+            {
+                dynamic.remove(index);
+            }
+        }
+    }
+    dynamic
 }
 
 fn warn_unsupported(directive: &str, reason: &str) {
@@ -634,6 +668,23 @@ mod tests {
                 [omitted, "localhost", "127.0.0.2", ""]
             );
         }
+    }
+
+    #[test]
+    fn dynamic_forward_classifier_consumes_unix_destination_pseudo_rows_as_a_multiset() {
+        // Given
+        let config = "hostname host\n\
+            dynamicforward 15002\n\
+            localforward 15002 /tmp/tcp-destination.sock\n\
+            dynamicforward /tmp/unix-source.sock\n\
+            localforward /tmp/unix-source.sock /tmp/unix-destination.sock\n\
+            dynamicforward 1080\n";
+
+        // When
+        let unsupported = unsupported_dynamic_forwards(config);
+
+        // Then
+        assert_eq!(unsupported, ["1080"]);
     }
 
     #[test]

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -671,26 +671,22 @@ mod tests {
 
     #[test]
     fn local_forward_listener_exposure_matches_explicit_bind_precedence() {
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream, UdpSocket};
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream};
 
-        let route = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).unwrap();
-        route.connect((Ipv4Addr::new(192, 0, 2, 1), 9)).unwrap();
-        let external_ip = route.local_addr().unwrap().ip();
-        assert!(!external_ip.is_loopback() && !external_ip.is_unspecified());
-
+        let loopback_alias = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
         for (gateway_ports, source, reachable, unreachable) in [
-            ("yes", "", external_ip, None),
+            ("yes", "", loopback_alias, None),
             (
                 "yes",
                 "localhost:",
                 IpAddr::V4(Ipv4Addr::LOCALHOST),
-                Some(external_ip),
+                Some(loopback_alias),
             ),
-            ("no", "*:", external_ip, None),
+            ("no", "*:", loopback_alias, None),
             (
                 "no",
                 "127.0.0.2:",
-                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+                loopback_alias,
                 Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
             ),
         ] {

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -1,5 +1,3 @@
-use std::net::{Ipv4Addr, Ipv6Addr};
-
 use crate::bootstrap::{validate_ssh_destination, InvocationCompletion, SshInvocation};
 use crate::deadline::Deadline;
 use crate::error::ClientError;
@@ -216,13 +214,6 @@ fn parse_forward<'a>(
             directive,
             reason: "invalid destination endpoint",
         })?;
-    if let (Some(host), Some(_)) = (destination.name.as_deref(), destination.port) {
-        if !is_representable_tcp_destination(host) {
-            return Ok(ForwardRecord::Unsupported(format!(
-                "destination host '{host}' is unsupported by ET protocol v6"
-            )));
-        }
-    }
     Ok(ForwardRecord::Supported(PortForwardSourceRequest {
         source: Some(source),
         destination: Some(destination),
@@ -239,16 +230,6 @@ fn endpoint_has_zero_port(value: &str) -> bool {
 
 fn is_relative_stream_path(value: &str) -> bool {
     !value.starts_with('/') && value.contains('/')
-}
-
-fn is_representable_tcp_destination(host: &str) -> bool {
-    host.eq_ignore_ascii_case("localhost")
-        || host
-            .parse::<Ipv4Addr>()
-            .is_ok_and(|address| address == Ipv4Addr::LOCALHOST)
-        || host
-            .parse::<Ipv6Addr>()
-            .is_ok_and(|address| address == Ipv6Addr::LOCALHOST)
 }
 
 impl GatewayPorts {
@@ -577,7 +558,7 @@ mod tests {
 
     #[test]
     fn local_forward_listener_exposure_matches_explicit_bind_precedence() {
-        use std::net::{IpAddr, SocketAddr, TcpListener, TcpStream, UdpSocket};
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream, UdpSocket};
 
         let route = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).unwrap();
         route.connect((Ipv4Addr::new(192, 0, 2, 1), 9)).unwrap();
@@ -687,7 +668,7 @@ mod tests {
     }
 
     #[test]
-    fn ssh_config_hardening_nonlocal_tcp_destinations_are_skipped_per_row() {
+    fn ssh_config_preserves_explicit_tcp_destination_names() {
         let resolved = parse_ssh_config(
             b"hostname host\n\
               localforward 15432 db.internal:5432\n\
@@ -702,11 +683,18 @@ mod tests {
 
         assert_eq!(
             resolved.local_forwards,
-            [request("localhost", Some(15434), "LocalHost", Some(5432))]
+            [
+                request("localhost", Some(15432), "db.internal", Some(5432)),
+                request("localhost", Some(15433), "127.0.0.2", Some(5432)),
+                request("localhost", Some(15434), "LocalHost", Some(5432)),
+            ]
         );
         assert_eq!(
             resolved.remote_forwards,
-            [request("localhost", Some(25433), "::1", Some(5432))]
+            [
+                request("localhost", Some(25432), "db.internal", Some(5432)),
+                request("localhost", Some(25433), "::1", Some(5432)),
+            ]
         );
     }
 

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -670,9 +670,37 @@ mod tests {
     }
 
     #[test]
+    fn local_forward_normalized_bind_shapes_preserve_explicit_precedence() {
+        for (gateway_ports, source, expected_name, expected_port) in [
+            ("yes", "15430", "", 15430),
+            ("yes", "localhost:15431", "localhost", 15431),
+            ("no", "*:15432", "", 15432),
+            ("no", "127.0.0.2:15433", "127.0.0.2", 15433),
+        ] {
+            // Given
+            let config = format!(
+                "hostname host\ngatewayports {gateway_ports}\n\
+                 localforward {source} localhost:9\n"
+            );
+
+            // When
+            let resolved = parse_ssh_config(config.as_bytes(), true, false).unwrap();
+
+            // Then
+            let source = resolved.local_forwards[0].source.as_ref().unwrap();
+            assert_eq!(source.name.as_deref(), Some(expected_name));
+            assert_eq!(source.port, Some(expected_port));
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
     fn local_forward_listener_exposure_matches_explicit_bind_precedence() {
         use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream};
 
+        // GitHub macOS runners do not configure a second loopback alias. C001's
+        // real OpenSSH/runtime evidence proves external-interface exposure;
+        // this in-process reachability matrix is deterministic on Linux only.
         let loopback_alias = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
         for (gateway_ports, source, reachable, unreachable) in [
             ("yes", "", loopback_alias, None),

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -29,6 +29,7 @@ pub struct ResolvedSshConfig {
     pub user: Option<String>,
     pub local_forwards: Vec<PortForwardSourceRequest>,
     pub remote_forwards: Vec<PortForwardSourceRequest>,
+    pub exit_on_forward_failure: bool,
 }
 
 enum ForwardRecord {
@@ -76,6 +77,23 @@ fn parse_ssh_config(
 ) -> Result<ResolvedSshConfig, ClientError> {
     let text =
         std::str::from_utf8(stdout).map_err(|_| ClientError::SshConfigMalformed("UTF-8 output"))?;
+    let exit_on_forward_failure = text
+        .lines()
+        .find_map(|line| {
+            let mut fields = line.split_whitespace();
+            fields
+                .next()
+                .is_some_and(|key| key.eq_ignore_ascii_case("exitonforwardfailure"))
+                .then(|| fields.next())
+                .flatten()
+        })
+        .map(|value| match value {
+            "yes" => Ok(true),
+            "no" => Ok(false),
+            _ => Err(ClientError::SshConfigMalformed("exitonforwardfailure")),
+        })
+        .transpose()?
+        .unwrap_or(false);
     let gateway_ports = text
         .lines()
         .find_map(|line| {
@@ -99,6 +117,11 @@ fn parse_ssh_config(
     let mut remote_forwards = Vec::new();
     if parse_local_forwards {
         for _ in unsupported_dynamic_forwards(text) {
+            if exit_on_forward_failure {
+                return Err(ClientError::Unsupported(
+                    "SSH forwarding request is unsupported while ExitOnForwardFailure is enabled",
+                ));
+            }
             et_cli::logging::warn(
                 "SSH dynamicforward is unsupported by ET protocol v6; skipping forwarding row",
             );
@@ -117,14 +140,26 @@ fn parse_ssh_config(
             Some(key) if parse_local_forwards && key.eq_ignore_ascii_case("localforward") => {
                 match parse_forward(fields, "localforward", policies)? {
                     ForwardRecord::Supported(forward) => local_forwards.push(forward),
-                    ForwardRecord::Unsupported(reason) => warn_unsupported("localforward", &reason),
+                    ForwardRecord::Unsupported(reason) => {
+                        if exit_on_forward_failure {
+                            return Err(ClientError::Unsupported(
+                                "SSH forwarding request is unsupported while ExitOnForwardFailure is enabled",
+                            ));
+                        }
+                        warn_unsupported("localforward", &reason);
+                    }
                 }
             }
             Some(key) if parse_remote_forwards && key.eq_ignore_ascii_case("remoteforward") => {
                 match parse_forward(fields, "remoteforward", policies)? {
                     ForwardRecord::Supported(forward) => remote_forwards.push(forward),
                     ForwardRecord::Unsupported(reason) => {
-                        warn_unsupported("remoteforward", &reason)
+                        if exit_on_forward_failure {
+                            return Err(ClientError::Unsupported(
+                                "SSH forwarding request is unsupported while ExitOnForwardFailure is enabled",
+                            ));
+                        }
+                        warn_unsupported("remoteforward", &reason);
                     }
                 }
             }
@@ -141,6 +176,7 @@ fn parse_ssh_config(
         user,
         local_forwards,
         remote_forwards,
+        exit_on_forward_failure,
     })
 }
 
@@ -439,8 +475,51 @@ mod tests {
                 user: Some("config-user".to_string()),
                 local_forwards: Vec::new(),
                 remote_forwards: Vec::new(),
+                exit_on_forward_failure: false,
             }
         );
+    }
+
+    #[test]
+    fn parses_effective_exit_on_forward_failure_policy() {
+        // Given / When
+        let nonfatal =
+            parse_ssh_config(b"hostname host\nexitonforwardfailure no\n", true, true).unwrap();
+        let strict =
+            parse_ssh_config(b"hostname host\nexitonforwardfailure yes\n", true, true).unwrap();
+
+        // Then
+        assert!(!nonfatal.exit_on_forward_failure);
+        assert!(strict.exit_on_forward_failure);
+    }
+
+    #[test]
+    fn strict_exit_policy_ignores_unix_destination_pseudo_dynamic_row() {
+        // Given / When
+        let resolved = parse_ssh_config(
+            b"hostname host\nexitonforwardfailure yes\n\
+              dynamicforward 15002\nlocalforward 15002 /tmp/destination.sock\n",
+            true,
+            true,
+        )
+        .unwrap();
+
+        // Then
+        assert_eq!(resolved.local_forwards.len(), 1);
+        assert!(resolved.exit_on_forward_failure);
+    }
+
+    #[test]
+    fn strict_exit_policy_rejects_unsupported_requested_rows() {
+        // Given / When
+        let result = parse_ssh_config(
+            b"hostname host\nexitonforwardfailure yes\ndynamicforward 1080\n",
+            true,
+            true,
+        );
+
+        // Then
+        assert!(matches!(result, Err(ClientError::Unsupported(_))));
     }
 
     #[test]

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -320,15 +320,14 @@ fn normalize_tcp_source(
         (false, _, None) => "localhost".to_owned(),
         (false, _, Some(requested)) if requested == "*" || requested == "[*]" => String::new(),
         (false, _, Some(requested)) => requested,
-        (true, GatewayPorts::No, _) => "localhost".to_owned(),
-        (true, GatewayPorts::Yes, _) => String::new(),
-        (true, GatewayPorts::ClientSpecified, None) => "localhost".to_owned(),
-        (true, GatewayPorts::ClientSpecified, Some(requested))
+        (true, GatewayPorts::No | GatewayPorts::ClientSpecified, None) => "localhost".to_owned(),
+        (true, GatewayPorts::Yes, None) => String::new(),
+        (true, _, Some(requested))
             if requested.is_empty() || requested == "*" || requested == "[*]" =>
         {
             String::new()
         }
-        (true, GatewayPorts::ClientSpecified, Some(requested)) => requested,
+        (true, _, Some(requested)) => requested,
     };
     endpoint.name = Some(normalized);
     endpoint
@@ -460,10 +459,10 @@ mod tests {
             resolved.local_forwards,
             [
                 request("localhost", Some(10022), "127.0.0.1", Some(22)),
-                request("localhost", Some(18080), "::1", Some(80)),
+                request("::1", Some(18080), "::1", Some(80)),
                 request("/tmp/local.sock", None, "/tmp/remote.sock", None),
                 request("/tmp/mixed.sock", None, "127.0.0.1", Some(8080)),
-                request("localhost", Some(9090), "/tmp/destination.sock", None,),
+                request("127.0.0.1", Some(9090), "/tmp/destination.sock", None,),
             ]
         );
         assert_eq!(
@@ -523,7 +522,7 @@ mod tests {
                 .iter()
                 .map(|request| request.source.as_ref().unwrap().name.as_deref().unwrap())
                 .collect::<Vec<_>>(),
-            ["localhost", "localhost", "localhost"]
+            ["", "", "127.0.0.2"]
         );
         assert_eq!(
             no.remote_forwards
@@ -539,7 +538,7 @@ mod tests {
                 .iter()
                 .map(|request| request.source.as_ref().unwrap().name.as_deref().unwrap())
                 .collect::<Vec<_>>(),
-            ["", "", ""]
+            ["", "", "127.0.0.2"]
         );
         assert_eq!(
             yes.remote_forwards
@@ -572,6 +571,86 @@ mod tests {
             assert!(
                 String::from_utf8_lossy(&clientspecified.stderr).contains("unsupported option")
                     && String::from_utf8_lossy(&clientspecified.stderr).contains("clientspecified")
+            );
+        }
+    }
+
+    #[test]
+    fn local_forward_listener_exposure_matches_explicit_bind_precedence() {
+        use std::net::{IpAddr, SocketAddr, TcpListener, TcpStream, UdpSocket};
+
+        let route = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).unwrap();
+        route.connect((Ipv4Addr::new(192, 0, 2, 1), 9)).unwrap();
+        let external_ip = route.local_addr().unwrap().ip();
+        assert!(!external_ip.is_loopback() && !external_ip.is_unspecified());
+
+        for (gateway_ports, source, reachable, unreachable) in [
+            ("yes", "", external_ip, None),
+            (
+                "yes",
+                "localhost:",
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                Some(external_ip),
+            ),
+            ("no", "*:", external_ip, None),
+            (
+                "no",
+                "127.0.0.2:",
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+                Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            ),
+        ] {
+            // Given
+            let reservation = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+            let port = reservation.local_addr().unwrap().port();
+            drop(reservation);
+            let config = format!(
+                "hostname host\ngatewayports {gateway_ports}\n\
+                 localforward {source}{port} localhost:9\n"
+            );
+            let resolved = parse_ssh_config(config.as_bytes(), true, false).unwrap();
+
+            // When
+            let forwarder =
+                et_net::forward::Forwarder::start(resolved.local_forwards.clone()).unwrap();
+
+            // Then
+            TcpStream::connect_timeout(&SocketAddr::new(reachable, port), Duration::from_secs(1))
+                .unwrap();
+            if let Some(unreachable) = unreachable {
+                assert!(TcpStream::connect_timeout(
+                    &SocketAddr::new(unreachable, port),
+                    Duration::from_millis(100),
+                )
+                .is_err());
+            }
+            forwarder.shutdown().unwrap();
+        }
+    }
+
+    #[test]
+    fn local_forward_preserves_explicit_bind_and_applies_gateway_ports_to_omitted_bind() {
+        for (gateway_ports, omitted) in [("no", "localhost"), ("yes", "")] {
+            // Given
+            let config = format!(
+                "hostname host\ngatewayports {gateway_ports}\n\
+                 localforward 15430 localhost:5432\n\
+                 localforward localhost:15431 localhost:5432\n\
+                 localforward 127.0.0.2:15432 localhost:5432\n\
+                 localforward *:15433 localhost:5432\n"
+            );
+
+            // When
+            let resolved = parse_ssh_config(config.as_bytes(), true, false).unwrap();
+
+            // Then
+            assert_eq!(
+                resolved
+                    .local_forwards
+                    .iter()
+                    .map(|request| request.source.as_ref().unwrap().name.as_deref().unwrap())
+                    .collect::<Vec<_>>(),
+                [omitted, "localhost", "127.0.0.2", ""]
             );
         }
     }

--- a/crates/et-bin/src/terminal.rs
+++ b/crates/et-bin/src/terminal.rs
@@ -186,10 +186,10 @@ fn register(router: &mut LocalStream, input: &CredentialInput) -> Result<(), Str
     // Upstream uses these to chown forwarded named pipes; Windows has no
     // POSIX ids, so the session reports zero there.
     #[cfg(unix)]
-    let (uid, gid) = (
-        i64::from(rustix::process::getuid().as_raw()),
-        i64::from(rustix::process::getgid().as_raw()),
-    );
+    let (uid, gid) = {
+        let (uid, gid) = effective_terminal_identity();
+        (i64::from(uid), i64::from(gid))
+    };
     #[cfg(windows)]
     let (uid, gid) = (0i64, 0i64);
     let user = TerminalUserInfo {
@@ -205,6 +205,35 @@ fn register(router: &mut LocalStream, input: &CredentialInput) -> Result<(), Str
     );
     write_local_packet(router, &packet)
         .map_err(|error| format!("could not register terminal: {error}"))
+}
+
+#[cfg(unix)]
+fn effective_terminal_identity() -> (u32, u32) {
+    (
+        rustix::process::geteuid().as_raw(),
+        rustix::process::getegid().as_raw(),
+    )
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_registration_identity_matches_effective_peer_credentials() {
+        // Given: this host cannot create differing real/effective IDs without
+        // privilege, so assert the exact credential API used by registration.
+        let expected = (
+            rustix::process::geteuid().as_raw(),
+            rustix::process::getegid().as_raw(),
+        );
+
+        // When
+        let identity = effective_terminal_identity();
+
+        // Then
+        assert_eq!(identity, expected);
+    }
 }
 
 fn clap_error(message: impl Into<String>) -> clap::Error {

--- a/crates/et-bin/src/terminal_jump.rs
+++ b/crates/et-bin/src/terminal_jump.rs
@@ -64,7 +64,7 @@ pub fn run(
         }
         destination
             .connection
-            .write_packet(EtPacketType::Heartbeat as u8, &[])
+            .write_packet_strict(EtPacketType::Heartbeat as u8, &[])
             .map_err(|error| format!("could not acknowledge destination response: {error}"))?;
     }
     destination
@@ -165,7 +165,7 @@ fn try_connect_once(
     }
     let mut connection = Connection::new_client(stream, key);
     connection
-        .write_packet(EtPacketType::InitialPayload as u8, &payload.encode_to_vec())
+        .write_packet_strict(EtPacketType::InitialPayload as u8, &payload.encode_to_vec())
         .map_err(|error| format!("could not send INITIAL_PAYLOAD: {error}"))?;
     let packet = connection
         .read_packet()

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -232,7 +232,7 @@ fn ssh_config_forwards_apply_on_the_unspecified_axis() {
 }
 
 #[test]
-fn ssh_config_hardening_nonlocal_destinations_warn_and_other_rows_continue() {
+fn ssh_config_preserves_explicit_destinations_and_warns_only_policy_denied_rows() {
     let (port, server) = initial_payload_server_with_error(Some("stop after payload"));
     let fake = FakeSsh::new();
     let config = concat!(
@@ -262,21 +262,40 @@ fn ssh_config_hardening_nonlocal_destinations_warn_and_other_rows_continue() {
     let payload = server.join().unwrap();
 
     assert_ne!(output.status.code(), Some(2), "{}", stderr(&output));
-    assert_eq!(payload.reversetunnels.len(), 1);
+    assert_eq!(payload.reversetunnels.len(), 2);
+    let endpoints: Vec<_> = payload
+        .reversetunnels
+        .iter()
+        .map(|request| {
+            let source = request.source.as_ref().unwrap();
+            let destination = request.destination.as_ref().unwrap();
+            (
+                source.name.as_deref(),
+                source.port,
+                destination.name.as_deref(),
+                destination.port,
+            )
+        })
+        .collect();
     assert_eq!(
-        payload.reversetunnels[0]
-            .source
-            .as_ref()
-            .and_then(|source| source.port),
-        Some(25433)
+        endpoints,
+        [
+            (
+                Some("localhost"),
+                Some(25432),
+                Some("db.internal"),
+                Some(5432)
+            ),
+            (Some("localhost"), Some(25433), Some("::1"), Some(5432)),
+        ]
     );
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout)
-            .lines()
-            .filter(|line| line.contains("WARNING"))
-            .count(),
-        4
-    );
+    let warnings: Vec<_> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|line| line.contains("WARNING"))
+        .map(str::to_owned)
+        .collect();
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].contains("wildcard bind is prohibited"));
 }
 
 #[test]

--- a/crates/et-bin/tests/tunnels_end_to_end.rs
+++ b/crates/et-bin/tests/tunnels_end_to_end.rs
@@ -252,6 +252,65 @@ fn native_jumphost_relays_imported_remote_skip_report_and_acknowledgement() {
 }
 
 #[test]
+fn native_jumphost_strict_imported_remote_skip_withholds_ack_and_releases_sibling() {
+    // Given
+    let mut destination = Stack::start();
+    let mut jump = Stack::start();
+    let occupied = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let occupied_port = occupied.local_addr().unwrap().port();
+    let sibling_port = reserve_port();
+    let config = format!(
+        "hostname 127.0.0.1\nuser tester\nexitonforwardfailure yes\n\
+         remoteforward {occupied_port} [127.0.0.1]:1\n\
+         remoteforward {sibling_port} [127.0.0.1]:1\n"
+    );
+    let mut client = Command::new(env!("CARGO_BIN_EXE_et"))
+        .env("PATH", &destination.directory)
+        .env("ET_SSH_COUNT", &destination.ssh_count)
+        .env("ET_SSH_CONFIG", config)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .args(["--terminal-path"])
+        .arg(&destination.terminal)
+        .args(["--serverfifo"])
+        .arg(&destination.router)
+        .args(["--jumphost", "jump.example", "--jport"])
+        .arg(jump.port.to_string())
+        .args(["--jserverfifo"])
+        .arg(&jump.router)
+        .arg("-N")
+        .arg(format!("tester@127.0.0.1:{}", destination.port))
+        .spawn()
+        .unwrap();
+
+    // When
+    let status = client
+        .wait_timeout(TIMEOUT)
+        .unwrap()
+        .expect("strict imported native-jumphost skip did not terminate the client");
+    let mut error = String::new();
+    client
+        .stderr
+        .take()
+        .unwrap()
+        .read_to_string(&mut error)
+        .unwrap();
+
+    // Then
+    assert!(!status.success());
+    assert!(
+        error.contains("required reverse forwarding row could not bind"),
+        "{error}"
+    );
+    jump.shutdown();
+    destination.shutdown();
+    let rebound = TcpListener::bind((Ipv4Addr::LOCALHOST, sibling_port)).unwrap();
+    drop(rebound);
+    drop(occupied);
+}
+
+#[test]
 fn native_jumphost_explicit_remote_skip_aborts_and_releases_final_sibling() {
     let mut destination = Stack::start();
     let mut jump = Stack::start();
@@ -294,7 +353,7 @@ fn native_jumphost_explicit_remote_skip_aborts_and_releases_final_sibling() {
 
     assert!(!status.success());
     assert!(
-        error.contains("explicit reverse forwarding row could not bind"),
+        error.contains("required reverse forwarding row could not bind"),
         "{error}"
     );
     jump.shutdown();
@@ -342,7 +401,7 @@ fn explicit_remote_bind_report_aborts_and_releases_sibling_listener() {
 
     assert!(!status.success());
     assert!(
-        error.contains("explicit reverse forwarding row could not bind"),
+        error.contains("required reverse forwarding row could not bind"),
         "{error}"
     );
     stack.shutdown();

--- a/crates/et-net/Cargo.toml
+++ b/crates/et-net/Cargo.toml
@@ -18,7 +18,7 @@ rustix = { version = "1.1.4", features = ["event"] }
 socket2 = "0.6.1"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.31.3", default-features = false, features = ["user"] }
+privdrop = "0.5.6"
 rustix = { version = "1.1.4", features = ["event", "fs", "net", "process"] }
 
 [[bin]]

--- a/crates/et-net/src/connection.rs
+++ b/crates/et-net/src/connection.rs
@@ -80,6 +80,20 @@ impl Connection {
         }
     }
 
+    /// Write a handshake packet and require it to reach a live transport.
+    ///
+    /// Active-session writes intentionally soft-disconnect and buffer for
+    /// recovery. Handshake acknowledgements and responses have no established
+    /// session to recover, so buffering them must fail the initialization.
+    pub fn write_packet_strict(&mut self, header: u8, payload: &[u8]) -> Result<(), ConnError> {
+        self.write_packet(header, payload)?;
+        if self.connected() {
+            Ok(())
+        } else {
+            Err(ConnError::Io(io::ErrorKind::NotConnected.into()))
+        }
+    }
+
     /// Write a framed packet to a still-connected peer with a bounded timeout.
     ///
     /// Uses a write loop (not bare `write_all`) so each `write` is capped by

--- a/crates/et-net/src/forward.rs
+++ b/crates/et-net/src/forward.rs
@@ -52,7 +52,7 @@ pub(crate) type Outbound = Result<Packet, ForwardError>;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ForwardOrigin {
     Explicit,
-    SshConfig,
+    SshConfig { strict: bool },
     Reported(usize),
 }
 
@@ -69,10 +69,10 @@ impl ForwardSource {
         }
     }
 
-    pub const fn ssh_config(request: PortForwardSourceRequest) -> Self {
+    pub const fn ssh_config(request: PortForwardSourceRequest, strict: bool) -> Self {
         Self {
             request,
-            origin: ForwardOrigin::SshConfig,
+            origin: ForwardOrigin::SshConfig { strict },
         }
     }
 }
@@ -322,7 +322,7 @@ fn bind_sources(
             let resolved = endpoint.resolve_for_bind();
             let source = match (resolved, origin) {
                 (Ok(source), _) => source,
-                (Err(error), ForwardOrigin::SshConfig) => {
+                (Err(error), ForwardOrigin::SshConfig { strict: false }) => {
                     skipped.push(SkippedForward {
                         request: original,
                         error,
@@ -340,7 +340,10 @@ fn bind_sources(
                     });
                     continue;
                 }
-                (Err(error), ForwardOrigin::Explicit) => return Err(ForwardError::Io(error)),
+                (
+                    Err(error),
+                    ForwardOrigin::Explicit | ForwardOrigin::SshConfig { strict: true },
+                ) => return Err(ForwardError::Io(error)),
             };
             if owner.is_some() {
                 match &source {
@@ -396,7 +399,7 @@ fn bind_sources(
                         });
                     }
                 }
-                (Err(error), ForwardOrigin::SshConfig) => {
+                (Err(error), ForwardOrigin::SshConfig { strict: false }) => {
                     skipped.push(SkippedForward {
                         request: original,
                         error,
@@ -412,7 +415,10 @@ fn bind_sources(
                         report_index: Some(index),
                     });
                 }
-                (Err(error), ForwardOrigin::Explicit) => return Err(ForwardError::Io(error)),
+                (
+                    Err(error),
+                    ForwardOrigin::Explicit | ForwardOrigin::SshConfig { strict: true },
+                ) => return Err(ForwardError::Io(error)),
             },
             #[cfg(unix)]
             PlannedSource::Environment {

--- a/crates/et-net/src/forward.rs
+++ b/crates/et-net/src/forward.rs
@@ -345,13 +345,11 @@ fn bind_sources(
             if owner.is_some() {
                 match &source {
                     ResolvedEndpoint::Tcp(addresses)
-                        if addresses
-                            .iter()
-                            .any(|address| address.ip().is_unspecified()) =>
+                        if addresses.iter().any(|address| !address.ip().is_loopback()) =>
                     {
                         return Err(ForwardError::Io(io::Error::new(
                             io::ErrorKind::PermissionDenied,
-                            "authenticated reverse TCP wildcard bind is not permitted",
+                            "authenticated reverse TCP bind must resolve only to loopback addresses",
                         )));
                     }
                     ResolvedEndpoint::Tcp(_) => {}

--- a/crates/et-net/src/forward.rs
+++ b/crates/et-net/src/forward.rs
@@ -425,14 +425,13 @@ fn bind_sources(
                 variable,
                 destination,
             } => {
-                let path = create_forward_pipe(owner)?;
-                let source = Endpoint::Unix(path.clone()).resolve_for_bind()?;
+                let mut pipe = create_forward_pipe(owner)?;
+                let source = Endpoint::Unix(pipe.path.clone()).resolve_for_bind()?;
                 let mut listeners = source.bind_with_user(owner)?;
-                environment.push((variable, path.to_string_lossy().into_owned()));
+                environment.push((variable, pipe.path.to_string_lossy().into_owned()));
+                let directory = pipe.disarm()?;
                 for mut listener in listeners.drain(..) {
-                    if let Some(directory) = path.parent() {
-                        listener.also_remove_dir(directory.to_path_buf());
-                    }
+                    listener.also_remove_dir(directory.clone());
                     bound.push(BoundSource {
                         listener,
                         destination: destination.clone(),
@@ -447,7 +446,15 @@ fn bind_sources(
 /// Create the private directory for a named-pipe forward and return the
 /// socket path inside it (upstream `et_forward_sock_XXXXXX/sock`).
 #[cfg(unix)]
-fn create_forward_pipe(owner: Option<(u32, u32)>) -> Result<std::path::PathBuf, ForwardError> {
+fn create_forward_pipe(owner: Option<(u32, u32)>) -> Result<ForwardPipe, ForwardError> {
+    create_forward_pipe_with(owner, |_| Ok(()))
+}
+
+#[cfg(unix)]
+fn create_forward_pipe_with(
+    owner: Option<(u32, u32)>,
+    after_create: impl FnOnce(&std::path::Path) -> io::Result<()>,
+) -> Result<ForwardPipe, ForwardError> {
     use std::os::unix::fs::DirBuilderExt;
     let (suffix, _) = et_core::keys::gen_id_passkey();
     let directory = std::env::temp_dir().join(format!("et_forward_sock_{suffix}"));
@@ -455,10 +462,45 @@ fn create_forward_pipe(owner: Option<(u32, u32)>) -> Result<std::path::PathBuf, 
         .mode(0o700)
         .create(&directory)
         .map_err(ForwardError::Io)?;
-    if let Some((uid, gid)) = owner {
-        std::os::unix::fs::chown(&directory, Some(uid), Some(gid)).map_err(ForwardError::Io)?;
+    let pipe = ForwardPipe {
+        path: directory.join("sock"),
+        directory: Some(directory),
+    };
+    after_create(
+        pipe.directory
+            .as_deref()
+            .ok_or(ForwardError::Protocol("forward pipe directory missing"))?,
+    )
+    .map_err(ForwardError::Io)?;
+    if let (Some((uid, gid)), Some(directory)) = (owner, pipe.directory.as_deref()) {
+        std::os::unix::fs::chown(directory, Some(uid), Some(gid)).map_err(ForwardError::Io)?;
     }
-    Ok(directory.join("sock"))
+    Ok(pipe)
+}
+
+#[cfg(unix)]
+struct ForwardPipe {
+    path: std::path::PathBuf,
+    directory: Option<std::path::PathBuf>,
+}
+
+#[cfg(unix)]
+impl ForwardPipe {
+    fn disarm(&mut self) -> Result<std::path::PathBuf, ForwardError> {
+        self.directory
+            .take()
+            .ok_or(ForwardError::Protocol("forward pipe directory missing"))
+    }
+}
+
+#[cfg(unix)]
+impl Drop for ForwardPipe {
+    fn drop(&mut self) {
+        if let Some(directory) = self.directory.as_ref() {
+            let _ = std::fs::remove_file(&self.path);
+            let _ = std::fs::remove_dir(directory);
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -479,4 +521,55 @@ pub fn is_forward_packet(header: u8) -> bool {
     header == TerminalPacketType::PortForwardDestinationRequest as u8
         || header == TerminalPacketType::PortForwardDestinationResponse as u8
         || header == TerminalPacketType::PortForwardData as u8
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::os::unix::net::UnixListener;
+
+    #[test]
+    fn named_pipe_failure_after_directory_creation_cleans_and_retries() {
+        // Given
+        let created = RefCell::new(None);
+
+        // When
+        let error = match create_forward_pipe_with(None, |directory| {
+            *created.borrow_mut() = Some(directory.to_path_buf());
+            Err(io::Error::other("injected before chown"))
+        }) {
+            Ok(_) => panic!("injected directory failure succeeded"),
+            Err(error) => error,
+        };
+        let directory = created.into_inner().unwrap();
+
+        // Then
+        assert!(matches!(error, ForwardError::Io(_)));
+        assert!(!directory.exists());
+        std::fs::create_dir(&directory).unwrap();
+        std::fs::remove_dir(&directory).unwrap();
+    }
+
+    #[test]
+    fn named_pipe_post_bind_failure_cleans_socket_and_directory_then_retries() {
+        // Given
+        let pipe = create_forward_pipe(None).unwrap();
+        let directory = pipe.directory.as_ref().unwrap().clone();
+        let path = pipe.path.clone();
+        let listener = UnixListener::bind(&path).unwrap();
+
+        // When: a later bind/configuration step fails and ownership never transfers.
+        drop(pipe);
+
+        // Then
+        assert!(!path.exists());
+        assert!(!directory.exists());
+        drop(listener);
+        std::fs::create_dir(&directory).unwrap();
+        let retry = UnixListener::bind(&path).unwrap();
+        drop(retry);
+        std::fs::remove_file(&path).unwrap();
+        std::fs::remove_dir(&directory).unwrap();
+    }
 }

--- a/crates/et-net/src/forward.rs
+++ b/crates/et-net/src/forward.rs
@@ -371,7 +371,7 @@ fn bind_sources(
         listener_count = listener_count
             .checked_add(additional_listeners)
             .ok_or(ForwardError::Protocol("reverse listener limit exceeded"))?;
-        if listener_count > MAX_SESSION_LISTENERS {
+        if owner.is_some() && listener_count > MAX_SESSION_LISTENERS {
             return Err(ForwardError::Protocol("reverse listener limit exceeded"));
         }
         plans.push(plan);

--- a/crates/et-net/src/forward_endpoint.rs
+++ b/crates/et-net/src/forward_endpoint.rs
@@ -218,43 +218,86 @@ impl ResolvedEndpoint {
             }
             (Self::Tcp(addresses), _) => bind_tcp_addresses(addresses.iter().copied()),
             #[cfg(unix)]
-            (Self::Unix(path), Some((uid, gid))) => {
-                let listener = crate::user_socket_ops::listen_unix_as_user(path, uid, gid)?;
-                listener.set_nonblocking(true)?;
-                Ok(vec![ForwardListener {
-                    inner: ListenerKind::Unix(listener),
-                    cleanup: Some(path.clone()),
-                    cleanup_dir: None,
-                }])
-            }
-            #[cfg(unix)]
-            (Self::Unix(path), None) => {
-                if path.exists() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::AddrInUse,
-                        "Unix source socket already exists",
-                    ));
-                }
-                let cleanup_dir = if let Some(parent) = path.parent() {
-                    if !parent.exists() {
-                        fs::create_dir_all(parent)?;
-                        fs::set_permissions(parent, fs::Permissions::from_mode(0o700))?;
-                        Some(parent.to_path_buf())
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
-                let listener = UnixListener::bind(path)?;
-                fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
-                listener.set_nonblocking(true)?;
-                Ok(vec![ForwardListener {
-                    inner: ListenerKind::Unix(listener),
-                    cleanup: Some(path.clone()),
-                    cleanup_dir,
-                }])
-            }
+            (Self::Unix(path), user) => bind_unix_source(path, user, || Ok(()), || Ok(())),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn bind_unix_source(
+    path: &std::path::Path,
+    user: Option<(u32, u32)>,
+    after_directory: impl FnOnce() -> io::Result<()>,
+    after_bind: impl FnOnce() -> io::Result<()>,
+) -> io::Result<Vec<ForwardListener>> {
+    if path.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::AddrInUse,
+            "Unix source socket already exists",
+        ));
+    }
+    let mut directory_guard = None;
+    if user.is_none() {
+        if let Some(parent) = path.parent().filter(|parent| !parent.exists()) {
+            fs::create_dir_all(parent)?;
+            directory_guard = Some(PathCleanup::directory(parent.to_path_buf()));
+            after_directory()?;
+            fs::set_permissions(parent, fs::Permissions::from_mode(0o700))?;
+        }
+    }
+    let listener = match user {
+        Some((uid, gid)) => crate::user_socket_ops::listen_unix_as_user(path, uid, gid)?,
+        None => UnixListener::bind(path)?,
+    };
+    let socket_guard = PathCleanup::socket(path.to_path_buf());
+    after_bind()?;
+    if user.is_none() {
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    }
+    listener.set_nonblocking(true)?;
+    Ok(vec![ForwardListener {
+        inner: ListenerKind::Unix(listener),
+        cleanup: socket_guard.disarm(),
+        cleanup_dir: directory_guard.and_then(PathCleanup::disarm),
+    }])
+}
+
+#[cfg(unix)]
+struct PathCleanup {
+    path: Option<PathBuf>,
+    socket: bool,
+}
+
+#[cfg(unix)]
+impl PathCleanup {
+    fn socket(path: PathBuf) -> Self {
+        Self {
+            path: Some(path),
+            socket: true,
+        }
+    }
+
+    fn directory(path: PathBuf) -> Self {
+        Self {
+            path: Some(path),
+            socket: false,
+        }
+    }
+
+    fn disarm(mut self) -> Option<PathBuf> {
+        self.path.take()
+    }
+}
+
+#[cfg(unix)]
+impl Drop for PathCleanup {
+    fn drop(&mut self) {
+        if let Some(path) = self.path.as_ref() {
+            let _ = if self.socket {
+                fs::remove_file(path)
+            } else {
+                fs::remove_dir(path)
+            };
         }
     }
 }
@@ -508,6 +551,67 @@ mod tests {
             #[cfg(unix)]
             Endpoint::Unix(_) => panic!("TCP destination parsed as Unix"),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_source_failure_after_directory_creation_cleans_and_retries() {
+        // Given
+        let root = std::env::temp_dir().join(format!("et-fwd-dir-{}", std::process::id()));
+        let path = root.join("created").join("source.sock");
+        let created = path.parent().unwrap().to_path_buf();
+
+        // When
+        let error = match bind_unix_source(
+            &path,
+            None,
+            || Err(io::Error::other("injected after directory creation")),
+            || Ok(()),
+        ) {
+            Ok(_) => panic!("injected directory failure succeeded"),
+            Err(error) => error,
+        };
+
+        // Then
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert!(!created.exists());
+        let listeners = bind_unix_source(&path, None, || Ok(()), || Ok(())).unwrap();
+        assert!(path.exists());
+        drop(listeners);
+        assert!(!path.exists());
+        assert!(!created.exists());
+        let _ = fs::remove_dir(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_source_failure_after_bind_cleans_socket_and_directory_then_retries() {
+        // Given
+        let root = std::env::temp_dir().join(format!("et-fwd-bind-{}", std::process::id()));
+        let path = root.join("created").join("source.sock");
+        let created = path.parent().unwrap().to_path_buf();
+
+        // When
+        let error = match bind_unix_source(
+            &path,
+            None,
+            || Ok(()),
+            || Err(io::Error::other("injected before final configuration")),
+        ) {
+            Ok(_) => panic!("injected post-bind failure succeeded"),
+            Err(error) => error,
+        };
+
+        // Then
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert!(!path.exists());
+        assert!(!created.exists());
+        let listeners = bind_unix_source(&path, None, || Ok(()), || Ok(())).unwrap();
+        assert!(path.exists());
+        drop(listeners);
+        assert!(!path.exists());
+        assert!(!created.exists());
+        let _ = fs::remove_dir(root);
     }
 
     #[cfg(unix)]

--- a/crates/et-net/src/forward_endpoint.rs
+++ b/crates/et-net/src/forward_endpoint.rs
@@ -65,11 +65,9 @@ impl Endpoint {
         }
     }
 
-    /// Resolve a `PORT_FORWARD_DESTINATION_REQUEST` endpoint with upstream
-    /// semantics (`PortForwardHandler::createDestination`): when a port is
-    /// present the name is ignored entirely and the connection always goes
-    /// to localhost (`::1` first, then `127.0.0.1`); otherwise the name is a
-    /// Unix socket path.
+    /// Parse a `PORT_FORWARD_DESTINATION_REQUEST`, preserving explicit TCP
+    /// names so resolution happens on the destination side. An absent name
+    /// retains protocol-v6's localhost default.
     pub(crate) fn parse_destination(endpoint: Option<SocketEndpoint>) -> io::Result<Self> {
         let endpoint = endpoint
             .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "endpoint is missing"))?;
@@ -84,10 +82,11 @@ impl Endpoint {
                         "endpoint port is invalid",
                     ));
                 }
-                Ok(Self::Tcp {
-                    host: "localhost".to_owned(),
-                    port,
-                })
+                let host = endpoint
+                    .name
+                    .filter(|name| !name.contains('\0'))
+                    .unwrap_or_else(|| "localhost".to_owned());
+                Ok(Self::Tcp { host, port })
             }
             None => {
                 let name = endpoint
@@ -131,7 +130,7 @@ impl Endpoint {
             Self::Tcp { host, port } => {
                 // Upstream connects to localhost destinations by trying ::1
                 // first and falling back to 127.0.0.1.
-                if host == "localhost" || host == "127.0.0.1" || host == "::1" || host.is_empty() {
+                if host.eq_ignore_ascii_case("localhost") {
                     let v6 = std::net::SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, *port));
                     match TcpStream::connect_timeout(&v6, CONNECT_TIMEOUT) {
                         Ok(stream) => return Ok(ForwardStream::Tcp(stream)),
@@ -464,6 +463,52 @@ impl Drop for ForwardListener {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn destination_parser_preserves_explicit_tcp_names_and_families() {
+        for name in ["127.0.0.1", "::1", "backend.internal"] {
+            // Given
+            let endpoint = SocketEndpoint {
+                name: Some(name.to_owned()),
+                port: Some(4242),
+            };
+
+            // When
+            let parsed = Endpoint::parse_destination(Some(endpoint)).unwrap();
+
+            // Then
+            match parsed {
+                Endpoint::Tcp { host, port } => {
+                    assert_eq!(host, name);
+                    assert_eq!(port, 4242);
+                }
+                #[cfg(unix)]
+                Endpoint::Unix(_) => panic!("TCP destination parsed as Unix"),
+            }
+        }
+    }
+
+    #[test]
+    fn destination_parser_defaults_only_absent_tcp_name_to_localhost() {
+        // Given
+        let endpoint = SocketEndpoint {
+            name: None,
+            port: Some(4242),
+        };
+
+        // When
+        let parsed = Endpoint::parse_destination(Some(endpoint)).unwrap();
+
+        // Then
+        match parsed {
+            Endpoint::Tcp { host, port } => {
+                assert_eq!(host, "localhost");
+                assert_eq!(port, 4242);
+            }
+            #[cfg(unix)]
+            Endpoint::Unix(_) => panic!("TCP destination parsed as Unix"),
+        }
+    }
 
     #[cfg(unix)]
     #[test]

--- a/crates/et-net/src/user_socket_ops.rs
+++ b/crates/et-net/src/user_socket_ops.rs
@@ -100,14 +100,34 @@ pub fn run_helper() -> i32 {
 
 /// Bind/listen a new owner-only UNIX socket path with the current credentials.
 pub fn listen_at_path(path: &Path) -> io::Result<UnixListener> {
+    listen_at_path_with(path, || Ok(()))
+}
+
+fn listen_at_path_with(
+    path: &Path,
+    after_bind: impl FnOnce() -> io::Result<()>,
+) -> io::Result<UnixListener> {
     if path_too_long(path) {
         return Err(io::Error::from_raw_os_error(
             rustix::io::Errno::NAMETOOLONG.raw_os_error(),
         ));
     }
     let listener = UnixListener::bind(path)?;
+    let mut cleanup = SocketPathCleanup(Some(path.to_path_buf()));
+    after_bind()?;
     fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    cleanup.0 = None;
     Ok(listener)
+}
+
+struct SocketPathCleanup(Option<PathBuf>);
+
+impl Drop for SocketPathCleanup {
+    fn drop(&mut self) {
+        if let Some(path) = self.0.as_ref() {
+            let _ = fs::remove_file(path);
+        }
+    }
 }
 
 /// connect() to a UNIX socket path with the current credentials.
@@ -400,6 +420,26 @@ mod tests {
         // When / Then
         assert!(!helper_identity_matches(target, &[65_534], &inherited));
         assert!(helper_identity_matches(target, &[65_534], &dropped));
+    }
+
+    #[test]
+    fn listen_failure_after_bind_cleans_socket_and_immediate_retry_succeeds() {
+        // Given
+        let dir = temp_dir();
+        let path = dir.join("post-bind-failure.sock");
+
+        // When
+        let error = listen_at_path_with(&path, || Err(io::Error::other("injected before chmod")))
+            .unwrap_err();
+
+        // Then
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert!(!path.exists());
+        let listener = listen_at_path(&path).unwrap();
+        assert!(path.exists());
+        drop(listener);
+        fs::remove_file(&path).unwrap();
+        fs::remove_dir(&dir).unwrap();
     }
 
     #[test]

--- a/crates/et-net/src/user_socket_ops.rs
+++ b/crates/et-net/src/user_socket_ops.rs
@@ -405,16 +405,19 @@ mod tests {
     use super::*;
     use std::io::{Read, Write};
     use std::os::unix::fs::FileTypeExt;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     fn temp_dir() -> PathBuf {
-        let stamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("time")
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!("et_user_sock_{stamp}"));
-        fs::create_dir_all(&dir).unwrap();
-        dir
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        loop {
+            let sequence = NEXT.fetch_add(1, Ordering::Relaxed);
+            let dir = PathBuf::from(format!("/tmp/e{:x}{sequence:x}", std::process::id()));
+            match fs::create_dir(&dir) {
+                Ok(()) => return dir,
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => panic!("could not create test directory: {error}"),
+            }
+        }
     }
 
     fn long_unix_path() -> PathBuf {

--- a/crates/et-net/src/user_socket_ops.rs
+++ b/crates/et-net/src/user_socket_ops.rs
@@ -7,6 +7,7 @@
 //! `unsafe`); it re-execs a helper, drops with [`nix`] in that
 //! single-threaded process, and uses the same fd-passing protocol.
 
+use std::error::Error;
 use std::ffi::OsStr;
 use std::fs;
 use std::io::{self, IoSlice, IoSliceMut};
@@ -218,6 +219,14 @@ fn drop_helper_privileges() -> io::Result<()> {
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or_else(|| rustix::process::getgid().as_raw());
+    if !rustix::process::geteuid().is_root()
+        && (rustix::process::geteuid().as_raw() != uid
+            || rustix::process::getegid().as_raw() != gid)
+    {
+        return Err(io::Error::from_raw_os_error(
+            rustix::io::Errno::PERM.raw_os_error(),
+        ));
+    }
     let uid_text = uid.to_string();
     let gid_text = gid.to_string();
     privdrop::PrivDrop::default()
@@ -226,7 +235,7 @@ fn drop_helper_privileges() -> io::Result<()> {
         .group_list(&[&gid_text])
         .fallback_to_ids_if_names_are_numeric()
         .apply()
-        .map_err(io::Error::other)?;
+        .map_err(privdrop_io_error)?;
     let identity = HelperIdentity {
         euid: rustix::process::geteuid().as_raw(),
         egid: rustix::process::getegid().as_raw(),
@@ -236,12 +245,22 @@ fn drop_helper_privileges() -> io::Result<()> {
             .collect(),
     };
     if !helper_identity_matches((uid, gid), &[gid], &identity) {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            "user-socket helper retained unexpected credentials",
+        return Err(io::Error::from_raw_os_error(
+            rustix::io::Errno::PERM.raw_os_error(),
         ));
     }
     Ok(())
+}
+
+fn privdrop_io_error(error: privdrop::PrivDropError) -> io::Error {
+    let errno = error
+        .source()
+        .and_then(|source| source.downcast_ref::<privdrop::reexports::nix::errno::Errno>())
+        .copied();
+    match errno {
+        Some(errno) => io::Error::from_raw_os_error(errno as i32),
+        None => io::Error::other(error),
+    }
 }
 
 struct HelperIdentity {
@@ -400,6 +419,18 @@ mod tests {
 
     fn long_unix_path() -> PathBuf {
         PathBuf::from("x".repeat(UNIX_PATH_MAX + 8))
+    }
+
+    #[test]
+    fn privilege_drop_errno_preserves_io_error_kind() {
+        // Given
+        let denied = privdrop::PrivDropError::from(privdrop::reexports::nix::errno::Errno::EPERM);
+
+        // When
+        let error = privdrop_io_error(denied);
+
+        // Then
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
     }
 
     #[test]

--- a/crates/et-net/src/user_socket_ops.rs
+++ b/crates/et-net/src/user_socket_ops.rs
@@ -198,21 +198,48 @@ fn drop_helper_privileges() -> io::Result<()> {
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or_else(|| rustix::process::getgid().as_raw());
-    let uid = nix::unistd::Uid::from_raw(uid);
-    let gid = nix::unistd::Gid::from_raw(gid);
-    // Match ET: setgroups/setgid/setuid while still root. nix `setgroups` is
-    // unavailable on Apple targets; Linux is the etserver-as-root case.
-    if nix::unistd::geteuid().as_raw() == 0 {
-        #[cfg(target_os = "linux")]
-        nix::unistd::setgroups(&[gid]).map_err(from_nix)?;
+    let uid_text = uid.to_string();
+    let gid_text = gid.to_string();
+    privdrop::PrivDrop::default()
+        .user(&uid_text)
+        .group(&gid_text)
+        .group_list(&[&gid_text])
+        .fallback_to_ids_if_names_are_numeric()
+        .apply()
+        .map_err(io::Error::other)?;
+    let identity = HelperIdentity {
+        euid: rustix::process::geteuid().as_raw(),
+        egid: rustix::process::getegid().as_raw(),
+        groups: rustix::process::getgroups()?
+            .into_iter()
+            .map(rustix::process::Gid::as_raw)
+            .collect(),
+    };
+    if !helper_identity_matches((uid, gid), &[gid], &identity) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "user-socket helper retained unexpected credentials",
+        ));
     }
-    nix::unistd::setgid(gid).map_err(from_nix)?;
-    nix::unistd::setuid(uid).map_err(from_nix)?;
     Ok(())
 }
 
-fn from_nix(error: nix::errno::Errno) -> io::Error {
-    io::Error::from_raw_os_error(error as i32)
+struct HelperIdentity {
+    euid: u32,
+    egid: u32,
+    groups: Vec<u32>,
+}
+
+fn helper_identity_matches(
+    target: (u32, u32),
+    expected_groups: &[u32],
+    identity: &HelperIdentity,
+) -> bool {
+    let mut expected = expected_groups.to_vec();
+    expected.sort_unstable();
+    let mut observed = identity.groups.clone();
+    observed.sort_unstable();
+    identity.euid == target.0 && identity.egid == target.1 && observed == expected
 }
 
 fn helper_exe() -> io::Result<PathBuf> {
@@ -353,6 +380,26 @@ mod tests {
 
     fn long_unix_path() -> PathBuf {
         PathBuf::from("x".repeat(UNIX_PATH_MAX + 8))
+    }
+
+    #[test]
+    fn helper_identity_rejects_inherited_privileged_supplementary_group() {
+        // Given
+        let target = (65_534, 65_534);
+        let inherited = HelperIdentity {
+            euid: 65_534,
+            egid: 65_534,
+            groups: vec![0, 65_534],
+        };
+        let dropped = HelperIdentity {
+            euid: 65_534,
+            egid: 65_534,
+            groups: vec![65_534],
+        };
+
+        // When / Then
+        assert!(!helper_identity_matches(target, &[65_534], &inherited));
+        assert!(helper_identity_matches(target, &[65_534], &dropped));
     }
 
     #[test]

--- a/crates/et-net/tests/connection_resilience.rs
+++ b/crates/et-net/tests/connection_resilience.rs
@@ -22,6 +22,23 @@ fn eof_invalidates_connection_so_future_output_is_buffered() {
 }
 
 #[test]
+fn strict_handshake_write_rejects_soft_disconnected_transport() {
+    // Given
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let client_stream = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+    let (server_stream, _) = listener.accept().unwrap();
+    let mut client = Connection::new_client(client_stream, &[9; 32]);
+    server_stream.shutdown(std::net::Shutdown::Both).unwrap();
+
+    // When
+    let result = client.write_packet_strict(7, b"acknowledgement");
+
+    // Then
+    assert!(result.is_err());
+    assert!(!client.connected());
+}
+
+#[test]
 fn recovery_protobuf_limit_is_explicit_and_enforced() {
     let old_listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let old_client = TcpStream::connect(old_listener.local_addr().unwrap()).unwrap();

--- a/crates/et-net/tests/forward.rs
+++ b/crates/et-net/tests/forward.rs
@@ -147,6 +147,67 @@ fn try_receive_reports_backpressure_and_outbound_drain_recovers() {
 
 #[cfg(unix)]
 #[test]
+fn imported_local_bind_failure_obeys_strict_policy_transactionally() {
+    // Given
+    struct RemoveDir(std::path::PathBuf);
+    impl Drop for RemoveDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+    let directory = std::env::temp_dir().join(format!("et-fp-{}", std::process::id()));
+    std::fs::create_dir(&directory).unwrap();
+    let _cleanup = RemoveDir(directory.clone());
+    let usable_path = directory.join("usable.sock");
+    let occupied_path = directory.join("occupied.sock");
+    let occupied = std::os::unix::net::UnixListener::bind(&occupied_path).unwrap();
+    let imported = |path: &std::path::Path, strict| ForwardSource {
+        request: PortForwardSourceRequest {
+            source: Some(SocketEndpoint {
+                name: Some(path.to_string_lossy().into_owned()),
+                port: None,
+            }),
+            destination: Some(SocketEndpoint {
+                name: Some("/tmp/destination.sock".to_owned()),
+                port: None,
+            }),
+            environmentvariable: None,
+        },
+        origin: ForwardOrigin::SshConfig { strict },
+    };
+
+    // When: nonfatal import contains one occupied row.
+    let (forwarder, skipped) = Forwarder::start_with_origins(vec![
+        imported(&usable_path, false),
+        imported(&occupied_path, false),
+    ])
+    .unwrap();
+
+    // Then: one warning record remains and the usable sibling stays bound.
+    assert_eq!(skipped.len(), 1);
+    assert!(usable_path.exists());
+    forwarder.shutdown().unwrap();
+
+    // When: strict import contains the same occupied row after a usable sibling.
+    let error = match Forwarder::start_with_origins(vec![
+        imported(&usable_path, true),
+        imported(&occupied_path, true),
+    ]) {
+        Ok((forwarder, _)) => {
+            forwarder.shutdown().unwrap();
+            panic!("strict imported bind failure was downgraded")
+        }
+        Err(error) => error,
+    };
+
+    // Then: strict setup fails and rolls the provisional sibling back.
+    assert!(matches!(error, ForwardError::Io(_)));
+    assert!(!usable_path.exists());
+    drop(occupied);
+}
+
+#[cfg(unix)]
+#[test]
 fn reverse_tcp_bind_uses_session_identity() {
     let root = rustix::process::geteuid().as_raw() == 0;
     let source_port = if root { 1 } else { reserve_port() };
@@ -261,7 +322,7 @@ fn imported_local_wildcard_is_externally_reachable_while_loopback_is_not() {
     let request = request_on("", wildcard_port, 1);
     let (wildcard, skipped) = Forwarder::start_with_origins(vec![ForwardSource {
         request,
-        origin: ForwardOrigin::SshConfig,
+        origin: ForwardOrigin::SshConfig { strict: false },
     }])
     .unwrap();
     assert!(skipped.is_empty());

--- a/crates/et-net/tests/forward.rs
+++ b/crates/et-net/tests/forward.rs
@@ -273,7 +273,7 @@ fn imported_local_wildcard_is_externally_reachable_while_loopback_is_not() {
 
 #[cfg(unix)]
 #[test]
-fn reverse_listener_limit_is_transactional() {
+fn local_forwarding_exceeds_reverse_cap_while_reverse_limit_is_transactional() {
     struct RemoveDir(std::path::PathBuf);
     impl Drop for RemoveDir {
         fn drop(&mut self) {
@@ -287,7 +287,7 @@ fn reverse_listener_limit_is_transactional() {
     let paths: Vec<_> = (0..33)
         .map(|index| directory.join(format!("source-{index}.sock")))
         .collect();
-    let requests = paths
+    let requests: Vec<PortForwardSourceRequest> = paths
         .iter()
         .map(|path| PortForwardSourceRequest {
             source: Some(SocketEndpoint {
@@ -302,14 +302,28 @@ fn reverse_listener_limit_is_transactional() {
         })
         .collect();
 
-    let error = match Forwarder::start(requests) {
-        Ok(forwarder) => {
+    // When: client-local forwarding owns more than the server reverse cap.
+    let local = Forwarder::start(requests.clone()).unwrap();
+
+    // Then: every local listener is usable and cleanup is deterministic.
+    assert!(paths.iter().all(|path| path.exists()));
+    local.shutdown().unwrap();
+    assert!(paths.iter().all(|path| !path.exists()));
+
+    // When: the same multiset is requested as authenticated server reverse forwarding.
+    let owner = (
+        rustix::process::geteuid().as_raw(),
+        rustix::process::getegid().as_raw(),
+    );
+    let error = match Forwarder::start_with_user(requests, Some(owner)) {
+        Ok((forwarder, _)) => {
             forwarder.shutdown().unwrap();
-            panic!("listener cap was not enforced");
+            panic!("reverse listener cap was not enforced");
         }
         Err(error) => error,
     };
 
+    // Then: the cap fails transactionally before any sibling bind.
     assert!(
         error.to_string().contains("listener limit"),
         "unexpected error: {error}"

--- a/crates/et-net/tests/forward.rs
+++ b/crates/et-net/tests/forward.rs
@@ -208,6 +208,40 @@ fn authenticated_reverse_tcp_wildcard_bind_exposes_session_to_external_network()
 
 #[cfg(target_os = "linux")]
 #[test]
+fn authenticated_reverse_tcp_rejects_resolved_non_loopback_address() {
+    // Given
+    let probe = std::net::UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).unwrap();
+    probe.connect((Ipv4Addr::new(192, 0, 2, 1), 9)).unwrap();
+    let external = match probe.local_addr().unwrap().ip() {
+        IpAddr::V4(address) if !address.is_loopback() => address,
+        address => panic!("route probe did not select a non-loopback IPv4 address: {address}"),
+    };
+    let owner = (
+        rustix::process::geteuid().as_raw(),
+        rustix::process::getegid().as_raw(),
+    );
+
+    // When
+    let error = match Forwarder::start_with_user(
+        vec![request_on(&external.to_string(), reserve_port(), 1)],
+        Some(owner),
+    ) {
+        Ok((forwarder, _)) => {
+            forwarder.shutdown().unwrap();
+            panic!("authenticated reverse listener accepted non-loopback authority")
+        }
+        Err(error) => error,
+    };
+
+    // Then
+    match error {
+        ForwardError::Io(error) => assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied),
+        other => panic!("unexpected non-loopback result: {other}"),
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
 fn imported_local_wildcard_is_externally_reachable_while_loopback_is_not() {
     let probe = std::net::UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).unwrap();
     probe.connect((Ipv4Addr::new(192, 0, 2, 1), 9)).unwrap();

--- a/crates/et-server/src/runtime_handler.rs
+++ b/crates/et-server/src/runtime_handler.rs
@@ -260,7 +260,7 @@ fn handle_new(
     };
     let requires_ack = response_error.is_some();
     if connection
-        .write_packet(
+        .write_packet_strict(
             EtPacketType::InitialResponse as u8,
             &InitialResponse {
                 error: response_error,
@@ -381,7 +381,7 @@ fn run_jumphost(
     };
     let response = InitialResponse::decode(response_packet.payload()).ok();
     if connection
-        .write_packet(
+        .write_packet_strict(
             EtPacketType::InitialResponse as u8,
             response_packet.payload(),
         )


### PR DESCRIPTION
## Summary

- preserve OpenSSH bind, destination, and `ExitOnForwardFailure` semantics for
  supported SSH-config forwarding
- enforce authenticated reverse-listener authority, portable privilege drops,
  strict initialization writes, and reverse-only listener limits
- clean failed Unix listener setup transactionally and align integration/error
  contracts found by the final full-workspace gate

## Context

This is the post-merge audit follow-up to #66 and #69, implementing omissions
found while re-reviewing [upstream Eternal Terminal issue
#90](https://github.com/MisterTea/EternalTerminal/issues/90).

Protocol v6 protobufs, fixtures, and version bytes are unchanged.

## Verification

- same ultrabrain reviewer: unconditional `APPROVE`
- real OpenSSH 10.2 + isolated sshd: 47/47 forwarding observables
- root etserver / non-root session / distinct attacker security runtime: PASS
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1` — 38 suites, 420 tests
- `cargo build -p et --target x86_64-pc-windows-gnu`
- exact CLI and real byte-exact loopback relay: 31/31 observables
- protocol-v6 source and fixture diff against `origin/main`: empty

## Release

Includes `.tegami/fix-ssh-config-forwarding-postmerge-audit.md` as an `et`
patch changeset.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens SSH-config forwarding so `et` preserves OpenSSH bind addresses and TCP destination names and honors `ExitOnForwardFailure`, and hardens server-side reverse listeners with portable privilege drops and transactional Unix setup cleanup.

**Forwarding semantics**
- Explicit bind addresses (`localhost`, `127.0.0.2`, `::1`, `*`) and destination hostnames now survive parsing instead of being normalized to localhost or skipped.
- `ExitOnForwardFailure yes` turns unsupported rows (dynamic forwards, prohibited wildcard binds) into startup errors; `no` keeps the existing warn-and-skip behavior.
- Handshake writes require a live transport, so initialization fails on a dead peer instead of buffering silently.

**Reverse authority and cleanup**
- Server-side reverse TCP binds reject any non-loopback resolved address, and the listener cap now applies only to reverse tunnels.
- Helper privilege drops now use `privdrop`, verify the resulting euid/egid and group list, and work on non-Linux Unix targets; terminal registration reports effective credentials.
- Failed Unix listener setup removes the socket and auto-created directory before returning the error, so retries are clean.
- Protocol v6 wire format and protobufs are unchanged; ships as an `et` patch changeset.

<sup>Written for commit ba32f2b48ddd64e0b3fe93364a1d4fee705f0843. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

