### PR TITLE
fix(terminal): align MOTD and shell prompt spacing

### DIFF
--- a/.tegami/fix-motd-prompt-spacing.md
+++ b/.tegami/fix-motd-prompt-spacing.md
@@ -1,6 +1,10 @@
 ---
-et: patch
+packages:
+  et:
+    type: patch
 ---
+
+## Align MOTD and shell prompt spacing
 
 Avoid an extra blank line between the MOTD and an interactive shell prompt
 when the login shell emits an initial newline.

--- a/.tegami/fix-motd-prompt-spacing.md
+++ b/.tegami/fix-motd-prompt-spacing.md
@@ -1,0 +1,6 @@
+---
+et: patch
+---
+
+Avoid an extra blank line between the MOTD and an interactive shell prompt
+when the login shell emits an initial newline.

--- a/crates/et-bin/src/terminal_motd.rs
+++ b/crates/et-bin/src/terminal_motd.rs
@@ -11,15 +11,8 @@ use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
-use et_core::packet::Packet;
-use et_core::proto::{TerminalBuffer, TerminalPacketType};
-use et_net::local::LocalStream;
-use et_net::local_packet::write_local_packet;
-use prost::Message;
 use rustix::fs::{Mode, OFlags};
 
-/// Largest output chunk per packet, matching the PTY output worker.
-const MAX_OUTPUT_CHUNK: usize = 16 * 1024;
 /// `pam_motd(8)` limits each message to 64 KiB.
 const MAX_MOTD_MESSAGE: usize = 64 * 1024;
 /// Bound aggregate startup output when many directory messages exist.
@@ -35,11 +28,10 @@ const DEFAULT_FILES: [&str; 3] = ["/etc/motd", "/run/motd", "/usr/lib/motd"];
 /// `pam_motd(8)`'s default directories, highest priority first.
 const DEFAULT_DIRS: [&str; 3] = ["/etc/motd.d", "/run/motd.d", "/usr/lib/motd.d"];
 
-/// Emit the message of the day to the router, if there is one to show.
+/// Load the message of the day, if there is one to show.
 ///
