### PR TITLE
Synchronize jumphost fixture teardown

### DIFF
--- a/crates/et-server/tests/runtime_adversarial.rs
+++ b/crates/et-server/tests/runtime_adversarial.rs
@@ -307,6 +307,7 @@ fn jumphost_payload_is_relayed_to_the_registered_terminal() {
     };
     let (stream, response) = server.handshake(ID_A);
     assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    let (client_received_tx, client_received_rx) = std::sync::mpsc::sync_channel(0);
     let terminal_handshake = std::thread::spawn(move || {
         let packet = et_net::local_packet::read_local_packet(&mut terminal).unwrap();
         assert_eq!(
@@ -322,10 +323,12 @@ fn jumphost_payload_is_relayed_to_the_registered_terminal() {
             ),
         )
         .unwrap();
+        client_received_rx.recv_timeout(TIMEOUT).unwrap();
         relayed
     });
     let (_client, initial) = runtime_support::initialize(stream, &key, payload);
     assert!(initial.error.is_none(), "{:?}", initial.error);
+    client_received_tx.send(()).unwrap();
     let relayed = terminal_handshake.join().unwrap();
     assert_eq!(relayed.jumphost, Some(true));
     server.runtime.shutdown().unwrap();


### PR DESCRIPTION
## Summary

- keep the mock jumphost terminal registered until the top-level client receives its relayed InitialResponse
- replace a teardown timing race with a zero-capacity, bounded event rendezvous
- restore deterministic post-merge Ubuntu CI without changing production or protocol behavior

## Context

Follow-up to #71. Main CI run https://github.com/minpeter/et.rs/actions/runs/33396703149 intermittently failed `jumphost_payload_is_relayed_to_the_registered_terminal` with `UnexpectedEof`. Three independent debugging lanes confirmed the mock terminal dropped too early, allowing legitimate lifecycle teardown to close the still-Starting client.

## Verification

- focused test: PASS
- `runtime_adversarial`: 9/9 PASS
- complete et-server test domain: PASS
- fmt and et-server clippy: PASS
- protocol-v6 diff: empty
- no sleeps or polling

Test-only change; no Tegami changeset required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition in the jumphost relay test where the mock terminal could be dropped before the client received its InitialResponse, causing intermittent `UnexpectedEof` failures in CI. The test now uses a zero-capacity channel to keep the terminal registered until the client confirms it has received the relayed response.

<sup>Written for commit c1cf3ce9a6cb07a11fd60b4c5a004aaba7b69576. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