-/// File-level failures are advisory and never fail the session. A router write
-/// failure follows the same error path as any other terminal output failure.
-pub fn emit(router: &mut LocalStream) -> Result<(), String> {
+/// File-level failures are advisory and never fail the session.
+pub fn load() -> Option<Vec<u8>> {
     let home = std::env::var_os("HOME").map(PathBuf::from);
     let override_path = std::env::var_os(OVERRIDE_VARIABLE)
         .filter(|path| !path.is_empty())
@@ -57,10 +49,7 @@ pub fn emit(router: &mut LocalStream) -> Result<(), String> {
     } else {
         load_defaults_from(&dynamic_files, &files, &directories, home.as_deref())
     };
-    let Some(text) = text else {
-        return Ok(());
-    };
-    write_output(router, &text)
+    text
 }
 
 fn load_from(
@@ -203,24 +192,6 @@ fn append_terminal_bytes(output: &mut Vec<u8>, bytes: &[u8]) {
     if output.len().saturating_add(2) <= MAX_MOTD_TOTAL {
         output.extend_from_slice(b"\r\n");
     }
-}
-
-fn output_packet(chunk: &[u8]) -> Packet {
-    let message = TerminalBuffer {
-        buffer: Some(chunk.to_vec()),
-    };
-    Packet::new(
-        TerminalPacketType::TerminalBuffer as u8,
-        message.encode_to_vec(),
-    )
-}
-
-fn write_output(router: &mut LocalStream, text: &[u8]) -> Result<(), String> {
-    for chunk in text.chunks(MAX_OUTPUT_CHUNK) {
-        write_local_packet(router, &output_packet(chunk))
-            .map_err(|error| format!("could not forward message of the day: {error}"))?;
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/et-bin/src/terminal_motd_tests.rs
+++ b/crates/et-bin/src/terminal_motd_tests.rs
@@ -194,10 +194,3 @@ fn load_preserves_raw_bytes_and_normalizes_only_lone_line_feeds() {
         b"a\r\nb\r\n\x1b[31mc\x07\xff\xfe\r\n"
     );
 }
-
-#[test]
-fn maximum_output_packet_fits_the_local_frame_bound() {
-    let packet = output_packet(&vec![b'x'; MAX_OUTPUT_CHUNK]);
-
-    assert!(packet.wire_len() <= et_net::local_packet::MAX_LOCAL_PACKET_LEN);
-}

--- a/crates/et-bin/src/terminal_pty.rs
+++ b/crates/et-bin/src/terminal_pty.rs
@@ -621,18 +621,20 @@ mod tests {
 
     fn collect_forwarded(segments: &[&[u8]], prefix: Option<&[u8]>) -> (Vec<Vec<u8>>, Vec<u8>) {
         let (writer, mut peer) = et_net::local::wake_pair().unwrap();
-        peer.set_read_timeout(Some(Duration::from_millis(100)))
-            .unwrap();
         let (packets_tx, packets_rx) = mpsc::sync_channel(1);
         thread::spawn(move || {
             let mut packets = Vec::new();
-            while let Ok(packet) = read_local_packet(&mut peer) {
-                packets.push(
-                    TerminalBuffer::decode(packet.payload())
-                        .unwrap()
-                        .buffer
-                        .unwrap(),
-                );
+            loop {
+                match read_local_packet(&mut peer) {
+                    Ok(packet) => packets.push(
+                        TerminalBuffer::decode(packet.payload())
+                            .unwrap()
+                            .buffer
+                            .unwrap(),
+                    ),
+                    Err(et_net::local_packet::LocalPacketError::TruncatedPrefix) => break,
+                    Err(error) => panic!("reading forwarded output packet: {error}"),
+                }
             }
             let _ = packets_tx.send(packets);
         });

--- a/crates/et-bin/src/terminal_pty.rs
+++ b/crates/et-bin/src/terminal_pty.rs
@@ -55,6 +55,8 @@ where
     F: FnOnce(&mut LocalStream) -> Result<(), String>,
 {
     let environment = read_initial_environment(&mut router)?;
+    #[cfg(unix)]
+    let motd = crate::terminal_motd::load();
     let pair = native_pty_system()
         .openpty(PtySize {
             rows: 24,
@@ -108,7 +110,16 @@ where
                 if !output_delay.is_zero() {
                     thread::sleep(output_delay);
                 }
-                forward_output(&mut pty_reader, &worker_writer, &worker_cancelled)
+                #[cfg(unix)]
+                let prefix = motd.as_deref();
+                #[cfg(not(unix))]
+                let prefix = None;
+                forward_output(
+                    &mut pty_reader,
+                    &worker_writer,
+                    &worker_cancelled,
+                    prefix,
+                )
             });
             let _ = output_tx.send(WorkerEvent::Output(result));
             signal(output_wake);
@@ -177,10 +188,6 @@ where
                 .lock()
                 .map_err(|_| "terminal router writer is unavailable".to_owned())?;
             started(&mut writer)?;
-            // Keep startup status ahead of every user-visible byte while
-            // preserving current-main's MOTD-before-shell ordering.
-            #[cfg(unix)]
-            crate::terminal_motd::emit(&mut writer)?;
             Ok(())
         });
     let output_started = setup.is_ok();
@@ -286,8 +293,15 @@ fn forward_output(
     reader: &mut dyn Read,
     router: &Mutex<LocalStream>,
     cancelled: &AtomicBool,
+    prefix: Option<&[u8]>,
 ) -> Result<(), String> {
+    if let Some(prefix) = prefix {
+        for chunk in prefix.chunks(MAX_OUTPUT_CHUNK) {
+            write_output(router, cancelled, chunk)?;
+        }
+    }
     let mut buffer = [0u8; MAX_OUTPUT_CHUNK];
+    let mut first = true;
     loop {
         let count = reader
             .read(&mut buffer)
@@ -295,19 +309,39 @@ fn forward_output(
         if count == 0 {
             return Ok(());
         }
-        let message = TerminalBuffer {
-            buffer: Some(buffer[..count].to_vec()),
-        };
-        let packet = Packet::new(
-            TerminalPacketType::TerminalBuffer as u8,
-            message.encode_to_vec(),
-        );
-        let mut router = router
-            .lock()
-            .map_err(|_| "terminal router writer is unavailable".to_owned())?;
-        write_local_packet_until_cancelled(&mut *router, &packet, cancelled)
-            .map_err(|error| format!("could not forward PTY output: {error}"))?;
+        let mut output = &buffer[..count];
+        if first && prefix.is_some() {
+            output = output
+                .strip_prefix(b"\r\r\n")
+                .or_else(|| output.strip_prefix(b"\r\n"))
+                .or_else(|| output.strip_prefix(b"\n"))
+                .unwrap_or(output);
+        }
+        first = false;
+        write_output(router, cancelled, output)?;
     }
+}
+
+fn write_output(
+    router: &Mutex<LocalStream>,
+    cancelled: &AtomicBool,
+    output: &[u8],
+) -> Result<(), String> {
+    if output.is_empty() {
+        return Ok(());
+    }
+    let message = TerminalBuffer {
+        buffer: Some(output.to_vec()),
+    };
+    let packet = Packet::new(
+        TerminalPacketType::TerminalBuffer as u8,
+        message.encode_to_vec(),
+    );
+    let mut router = router
+        .lock()
+        .map_err(|_| "terminal router writer is unavailable".to_owned())?;
+    write_local_packet_until_cancelled(&mut *router, &packet, cancelled)
+        .map_err(|error| format!("could not forward PTY output: {error}"))
 }
 
 struct PumpCompletion {
@@ -665,6 +699,7 @@ mod tests {
                 &mut Cursor::new(b"immediate output"),
                 &worker_writer,
                 &worker_cancelled,
+                None,
             )
         });
 

--- a/crates/et-bin/src/terminal_pty.rs
+++ b/crates/et-bin/src/terminal_pty.rs
@@ -723,4 +723,24 @@ mod tests {
         );
         worker.join().unwrap().unwrap();
     }
+
+    #[test]
+    fn maximum_motd_is_split_into_local_frame_sized_chunks() {
+        let output = vec![b'x'; 256 * 1024];
+
+        let chunks = output.chunks(MAX_OUTPUT_CHUNK).collect::<Vec<_>>();
+
+        assert_eq!(chunks.len(), 16);
+        assert!(chunks.iter().all(|chunk| {
+            let message = TerminalBuffer {
+                buffer: Some(chunk.to_vec()),
+            };
+            Packet::new(
+                TerminalPacketType::TerminalBuffer as u8,
+                message.encode_to_vec(),
+            )
+            .wire_len()
+                <= et_net::local_packet::MAX_LOCAL_PACKET_LEN
+        }));
+    }
 }

--- a/crates/et-bin/src/terminal_pty.rs
+++ b/crates/et-bin/src/terminal_pty.rs
@@ -114,12 +114,7 @@ where
                 let prefix = motd.as_deref();
                 #[cfg(not(unix))]
                 let prefix = None;
-                forward_output(
-                    &mut pty_reader,
-                    &worker_writer,
-                    &worker_cancelled,
-                    prefix,
-                )
+                forward_output(&mut pty_reader, &worker_writer, &worker_cancelled, prefix)
             });
             let _ = output_tx.send(WorkerEvent::Output(result));
             signal(output_wake);
@@ -301,24 +296,45 @@ fn forward_output(
         }
     }
     let mut buffer = [0u8; MAX_OUTPUT_CHUNK];
-    let mut first = true;
+    let mut startup = prefix.map(|_| Vec::with_capacity(3));
     loop {
         let count = reader
             .read(&mut buffer)
             .map_err(|error| format!("could not read PTY output: {error}"))?;
         if count == 0 {
+            if let Some(startup) = startup {
+                write_output(router, cancelled, &startup)?;
+            }
             return Ok(());
         }
-        let mut output = &buffer[..count];
-        if first && prefix.is_some() {
-            output = output
-                .strip_prefix(b"\r\r\n")
-                .or_else(|| output.strip_prefix(b"\r\n"))
-                .or_else(|| output.strip_prefix(b"\n"))
-                .unwrap_or(output);
+        if let Some(mut pending) = startup.take() {
+            let mut consumed = 0;
+            while consumed < count && pending.len() < 3 {
+                pending.push(buffer[consumed]);
+                consumed += 1;
+                if pending == b"\n" || pending == b"\r\n" || pending == b"\r\r\n" {
+                    pending.clear();
+                    break;
+                }
+                if !b"\r\r\n".starts_with(&pending) && !b"\r\n".starts_with(&pending) {
+                    break;
+                }
+            }
+            if !pending.is_empty()
+                && (b"\r\r\n".starts_with(&pending) || b"\r\n".starts_with(&pending))
+                && pending.len() < 3
+            {
+                startup = Some(pending);
+                if consumed == count {
+                    continue;
+                }
+            } else {
+                write_output(router, cancelled, &pending)?;
+            }
+            write_output(router, cancelled, &buffer[consumed..count])?;
+            continue;
         }
-        first = false;
-        write_output(router, cancelled, output)?;
+        write_output(router, cancelled, &buffer[..count])?;
     }
 }
 
@@ -589,6 +605,49 @@ mod tests {
     use prost::Message;
     use std::io::Cursor;
 
+    struct SegmentedReader {
+        segments: std::collections::VecDeque<Vec<u8>>,
+    }
+
+    impl Read for SegmentedReader {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            let Some(segment) = self.segments.pop_front() else {
+                return Ok(0);
+            };
+            buffer[..segment.len()].copy_from_slice(&segment);
+            Ok(segment.len())
+        }
+    }
+
+    fn collect_forwarded(segments: &[&[u8]], prefix: Option<&[u8]>) -> (Vec<Vec<u8>>, Vec<u8>) {
+        let (writer, mut peer) = et_net::local::wake_pair().unwrap();
+        peer.set_read_timeout(Some(Duration::from_millis(100)))
+            .unwrap();
+        let (packets_tx, packets_rx) = mpsc::sync_channel(1);
+        thread::spawn(move || {
+            let mut packets = Vec::new();
+            while let Ok(packet) = read_local_packet(&mut peer) {
+                packets.push(
+                    TerminalBuffer::decode(packet.payload())
+                        .unwrap()
+                        .buffer
+                        .unwrap(),
+                );
+            }
+            let _ = packets_tx.send(packets);
+        });
+        let writer = Mutex::new(writer);
+        let cancelled = AtomicBool::new(false);
+        let mut reader = SegmentedReader {
+            segments: segments.iter().map(|segment| segment.to_vec()).collect(),
+        };
+        forward_output(&mut reader, &writer, &cancelled, prefix).unwrap();
+        drop(writer);
+        let packets = packets_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        let output = packets.concat();
+        (packets, output)
+    }
+
     #[cfg(unix)]
     #[test]
     fn normal_immediate_exit_drains_delayed_output_before_eof() {
@@ -728,19 +787,35 @@ mod tests {
     fn maximum_motd_is_split_into_local_frame_sized_chunks() {
         let output = vec![b'x'; 256 * 1024];
 
-        let chunks = output.chunks(MAX_OUTPUT_CHUNK).collect::<Vec<_>>();
+        let (packets, forwarded) = collect_forwarded(&[], Some(&output));
 
-        assert_eq!(chunks.len(), 16);
-        assert!(chunks.iter().all(|chunk| {
-            let message = TerminalBuffer {
-                buffer: Some(chunk.to_vec()),
-            };
-            Packet::new(
-                TerminalPacketType::TerminalBuffer as u8,
-                message.encode_to_vec(),
-            )
-            .wire_len()
-                <= et_net::local_packet::MAX_LOCAL_PACKET_LEN
-        }));
+        assert_eq!(packets.len(), 16);
+        assert!(packets
+            .iter()
+            .all(|packet| packet.len() == MAX_OUTPUT_CHUNK));
+        assert_eq!(forwarded, output);
+    }
+
+    #[test]
+    fn motd_newline_elision_is_independent_of_pty_read_boundaries() {
+        for segments in [
+            vec![b"\r".as_slice(), b"\r\nprompt".as_slice()],
+            vec![b"\r\r".as_slice(), b"\nprompt".as_slice()],
+            vec![b"\r".as_slice(), b"\n".as_slice(), b"prompt".as_slice()],
+            vec![b"\n".as_slice(), b"prompt".as_slice()],
+        ] {
+            let (_, output) = collect_forwarded(&segments, Some(b"motd\r\n"));
+            assert_eq!(output, b"motd\r\nprompt", "segments={segments:?}");
+        }
+    }
+
+    #[test]
+    fn unmatched_startup_bytes_are_preserved_across_pty_reads() {
+        let (_, output) = collect_forwarded(
+            &[b"\r".as_slice(), b"Xprompt".as_slice()],
+            Some(b"motd\r\n"),
+        );
+
+        assert_eq!(output, b"motd\r\n\rXprompt");
     }
 }

--- a/crates/et-bin/tests/terminal_runtime.rs
+++ b/crates/et-bin/tests/terminal_runtime.rs
@@ -603,8 +603,7 @@ fn real_terminal_does_not_stack_motd_newline_with_shell_startup_newline() {
         &[("ET_MOTD_PATH", motd.as_os_str())],
     );
     write_credentials(&mut child);
-    let (mut router, _) = fixture.listener.accept().unwrap();
-    router.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let mut router = fixture.accept();
     let _ = read_local_packet(&mut router).unwrap();
     acknowledge_registration(&mut router);
     fixture.wait_ready();
@@ -658,8 +657,7 @@ fn real_terminal_suppresses_motd_when_home_has_hushlogin() {
         ],
     );
     write_credentials(&mut child);
-    let (mut router, _) = fixture.listener.accept().unwrap();
-    router.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let mut router = fixture.accept();
     let _ = read_local_packet(&mut router).unwrap();
     acknowledge_registration(&mut router);
     fixture.wait_ready();

--- a/crates/et-bin/tests/terminal_runtime.rs
+++ b/crates/et-bin/tests/terminal_runtime.rs
@@ -558,6 +558,7 @@ fn real_terminal_places_prompt_on_line_after_motd() {
     let (mut router, _) = fixture.listener.accept().unwrap();
     router.set_read_timeout(Some(TIMEOUT)).unwrap();
     let _ = read_local_packet(&mut router).unwrap();
+    acknowledge_registration(&mut router);
     fixture.wait_ready();
 
     // When: the terminal session starts the login shell.
@@ -569,6 +570,7 @@ fn real_terminal_places_prompt_on_line_after_motd() {
             environmentvalues: Vec::new(),
         },
     );
+    expect_startup(&mut router);
     let output = collect_until(&mut router, |output| contains(output, PROMPT_MARKER));
 
     // Then: exactly one terminal line transition separates MOTD and prompt.
@@ -606,6 +608,7 @@ fn real_terminal_does_not_stack_motd_newline_with_shell_startup_newline() {
     let (mut router, _) = fixture.listener.accept().unwrap();
     router.set_read_timeout(Some(TIMEOUT)).unwrap();
     let _ = read_local_packet(&mut router).unwrap();
+    acknowledge_registration(&mut router);
     fixture.wait_ready();
 
     // When: the terminal starts the login shell after emitting MOTD.
@@ -617,6 +620,7 @@ fn real_terminal_does_not_stack_motd_newline_with_shell_startup_newline() {
             environmentvalues: Vec::new(),
         },
     );
+    expect_startup(&mut router);
     let output = collect_until(&mut router, |output| contains(output, PROMPT_MARKER));
 
     // Then: MOTD and shell startup do not create a blank line together.

--- a/crates/et-bin/tests/terminal_runtime.rs
+++ b/crates/et-bin/tests/terminal_runtime.rs
@@ -496,8 +496,7 @@ fn real_terminal_emits_motd_before_login_shell_output() {
         &[("ET_MOTD_PATH", motd.as_os_str())],
     );
     write_credentials(&mut child);
-    let (mut router, _) = fixture.listener.accept().unwrap();
-    router.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let mut router = fixture.accept();
     let _ = read_local_packet(&mut router).unwrap();
     acknowledge_registration(&mut router);
     fixture.wait_ready();
@@ -555,8 +554,7 @@ fn real_terminal_places_prompt_on_line_after_motd() {
         &[("ET_MOTD_PATH", motd.as_os_str())],
     );
     write_credentials(&mut child);
-    let (mut router, _) = fixture.listener.accept().unwrap();
-    router.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let mut router = fixture.accept();
     let _ = read_local_packet(&mut router).unwrap();
     acknowledge_registration(&mut router);
     fixture.wait_ready();

--- a/crates/et-bin/tests/terminal_runtime.rs
+++ b/crates/et-bin/tests/terminal_runtime.rs
@@ -26,6 +26,7 @@ const KEY: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef";
 const TIMEOUT: Duration = Duration::from_secs(5);
 const LOGIN_TERM_COMPLETION: &[u8] = b"__ET_LOGIN_TERM_COMPLETE__\r\n";
 const MOTD_MARKER: &[u8] = b"ET-MOTD-MARKER";
+const PROMPT_MARKER: &[u8] = b"ET-PROMPT> ";
 
 #[test]
 fn bootstrap_parent_reports_marker_and_leaves_registered_session_running() {
@@ -541,6 +542,102 @@ fn real_terminal_emits_motd_before_login_shell_output() {
         "expected MOTD exactly once; got {:?}",
         String::from_utf8_lossy(&output),
     );
+}
+
+#[test]
+fn real_terminal_places_prompt_on_line_after_motd() {
+    // Given: a one-line MOTD and a login shell that emits its prompt immediately.
+    let fixture = Fixture::new("motd-prompt-spacing");
+    let motd = fixture.file("motd", b"ET-MOTD-MARKER\n");
+    let shell = fixture.prompt_probe_shell();
+    let mut child = fixture.spawn_session(
+        shell.to_str().unwrap(),
+        &[("ET_MOTD_PATH", motd.as_os_str())],
+    );
+    write_credentials(&mut child);
+    let (mut router, _) = fixture.listener.accept().unwrap();
+    router.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let _ = read_local_packet(&mut router).unwrap();
+    fixture.wait_ready();
+
+    // When: the terminal session starts the login shell.
+    send(
+        &mut router,
+        TerminalPacketType::TerminalInit,
+        &TermInit {
+            environmentnames: Vec::new(),
+            environmentvalues: Vec::new(),
+        },
+    );
+    let output = collect_until(&mut router, |output| contains(output, PROMPT_MARKER));
+
+    // Then: exactly one terminal line transition separates MOTD and prompt.
+    let motd_at = find(&output, MOTD_MARKER).unwrap();
+    let prompt_at = find(&output, PROMPT_MARKER).unwrap();
+    assert_eq!(
+        &output[motd_at + MOTD_MARKER.len()..prompt_at],
+        b"\r\n",
+        "expected prompt directly below MOTD; got {:?}",
+        String::from_utf8_lossy(&output),
+    );
+
+    send(
+        &mut router,
+        TerminalPacketType::TerminalBuffer,
+        &TerminalBuffer {
+            buffer: Some(b"exit\n".to_vec()),
+        },
+    );
+    let status = child.wait_timeout(TIMEOUT).unwrap().unwrap();
+    assert!(status.success());
+}
+
+#[test]
+fn real_terminal_does_not_stack_motd_newline_with_shell_startup_newline() {
+    // Given: a MOTD plus a login shell whose startup moves to a fresh line.
+    let fixture = Fixture::new("motd-leading-shell-newline");
+    let motd = fixture.file("motd", b"ET-MOTD-MARKER\n");
+    let shell = fixture.leading_newline_prompt_shell();
+    let mut child = fixture.spawn_session(
+        shell.to_str().unwrap(),
+        &[("ET_MOTD_PATH", motd.as_os_str())],
+    );
+    write_credentials(&mut child);
+    let (mut router, _) = fixture.listener.accept().unwrap();
+    router.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let _ = read_local_packet(&mut router).unwrap();
+    fixture.wait_ready();
+
+    // When: the terminal starts the login shell after emitting MOTD.
+    send(
+        &mut router,
+        TerminalPacketType::TerminalInit,
+        &TermInit {
+            environmentnames: Vec::new(),
+            environmentvalues: Vec::new(),
+        },
+    );
+    let output = collect_until(&mut router, |output| contains(output, PROMPT_MARKER));
+
+    // Then: MOTD and shell startup do not create a blank line together.
+    let motd_at = find(&output, MOTD_MARKER).unwrap();
+    let prompt_at = find(&output, PROMPT_MARKER).unwrap();
+    assert_eq!(
+        &output[motd_at + MOTD_MARKER.len()..prompt_at],
+        b"\r\n",
+        "expected prompt directly below MOTD; got {:?}",
+        String::from_utf8_lossy(&output),
+    );
+
+    send(
+        &mut router,
+        TerminalPacketType::TerminalBuffer,
+        &TerminalBuffer {
+            buffer: Some(b"exit\n".to_vec()),
+        },
+    );
+    let status = child.wait_timeout(TIMEOUT).unwrap().unwrap();
+    assert!(status.success());
 }
 
 #[test]

--- a/crates/et-bin/tests/terminal_runtime_support/mod.rs
+++ b/crates/et-bin/tests/terminal_runtime_support/mod.rs
@@ -138,6 +138,42 @@ impl Fixture {
         path
     }
 
+    /// Wrapper that emits a prompt marker immediately when invoked as a login shell.
+    pub fn prompt_probe_shell(&self) -> std::path::PathBuf {
+        let path = self.directory.join("prompt-probe-shell");
+        fs::write(
+            &path,
+            "#!/bin/sh\n\
+             if [ \"${1-}\" = \"-l\" ]; then\n\
+             printf 'ET-PROMPT> '\n\
+             shift\n\
+             exec /bin/sh \"$@\"\n\
+             fi\n\
+             exec /bin/sh \"$@\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+        path
+    }
+
+    /// Login-shell wrapper matching profiles that begin by moving to a fresh line.
+    pub fn leading_newline_prompt_shell(&self) -> std::path::PathBuf {
+        let path = self.directory.join("leading-newline-prompt-shell");
+        fs::write(
+            &path,
+            "#!/bin/sh\n\
+             if [ \"${1-}\" = \"-l\" ]; then\n\
+             printf '\\r\\nET-PROMPT> '\n\
+             shift\n\
+             exec /bin/sh \"$@\"\n\
+             fi\n\
+             exec /bin/sh \"$@\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+        path
+    }
+
     pub fn spawn_parent(&self) -> std::process::Child {
         Command::new(env!("CARGO_BIN_EXE_et"))
             .args(["terminal", "--serverfifo"])

--- a/crates/et-bin/tests/terminal_tty_qa.rs
+++ b/crates/et-bin/tests/terminal_tty_qa.rs
@@ -294,12 +294,18 @@ impl Stack {
             .spawn()
             .unwrap();
         wait_ready(&mut server, port, &router);
+        let home = directory.join("home");
+        fs::create_dir(&home).unwrap();
+        fs::write(home.join(".hushlogin"), b"").unwrap();
         let ssh = directory.join("ssh");
         fs::write(
             &ssh,
-            "#!/bin/sh\nif [ \"$1\" = \"-G\" ]; then\n\
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = \"-G\" ]; then\n\
              printf 'hostname 127.0.0.1\\nuser tester\\n'; exit 0; fi\n\
-             for last do :; done\nexec /bin/sh -c \"$last\"\n",
+             for last do :; done\nexport HOME={}\nexec /bin/sh -c \"$last\"\n",
+                shell_quote(home.to_str().unwrap())
+            ),
         )
         .unwrap();
         fs::set_permissions(&ssh, fs::Permissions::from_mode(0o755)).unwrap();


### PR DESCRIPTION
## Summary
- emit MOTD through the ordered PTY output worker
- collapse one immediately adjacent shell-leading newline after MOTD
- add deterministic regression coverage and an `et` patch changeset

## QA
- real OpenSSH bootstrap into the worktree `etterminal` and isolated `etserver`
- raw ET boundary: `REAL-SSH-ET-MOTD\r\nREAL-ET-PROMPT> `
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`

Protocol v6 protobuf and wire fixtures are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns MOTD and shell prompt spacing so an extra blank line no longer appears between them when the login shell emits a leading newline.

- Moves MOTD emission into the PTY output worker so it shares shell output's ordering and packet framing, with large MOTDs still split to local frame bounds.
- Collapses one shell-leading newline following the MOTD, even when it arrives split across PTY reads.
- Adds regression tests for prompt spacing, fragmented newlines, and frame bounds, and bounds MOTD fixture accepts to remove timing races.
- Isolates TTY QA from any host MOTD via a `.hushlogin` home.
- Adds a patch changeset for `et`.

<sup>Written for commit 17d9fec146c9beb345edf6d5f0f818c56b7d0231. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

