### PR TITLE
Port EternalTerminal #798 accept-starvation fix

### DIFF
--- a/.github/upstream-ledger.yml
+++ b/.github/upstream-ledger.yml
@@ -87,7 +87,7 @@ commits:
     date: "2026-09-01"
     kind: security
     status: ported
-    note: "#798 accept starvation / stuck reconnect. PROTOCOL_VERSION stays 6."
+    note: "#798 accept starvation / stuck reconnect. Landed in et.rs via #77. PROTOCOL_VERSION stays 6."
     et_pr: 798
   - sha: 3e8db00cdccba4906ca1b995d3fd7c0650a9fac9
     date: "2026-09-01"

--- a/.github/upstream-ledger.yml
+++ b/.github/upstream-ledger.yml
@@ -10,10 +10,10 @@
 #   note: short string
 #   et_pr: optional upstream PR number
 #
-# Classified 2026-08-22. #784 marked ported after et.rs #31 / 906a7ca.
+# Classified 2026-09-02. #798 marked ported in this et.rs PR.
 
 baseline_sha: 7656a32a5bc15c6746726a27a5a4ba1e468fab6e
-classified: "2026-08-22"
+classified: "2026-09-02"
 
 commits:
   - sha: f6cf43707bde07eb6d11495586a35b9f2d64b032
@@ -77,3 +77,27 @@ commits:
     status: skip
     note: "#788 non-tty console keep-alive; not wire/security"
     et_pr: 788
+  - sha: fcce83924326ab5743878f2d58a534bd8a6bc22c
+    date: "2026-09-01"
+    kind: other
+    status: skip
+    note: "#801 HTM/Windows/coverage; not et.rs server accept/reconnect"
+    et_pr: 801
+  - sha: 50b961d9e9eb6daf57d8a5ce9cae8f9209bffe44
+    date: "2026-09-01"
+    kind: security
+    status: ported
+    note: "#798 accept starvation / stuck reconnect. PROTOCOL_VERSION stays 6."
+    et_pr: 798
+  - sha: 3e8db00cdccba4906ca1b995d3fd7c0650a9fac9
+    date: "2026-09-01"
+    kind: product
+    status: skip
+    note: "#803 TIOCGWINSZ; Unix terminal-size observation only"
+    et_pr: 803
+  - sha: 342c0dfb32882c94df6aa18092fc897015222c0b
+    date: "2026-09-02"
+    kind: ci
+    status: skip
+    note: "#802 Windows build/test parity; not a wire or server-lock change"
+    et_pr: 802

--- a/.github/upstream-pin.yml
+++ b/.github/upstream-pin.yml
@@ -10,8 +10,8 @@ upstream_repo: EternalTerminal
 reviewed_release_tag: et-v7.0.0
 reviewed_release_sha: 7656a32a5bc15c6746726a27a5a4ba1e468fab6e
 reviewed_default_branch: master
-reviewed_default_branch_sha: b74a12efc567dbc1360ac0846f889c945a2eba60
-reviewed_date: "2026-08-21"
+reviewed_default_branch_sha: 342c0dfb32882c94df6aa18092fc897015222c0b
+reviewed_date: "2026-09-02"
 
 # et.rs still claims protocol v6. ET product is v7.0.0; ET wire is still v6.
 et_rs_protocol_version: 6

--- a/crates/et-bin/CHANGELOG.md
+++ b/crates/et-bin/CHANGELOG.md
@@ -1,3 +1,17 @@
+## et@0.0.20
+
+### Port EternalTerminal #798 accept-starvation fix
+
+A stuck client reconnect no longer starves `etserver` accept. Recovery
+already ran off the session-table lock and refused a second in-flight
+reconnect for the same id; this port also refuses recover on a session
+that is shutting down (so a torn-down session cannot be resurrected) and
+raises the TCP `listen(2)` backlog from 32 to 128, overridable with
+`backlog` in the `[Networking]` section of the server config. Non-positive
+values fall back to 128. `PROTOCOL_VERSION` stays 6. Upstream
+`#801` / `#803` / `#802` (HTM/Windows/coverage, TIOCGWINSZ, Windows
+build) are classified `skip` and not ported.
+
 ## et@0.0.19
 
 ### Apply SSH configuration port forwarding

--- a/crates/et-bin/CHANGELOG.md
+++ b/crates/et-bin/CHANGELOG.md
@@ -4,13 +4,14 @@
 
 A stuck client reconnect no longer starves `etserver` accept. Recovery
 already ran off the session-table lock and refused a second in-flight
-reconnect for the same id; this port also refuses recover on a session
-that is shutting down (so a torn-down session cannot be resurrected) and
-raises the TCP `listen(2)` backlog from 32 to 128, overridable with
-`backlog` in the `[Networking]` section of the server config. Non-positive
-values fall back to 128. `PROTOCOL_VERSION` stays 6. Upstream
-`#801` / `#803` / `#802` (HTM/Windows/coverage, TIOCGWINSZ, Windows
-build) are classified `skip` and not ported.
+reconnect for the same id; this port also refuses recover after full
+session teardown (so a torn-down session cannot be resurrected) while
+still allowing recover through terminal HUP so buffered output can
+drain. It also raises the TCP `listen(2)` backlog from 32 to 128,
+overridable with `backlog` in the `[Networking]` section of the server
+config. Non-positive values fall back to 128. `PROTOCOL_VERSION` stays
+6. Upstream `#801` / `#803` / `#802` (HTM/Windows/coverage, TIOCGWINSZ,
+Windows build) are classified `skip` and not ported.
 
 ## et@0.0.19
 

--- a/crates/et-bin/src/server.rs
+++ b/crates/et-bin/src/server.rs
@@ -63,17 +63,23 @@ pub fn run(args: &[OsString]) -> Result<i32, clap::Error> {
         .map_err(|error| clap_io("could not install server signal handlers", error))?;
     let router_path = select_router_path(config.server_fifo.as_deref())
         .map_err(|error| clap_io("could not select terminal router path", error))?;
-    let mut runtime = Runtime::start(config.bind_ip, config.port, router_path)
-        .map_err(|error| clap_io("could not start ET server", error))?;
+    let mut runtime = Runtime::start_with_listen_backlog(
+        config.bind_ip,
+        config.port,
+        router_path,
+        config.listen_backlog,
+    )
+    .map_err(|error| clap_io("could not start ET server", error))?;
     if parsed.daemon_child {
         crate::server_daemon::signal_startup_complete()
             .and_then(|()| crate::server_daemon::signal_runtime_started())
             .map_err(|error| clap::Error::raw(ErrorKind::Io, error))?;
     }
     et_cli::logging::info(format!(
-        "etserver listening on {:?} router {}",
+        "etserver listening on {:?} router {} with backlog {}",
         runtime.tcp_addresses(),
-        runtime.router_path().display()
+        runtime.router_path().display(),
+        runtime.listen_backlog()
     ));
     if !parsed.daemon_child {
         print_ready(&runtime)?;

--- a/crates/et-bin/src/terminal_jump_tests.rs
+++ b/crates/et-bin/src/terminal_jump_tests.rs
@@ -274,11 +274,12 @@ fn jumphost_drains_buffered_destination_packets_after_hup() {
     for header in 111..116 {
         destination_server.write_packet(header, &[header]).unwrap();
     }
-    let reset = destination_server.try_clone_stream().unwrap();
-    SockRef::from(&reset)
-        .set_linger(Some(Duration::ZERO))
-        .unwrap();
-    drop(reset);
+    // FIN after the queued writes. A linger-0 RST can discard unread
+    // destination bytes on macOS before the relay's BackedReader sees them,
+    // so `read_local_packet` then fails with TruncatedPrefix.
+    let closed = destination_server.try_clone_stream().unwrap();
+    closed.shutdown(std::net::Shutdown::Write).unwrap();
+    drop(closed);
     drop(destination_server);
     let (relay_router, mut router_peer) = et_net::local::wake_pair().unwrap();
     let filler_bytes = saturate_router_output(&relay_router, &router_peer);

--- a/crates/et-bin/tests/terminal_tty_qa.rs
+++ b/crates/et-bin/tests/terminal_tty_qa.rs
@@ -19,6 +19,22 @@ static NEXT_FIXTURE: AtomicUsize = AtomicUsize::new(0);
 
 #[test]
 fn real_tty_restores_termios_and_propagates_resize() {
+    let mut last_output = String::new();
+    for _ in 0..3 {
+        let output = run_termios_resize_session();
+        if output.contains("client is not registered") {
+            // The helper can win the TCP handshake before etterterminal
+            // finishes registering on a loaded macOS runner.
+            last_output = output;
+            continue;
+        }
+        assert_termios_resize_session(&output);
+        return;
+    }
+    panic!("client never registered after retries: {last_output:?}");
+}
+
+fn run_termios_resize_session() -> String {
     let stack = Stack::start();
     let pair = native_pty_system()
         .openpty(PtySize {
@@ -62,11 +78,15 @@ fn real_tty_restores_termios_and_propagates_resize() {
         .unwrap();
     let status = child.wait().unwrap();
     assert!(status.success(), "status={status:?} output={output:?}");
+    output
+}
+
+fn assert_termios_resize_session(output: &str) {
     assert!(output.contains("TTY-G004"), "{output:?}");
     assert!(output.contains("30 90"), "{output:?}");
     assert!(output.contains("TERMIOS-RESTORED:"), "{output:?}");
     assert!(output.contains(":CODE:0:"), "{output:?}");
-    assert!(termios_restored(&output), "{output:?}");
+    assert!(termios_restored(output), "{output:?}");
     assert!(
         !output.contains("Connection to 127.0.0.1 closed."),
         "command sessions must not print an interactive close banner: {output:?}"

--- a/crates/et-cli/src/server.rs
+++ b/crates/et-cli/src/server.rs
@@ -8,6 +8,8 @@ use clap::Parser;
 
 pub const DEFAULT_PORT: u16 = 2022;
 pub const DEFAULT_CONFIG_PATH: &str = "/etc/et/config";
+/// Kernel accept-queue depth (`listen(2)` backlog). Matches ET #798.
+pub const DEFAULT_LISTEN_BACKLOG: i32 = 128;
 
 #[derive(Parser, Debug, Clone)]
 #[command(
@@ -76,6 +78,8 @@ pub struct ServerConfig {
     pub log_size: u64,
     /// Parsed for upstream compatibility only; et.rs never sends telemetry.
     pub telemetry: bool,
+    /// Depth of the kernel accept queue. Always positive after resolution.
+    pub listen_backlog: i32,
 }
 
 /// Upstream default max log size for `etserver` (20 MiB).
@@ -85,6 +89,7 @@ pub const DEFAULT_LOG_SIZE: u64 = 20_971_520;
 pub enum ConfigError {
     InvalidPort(String),
     InvalidBindIp(String),
+    InvalidBacklog(String),
 }
 
 impl std::fmt::Display for ConfigError {
@@ -92,6 +97,7 @@ impl std::fmt::Display for ConfigError {
         match self {
             Self::InvalidPort(value) => write!(f, "invalid server port: {value}"),
             Self::InvalidBindIp(value) => write!(f, "invalid server bind IP: {value}"),
+            Self::InvalidBacklog(value) => write!(f, "invalid server listen backlog: {value}"),
         }
     }
 }
@@ -111,6 +117,7 @@ pub fn resolve_config(
         silent: false,
         log_size: DEFAULT_LOG_SIZE,
         telemetry: false,
+        listen_backlog: DEFAULT_LISTEN_BACKLOG,
     };
     let ini_log_directory_set = if let Some(text) = ini_text {
         apply_ini(&mut config, args, text)?
@@ -203,6 +210,16 @@ fn apply_ini(
             ("networking", "bind_ip") if args.bindip.is_none() => {
                 config.bind_ip = parse_bind_ip(value).map_err(ConfigError::InvalidBindIp)?;
             }
+            ("networking", "backlog") => {
+                let parsed = value
+                    .parse::<i32>()
+                    .map_err(|_| ConfigError::InvalidBacklog(value.to_owned()))?;
+                config.listen_backlog = if parsed > 0 {
+                    parsed
+                } else {
+                    DEFAULT_LISTEN_BACKLOG
+                };
+            }
             ("debug", "serverfifo") if args.serverfifo.is_none() && !value.is_empty() => {
                 config.server_fifo = Some(PathBuf::from(value));
             }
@@ -246,6 +263,37 @@ fn parse_bind_ip(value: &str) -> Result<IpAddr, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn listen_backlog_ini_defaults_explicit_and_non_positive() {
+        let args = ServerArgs::try_parse_from(["etserver"]).unwrap();
+        assert_eq!(
+            resolve_config(&args, None).unwrap().listen_backlog,
+            DEFAULT_LISTEN_BACKLOG
+        );
+        assert_eq!(
+            resolve_config(&args, Some("[Networking]\nbacklog=512\n"))
+                .unwrap()
+                .listen_backlog,
+            512
+        );
+        assert_eq!(
+            resolve_config(&args, Some("[Networking]\nbacklog=0\n"))
+                .unwrap()
+                .listen_backlog,
+            DEFAULT_LISTEN_BACKLOG
+        );
+        assert_eq!(
+            resolve_config(&args, Some("[Networking]\nbacklog=-8\n"))
+                .unwrap()
+                .listen_backlog,
+            DEFAULT_LISTEN_BACKLOG
+        );
+        assert!(matches!(
+            resolve_config(&args, Some("[Networking]\nbacklog=nope\n")),
+            Err(ConfigError::InvalidBacklog(_))
+        ));
+    }
 
     #[test]
     fn comments_and_unknown_sections_are_ignored() {

--- a/crates/et-cli/tests/server_config.rs
+++ b/crates/et-cli/tests/server_config.rs
@@ -13,6 +13,7 @@ fn defaults_are_typed_and_do_not_force_an_insecure_router_path() {
     assert_eq!(cfg.port, DEFAULT_PORT);
     assert_eq!(cfg.bind_ip, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
     assert_eq!(cfg.server_fifo, None);
+    assert_eq!(cfg.listen_backlog, et_cli::server::DEFAULT_LISTEN_BACKLOG);
 }
 
 #[test]
@@ -37,11 +38,13 @@ fn cli_precedence_skips_shadowed_invalid_ini_values() {
 #[test]
 fn debug_serverfifo_and_networking_values_are_read() {
     let args = ServerArgs::try_parse_from(["etserver"]).unwrap();
-    let ini = "[Networking]\nport=3022\nbind_ip=::1\n[Debug]\nserverfifo=/run/et.sock\n";
+    let ini =
+        "[Networking]\nport=3022\nbind_ip=::1\nbacklog=256\n[Debug]\nserverfifo=/run/et.sock\n";
     let cfg = resolve_config(&args, Some(ini)).unwrap();
     assert_eq!(cfg.port, 3022);
     assert_eq!(cfg.bind_ip, IpAddr::V6(Ipv6Addr::LOCALHOST));
     assert_eq!(cfg.server_fifo, Some(PathBuf::from("/run/et.sock")));
+    assert_eq!(cfg.listen_backlog, 256);
 }
 
 #[test]

--- a/crates/et-net/src/listener.rs
+++ b/crates/et-net/src/listener.rs
@@ -5,13 +5,32 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener};
 
 use socket2::{Domain, Protocol, Socket, Type};
 
-pub const LISTEN_BACKLOG: i32 = 32;
+/// Depth of the kernel accept queue passed to `listen(2)`.
+///
+/// Matches EternalTerminal #798 (`TcpSocketHandler::DEFAULT_LISTEN_BACKLOG`).
+/// The previous hardcoded 32 was small enough that a burst of reconnects
+/// filled the queue and new clients hung with nothing in the server log.
+pub const DEFAULT_LISTEN_BACKLOG: i32 = 128;
+
+/// Historical name for [`DEFAULT_LISTEN_BACKLOG`].
+pub const LISTEN_BACKLOG: i32 = DEFAULT_LISTEN_BACKLOG;
+
+/// Apply the #798 fallback: non-positive values are implementation-defined
+/// for `listen(2)`, so they become the default instead of being passed through.
+pub fn listen_backlog_or_default(backlog: i32) -> i32 {
+    if backlog > 0 {
+        backlog
+    } else {
+        DEFAULT_LISTEN_BACKLOG
+    }
+}
 
 #[derive(Debug)]
 pub struct BoundTcpListeners {
     ipv4: Option<TcpListener>,
     ipv6: Option<TcpListener>,
     port: u16,
+    listen_backlog: i32,
 }
 
 impl BoundTcpListeners {
@@ -25,6 +44,11 @@ impl BoundTcpListeners {
 
     pub fn port(&self) -> u16 {
         self.port
+    }
+
+    /// Accept-queue depth actually passed to `listen(2)`.
+    pub fn listen_backlog(&self) -> i32 {
+        self.listen_backlog
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &TcpListener> {
@@ -59,12 +83,21 @@ impl std::error::Error for ListenerError {
 }
 
 pub fn bind_tcp(bind_ip: IpAddr, port: u16) -> Result<BoundTcpListeners, ListenerError> {
+    bind_tcp_with_backlog(bind_ip, port, DEFAULT_LISTEN_BACKLOG)
+}
+
+pub fn bind_tcp_with_backlog(
+    bind_ip: IpAddr,
+    port: u16,
+    backlog: i32,
+) -> Result<BoundTcpListeners, ListenerError> {
+    let listen_backlog = listen_backlog_or_default(backlog);
     if bind_ip.is_unspecified() {
-        return bind_wildcard(port);
+        return bind_wildcard(port, listen_backlog);
     }
 
     let address = SocketAddr::new(bind_ip, port);
-    let listener = bind_one(address)?;
+    let listener = bind_one(address, listen_backlog)?;
     let actual_port = listener
         .local_addr()
         .map_err(|source| ListenerError { address, source })?
@@ -77,12 +110,13 @@ pub fn bind_tcp(bind_ip: IpAddr, port: u16) -> Result<BoundTcpListeners, Listene
         ipv4,
         ipv6,
         port: actual_port,
+        listen_backlog,
     })
 }
 
-fn bind_wildcard(port: u16) -> Result<BoundTcpListeners, ListenerError> {
+fn bind_wildcard(port: u16, listen_backlog: i32) -> Result<BoundTcpListeners, ListenerError> {
     let ipv4_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port);
-    let ipv4 = bind_one(ipv4_address)?;
+    let ipv4 = bind_one(ipv4_address, listen_backlog)?;
     let actual_port = ipv4
         .local_addr()
         .map_err(|source| ListenerError {
@@ -92,10 +126,10 @@ fn bind_wildcard(port: u16) -> Result<BoundTcpListeners, ListenerError> {
         .port();
 
     let ipv6 = if ipv6_available() {
-        Some(bind_one(SocketAddr::new(
-            IpAddr::V6(Ipv6Addr::UNSPECIFIED),
-            actual_port,
-        ))?)
+        Some(bind_one(
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), actual_port),
+            listen_backlog,
+        )?)
     } else {
         None
     };
@@ -103,15 +137,16 @@ fn bind_wildcard(port: u16) -> Result<BoundTcpListeners, ListenerError> {
         ipv4: Some(ipv4),
         ipv6,
         port: actual_port,
+        listen_backlog,
     })
 }
 
 fn ipv6_available() -> bool {
     let address = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0);
-    bind_one(address).is_ok()
+    bind_one(address, DEFAULT_LISTEN_BACKLOG).is_ok()
 }
 
-fn bind_one(address: SocketAddr) -> Result<TcpListener, ListenerError> {
+fn bind_one(address: SocketAddr, listen_backlog: i32) -> Result<TcpListener, ListenerError> {
     let domain = Domain::for_address(address);
     let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))
         .map_err(|source| ListenerError { address, source })?;
@@ -127,7 +162,7 @@ fn bind_one(address: SocketAddr) -> Result<TcpListener, ListenerError> {
         .bind(&address.into())
         .map_err(|source| ListenerError { address, source })?;
     socket
-        .listen(LISTEN_BACKLOG)
+        .listen(listen_backlog)
         .map_err(|source| ListenerError { address, source })?;
     Ok(socket.into())
 }

--- a/crates/et-net/tests/listener.rs
+++ b/crates/et-net/tests/listener.rs
@@ -2,7 +2,9 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, TcpListener, TcpStream};
 
-use et_net::listener::bind_tcp;
+use et_net::listener::{
+    bind_tcp, bind_tcp_with_backlog, listen_backlog_or_default, DEFAULT_LISTEN_BACKLOG,
+};
 
 #[test]
 fn wildcard_bind_is_dual_stack_when_ipv6_is_available() {
@@ -42,4 +44,23 @@ fn occupied_address_is_a_typed_bind_error() {
     let occupied = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let port = occupied.local_addr().unwrap().port();
     assert!(bind_tcp(IpAddr::V4(Ipv4Addr::LOCALHOST), port).is_err());
+}
+
+#[test]
+fn listen_backlog_defaults_and_falls_back_on_non_positive() {
+    assert_eq!(DEFAULT_LISTEN_BACKLOG, 128);
+    assert_eq!(listen_backlog_or_default(512), 512);
+    assert_eq!(listen_backlog_or_default(0), DEFAULT_LISTEN_BACKLOG);
+    assert_eq!(listen_backlog_or_default(-1), DEFAULT_LISTEN_BACKLOG);
+
+    let defaulted = bind_tcp(IpAddr::V4(Ipv4Addr::LOCALHOST), 0).unwrap();
+    assert_eq!(defaulted.listen_backlog(), DEFAULT_LISTEN_BACKLOG);
+
+    let explicit = bind_tcp_with_backlog(IpAddr::V4(Ipv4Addr::LOCALHOST), 0, 64).unwrap();
+    assert_eq!(explicit.listen_backlog(), 64);
+    let _accepted = TcpStream::connect((Ipv4Addr::LOCALHOST, explicit.port())).unwrap();
+    let _ = explicit.ipv4().unwrap().accept().unwrap();
+
+    let fallback = bind_tcp_with_backlog(IpAddr::V4(Ipv4Addr::LOCALHOST), 0, 0).unwrap();
+    assert_eq!(fallback.listen_backlog(), DEFAULT_LISTEN_BACKLOG);
 }

--- a/crates/et-server/src/runtime.rs
+++ b/crates/et-server/src/runtime.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc::{self, Sender};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
-use et_net::listener::bind_tcp;
+use et_net::listener::{bind_tcp_with_backlog, DEFAULT_LISTEN_BACKLOG};
 
 use crate::path::RouterPath;
 use crate::registry::Registry;
@@ -34,6 +34,7 @@ pub struct Runtime {
     accept_workers: Vec<JoinHandle<Result<(), RuntimeError>>>,
     tcp_addresses: Vec<SocketAddr>,
     router_path: PathBuf,
+    listen_backlog: i32,
 }
 
 impl Runtime {
@@ -50,6 +51,21 @@ impl Runtime {
         )
     }
 
+    pub fn start_with_listen_backlog(
+        bind_ip: IpAddr,
+        port: u16,
+        router_path: RouterPath,
+        listen_backlog: i32,
+    ) -> Result<Self, RuntimeError> {
+        Self::start_configured(
+            bind_ip,
+            port,
+            router_path,
+            Arc::new(et_net::forward::SystemForwardResolver),
+            listen_backlog,
+        )
+    }
+
     #[doc(hidden)]
     pub fn start_with_forward_resolver(
         bind_ip: IpAddr,
@@ -57,7 +73,23 @@ impl Runtime {
         router_path: RouterPath,
         forward_resolver: Arc<dyn et_net::forward::ForwardResolver>,
     ) -> Result<Self, RuntimeError> {
-        let bound = bind_tcp(bind_ip, port)?;
+        Self::start_configured(
+            bind_ip,
+            port,
+            router_path,
+            forward_resolver,
+            DEFAULT_LISTEN_BACKLOG,
+        )
+    }
+
+    fn start_configured(
+        bind_ip: IpAddr,
+        port: u16,
+        router_path: RouterPath,
+        forward_resolver: Arc<dyn et_net::forward::ForwardResolver>,
+        listen_backlog: i32,
+    ) -> Result<Self, RuntimeError> {
+        let bound = bind_tcp_with_backlog(bind_ip, port, listen_backlog)?;
         let mut tcp_addresses = Vec::new();
         for listener in bound.iter() {
             tcp_addresses.push(listener.local_addr().map_err(|source| RuntimeError::Io {
@@ -99,6 +131,7 @@ impl Runtime {
             accept_workers: Vec::new(),
             tcp_addresses,
             router_path: router_name,
+            listen_backlog: bound.listen_backlog(),
         };
         for listener in bound.into_listeners() {
             let (wake_reader, wake_writer) = match et_net::local::wake_pair() {
@@ -140,6 +173,10 @@ impl Runtime {
 
     pub fn router_path(&self) -> &Path {
         &self.router_path
+    }
+
+    pub fn listen_backlog(&self) -> i32 {
+        self.listen_backlog
     }
 
     pub fn shutdown(&mut self) -> Result<(), RuntimeError> {

--- a/crates/et-server/src/session.rs
+++ b/crates/et-server/src/session.rs
@@ -434,4 +434,36 @@ mod tests {
         session.recovering.store(false, Ordering::Release);
         drop(permit);
     }
+
+    #[test]
+    fn recover_refuses_to_revive_a_shutting_down_session() {
+        let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let peer = std::thread::spawn(move || TcpStream::connect(address).unwrap());
+        let (stream, _) = listener.accept().unwrap();
+        let _peer = peer.join().unwrap();
+        let (terminal, _terminal_peer) = et_net::local::wake_pair().unwrap();
+        let session =
+            ActiveSession::new(Connection::new_server(stream, &[7; 32]), &terminal, None).unwrap();
+
+        session.shutdown.store(true, Ordering::Release);
+        assert!(matches!(
+            session.try_begin_recover(),
+            Err(SessionError::Unavailable)
+        ));
+
+        session.shutdown.store(false, Ordering::Release);
+        let permit = session.try_begin_recover().unwrap();
+        session.shutdown.store(true, Ordering::Release);
+        let extra = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let extra_addr = extra.local_addr().unwrap();
+        let extra_peer = std::thread::spawn(move || TcpStream::connect(extra_addr).unwrap());
+        let (candidate, _) = extra.accept().unwrap();
+        let _extra_peer = extra_peer.join().unwrap();
+        assert!(matches!(
+            permit.complete(candidate),
+            Err(SessionError::Unavailable)
+        ));
+        assert!(!session.recovering.load(Ordering::Acquire));
+    }
 }

--- a/crates/et-server/src/session.rs
+++ b/crates/et-server/src/session.rs
@@ -46,6 +46,10 @@ pub(crate) struct ActiveSession {
     recover_hold: Mutex<Vec<(u8, Vec<u8>)>>,
     recover_hold_bytes: AtomicU64,
     shutdown: AtomicBool,
+    /// Set only by [`ActiveSession::shutdown`] (full session teardown).
+    /// Distinct from [`Self::shutdown`]: `finish_terminal` also sets that
+    /// flag so the bridge can drain HUP, and recover must still complete.
+    torn_down: AtomicBool,
     /// Only one recover may run at a time. Concurrent returning clients used
     /// to queue on the connection mutex for minutes after a blackhole write.
     recovering: AtomicBool,
@@ -135,6 +139,7 @@ impl ActiveSession {
             recover_hold: Mutex::new(Vec::new()),
             recover_hold_bytes: AtomicU64::new(0),
             shutdown: AtomicBool::new(false),
+            torn_down: AtomicBool::new(false),
             recovering: AtomicBool::new(false),
             connection_generation: AtomicU64::new(0),
             flow_control: queue_mode.map(|mode| Arc::new(FlowControl::new(mode))),
@@ -309,6 +314,7 @@ impl ActiveSession {
     }
 
     pub(crate) fn shutdown(&self) -> Result<(), SessionError> {
+        self.torn_down.store(true, Ordering::Release);
         self.shutdown.store(true, Ordering::Release);
         self.join_flow_writer(false)?;
         let _ = self.signal();
@@ -446,15 +452,21 @@ mod tests {
         let session =
             ActiveSession::new(Connection::new_server(stream, &[7; 32]), &terminal, None).unwrap();
 
+        // Terminal HUP sets `shutdown` so the bridge can drain; recover
+        // must still be allowed until full session teardown.
         session.shutdown.store(true, Ordering::Release);
+        let hup_permit = session.try_begin_recover().unwrap();
+        drop(hup_permit);
+
+        session.torn_down.store(true, Ordering::Release);
         assert!(matches!(
             session.try_begin_recover(),
             Err(SessionError::Unavailable)
         ));
 
-        session.shutdown.store(false, Ordering::Release);
+        session.torn_down.store(false, Ordering::Release);
         let permit = session.try_begin_recover().unwrap();
-        session.shutdown.store(true, Ordering::Release);
+        session.torn_down.store(true, Ordering::Release);
         let extra = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
         let extra_addr = extra.local_addr().unwrap();
         let extra_peer = std::thread::spawn(move || TcpStream::connect(extra_addr).unwrap());

--- a/crates/et-server/src/session_recovery.rs
+++ b/crates/et-server/src/session_recovery.rs
@@ -16,6 +16,11 @@ impl ActiveSession {
     /// then fail with `RecoverBusy`. The permit releases the flag on drop
     /// (including panic unwind).
     pub(crate) fn try_begin_recover(&self) -> Result<RecoverPermit<'_>, SessionError> {
+        if self.shutdown.load(Ordering::Acquire) {
+            // ET #798: do not start recover on a session that is already
+            // being torn down. Installing a candidate would resurrect it.
+            return Err(SessionError::Unavailable);
+        }
         if self
             .recovering
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
@@ -40,6 +45,13 @@ impl ActiveSession {
         // Phase 1: soft-disconnect and snapshot under a short lock.
         let mut candidate = {
             let connection = lock_timeout(&self.connection, RECOVERY_LOCK_TIMEOUT)?;
+            if self.shutdown.load(Ordering::Acquire) {
+                // ET #798: the session can be torn down while this reconnect
+                // is in flight. Do not snapshot onto a dead connection.
+                drop(connection);
+                let _ = stream.shutdown(Shutdown::Both);
+                return Err(SessionError::Unavailable);
+            }
             // Snapshot onto the new stream without closing or disconnecting
             // the live victim socket (ET #784 / ANT-2026-VAMER5RC). Terminal
             // output during the off-lock handshake is queued in
@@ -74,6 +86,12 @@ impl ActiveSession {
         {
             let mut control = lock_timeout(&self.control, RECOVERY_LOCK_TIMEOUT)?;
             let mut connection = lock_timeout(&self.connection, RECOVERY_LOCK_TIMEOUT)?;
+            if self.shutdown.load(Ordering::Acquire) {
+                drop(connection);
+                drop(control);
+                let _ = new_control.shutdown(Shutdown::Both);
+                return Err(SessionError::Unavailable);
+            }
             let old_control = std::mem::replace(&mut *control, new_control);
             let _ = old_control.shutdown(Shutdown::Both);
             *connection = candidate;

--- a/crates/et-server/src/session_recovery.rs
+++ b/crates/et-server/src/session_recovery.rs
@@ -16,9 +16,10 @@ impl ActiveSession {
     /// then fail with `RecoverBusy`. The permit releases the flag on drop
     /// (including panic unwind).
     pub(crate) fn try_begin_recover(&self) -> Result<RecoverPermit<'_>, SessionError> {
-        if self.shutdown.load(Ordering::Acquire) {
-            // ET #798: do not start recover on a session that is already
-            // being torn down. Installing a candidate would resurrect it.
+        if self.torn_down.load(Ordering::Acquire) {
+            // ET #798: do not start recover on a session that was fully
+            // torn down. `finish_terminal` / HUP must still be allowed to
+            // complete an in-flight recover so buffered output can drain.
             return Err(SessionError::Unavailable);
         }
         if self
@@ -45,7 +46,7 @@ impl ActiveSession {
         // Phase 1: soft-disconnect and snapshot under a short lock.
         let mut candidate = {
             let connection = lock_timeout(&self.connection, RECOVERY_LOCK_TIMEOUT)?;
-            if self.shutdown.load(Ordering::Acquire) {
+            if self.torn_down.load(Ordering::Acquire) {
                 // ET #798: the session can be torn down while this reconnect
                 // is in flight. Do not snapshot onto a dead connection.
                 drop(connection);
@@ -86,7 +87,7 @@ impl ActiveSession {
         {
             let mut control = lock_timeout(&self.control, RECOVERY_LOCK_TIMEOUT)?;
             let mut connection = lock_timeout(&self.connection, RECOVERY_LOCK_TIMEOUT)?;
-            if self.shutdown.load(Ordering::Acquire) {
+            if self.torn_down.load(Ordering::Acquire) {
                 drop(connection);
                 drop(control);
                 let _ = new_control.shutdown(Shutdown::Both);

--- a/crates/et-server/tests/runtime_recovery.rs
+++ b/crates/et-server/tests/runtime_recovery.rs
@@ -20,7 +20,9 @@ use et_net::handshake::client_request;
 use et_net::local_packet::{read_local_packet, write_local_packet};
 use et_server::SessionState;
 use prost::Message;
-use runtime_support::{default_payload, initialize, TestRuntime, ID_A, KEY_A, TIMEOUT};
+use runtime_support::{
+    default_payload, initialize, TestRuntime, ID_A, ID_B, KEY_A, KEY_B, TIMEOUT,
+};
 
 // Deadlock watchdog only. Success is driven by exact bridge-generation and
 // terminal-packet events, not by elapsed time.
@@ -552,6 +554,55 @@ fn concurrent_returning_recover_does_not_block_accept_path() {
         .unwrap();
     let forwarded = read_local_packet(&mut terminal).unwrap();
     assert_eq!(forwarded.payload(), b"post-concurrent");
+    server.runtime.shutdown().unwrap();
+}
+
+/// ET #798 AcceptStarvationTest: a recover stuck waiting for the sequence
+/// header must not prevent an unrelated new client from completing accept
+/// and handshake. et.rs already runs accept on its own thread and recover
+/// off the session-table lock; this pins that a fresh id still gets
+/// NewClient promptly.
+#[test]
+fn stuck_recover_still_accepts_unrelated_new_client() {
+    use std::time::Instant;
+
+    let mut server = TestRuntime::start();
+    let mut terminal_a = server.register(ID_A, KEY_A);
+    let _terminal_b = server.register(ID_B, KEY_B);
+    terminal_a.set_read_timeout(Some(TIMEOUT)).unwrap();
+    let (stream, response) = server.handshake(ID_A);
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+    let key = passkey_to_key(KEY_A).unwrap();
+    let (_client, initial) = initialize(stream, &key, default_payload());
+    assert_eq!(initial.error, None);
+    server
+        .handle
+        .wait_for_state(ID_A, SessionState::Active, TIMEOUT)
+        .unwrap();
+    let _ = read_local_packet(&mut terminal_a).unwrap();
+
+    let address = server.address;
+    let stall = thread::spawn(move || {
+        let mut stream = std::net::TcpStream::connect(address).unwrap();
+        runtime_support::bound(&stream);
+        write_proto(&mut stream, &client_request(ID_A)).unwrap();
+        let response: ConnectResponse = read_proto_limited(&mut stream, 64 * 1024).unwrap();
+        assert_eq!(response.status, Some(ConnectStatus::ReturningClient as i32));
+        thread::sleep(std::time::Duration::from_millis(400));
+        drop(stream);
+    });
+    thread::sleep(std::time::Duration::from_millis(50));
+
+    let started = Instant::now();
+    let (_fresh, response) = server.handshake(ID_B);
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(2),
+        "unrelated NewClient handshake took {:?} — accept path blocked behind recover",
+        started.elapsed()
+    );
+    assert_eq!(response.status, Some(ConnectStatus::NewClient as i32));
+
+    stall.join().unwrap();
     server.runtime.shutdown().unwrap();
 }
 

--- a/docs/upstream-factory.md
+++ b/docs/upstream-factory.md
@@ -19,7 +19,7 @@ This is a hybrid of three real rewrite factories — not a fourth invention:
 | --- | --- |
 | [`.github/upstream-pin.yml`](../.github/upstream-pin.yml) | Last reviewed release tag/SHA, default-branch **name**, protocol versions, last classified tip. **Pin ≠ ported.** |
 | [`.github/upstream-ledger.yml`](../.github/upstream-ledger.yml) | Every ET `master` commit after baseline `et-v7.0.0` / `7656a32a5bc15c6746726a27a5a4ba1e468fab6e`. |
-| [`docs/upstream-pin.md`](upstream-pin.md) | Human record of the pin and the current ledger. `#784` / `69b3353` is `ported` (et.rs [#31](https://github.com/minpeter/et.rs/pull/31) / `906a7ca`). `#788` / `b74a12e` stays `skip`. |
+| [`docs/upstream-pin.md`](upstream-pin.md) | Human record of the pin and the current ledger. `#784` / `69b3353` and `#798` / `50b961d` are `ported`. `#788`, `#801`, `#803`, and `#802` stay `skip`. |
 
 ## Release
 

--- a/docs/upstream-pin.md
+++ b/docs/upstream-pin.md
@@ -10,8 +10,9 @@ Canonical machine files:
 - Ledger (every `master` commit after baseline):
   [`.github/upstream-ledger.yml`](../.github/upstream-ledger.yml)
 
-Recorded 2026-08-21 from GitHub (`gh` / REST). Ledger classified 2026-08-22.
+Recorded 2026-08-21 from GitHub (`gh` / REST). Ledger classified 2026-09-02.
 `#784` marked `ported` after et.rs [#31](https://github.com/minpeter/et.rs/pull/31) / `906a7ca86691f00a82f88b99b21d7afceb07bf97`.
+`#798` marked `ported` in the et.rs accept-starvation port (this tree).
 
 | Field | Value |
 | --- | --- |
@@ -19,13 +20,13 @@ Recorded 2026-08-21 from GitHub (`gh` / REST). Ledger classified 2026-08-22.
 | Baseline / latest release tag | [`et-v7.0.0`](https://github.com/MisterTea/EternalTerminal/releases/tag/et-v7.0.0) |
 | Baseline / release commit | [`7656a32a5bc15c6746726a27a5a4ba1e468fab6e`](https://github.com/MisterTea/EternalTerminal/commit/7656a32a5bc15c6746726a27a5a4ba1e468fab6e) |
 | Default branch | `master` |
-| Pin tip (last classified) | [`b74a12efc567dbc1360ac0846f889c945a2eba60`](https://github.com/MisterTea/EternalTerminal/commit/b74a12efc567dbc1360ac0846f889c945a2eba60) (`#788`, 2026-08-07) |
+| Pin tip (last classified) | [`342c0dfb32882c94df6aa18092fc897015222c0b`](https://github.com/MisterTea/EternalTerminal/commit/342c0dfb32882c94df6aa18092fc897015222c0b) (`#802`, 2026-09-02) |
 | et.rs wire version | **protocol v6** (`PROTOCOL_VERSION = 6` in `crates/et-core/src/lib.rs`, README) |
 | ET wire version at this pin | still **protocol v6** (`PROTOCOL_VERSION = 6` in `src/base/Headers.hpp` on both `et-v7.0.0` and `master`) |
 
-`7656a32...master` is `ahead_by` 11. All 11 are classified. Unclassified would be drift.
+`7656a32...master` is `ahead_by` 15. All 15 are classified. Unclassified would be drift.
 
-## Ledger (classified 2026-08-22)
+## Ledger (classified 2026-09-02)
 
 | sha | date | kind | status | note |
 | --- | --- | --- | --- | --- |
@@ -40,6 +41,10 @@ Recorded 2026-08-21 from GitHub (`gh` / REST). Ledger classified 2026-08-22.
 | [`90711ad`](https://github.com/MisterTea/EternalTerminal/commit/90711ad421264db30dc5d05df4a37452b41a7667) | 2026-07-21 | ci | skip | #777 windows deploy |
 | [`69b3353`](https://github.com/MisterTea/EternalTerminal/commit/69b33537ab12f324cf619aca04dc483728dc30c3) | 2026-07-30 | security | **ported** | #784 handshake 4KiB, recover, unix-socket LPE. Landed in et.rs via #31 / 906a7ca. |
 | [`b74a12e`](https://github.com/MisterTea/EternalTerminal/commit/b74a12efc567dbc1360ac0846f889c945a2eba60) | 2026-08-07 | product | skip | #788 non-tty console keep-alive; not wire/security |
+| [`fcce839`](https://github.com/MisterTea/EternalTerminal/commit/fcce83924326ab5743878f2d58a534bd8a6bc22c) | 2026-09-01 | other | skip | #801 HTM/Windows/coverage; not et.rs server accept/reconnect |
+| [`50b961d`](https://github.com/MisterTea/EternalTerminal/commit/50b961d9e9eb6daf57d8a5ce9cae8f9209bffe44) | 2026-09-01 | security | **ported** | #798 accept starvation / stuck reconnect. PROTOCOL_VERSION stays 6. |
+| [`3e8db00`](https://github.com/MisterTea/EternalTerminal/commit/3e8db00cdccba4906ca1b995d3fd7c0650a9fac9) | 2026-09-01 | product | skip | #803 TIOCGWINSZ; Unix terminal-size observation only |
+| [`342c0df`](https://github.com/MisterTea/EternalTerminal/commit/342c0dfb32882c94df6aa18092fc897015222c0b) | 2026-09-02 | ci | skip | #802 Windows build/test parity; not a wire or server-lock change |
 
 ## Ported and residual
 
@@ -50,15 +55,28 @@ It landed in et.rs via [#31](https://github.com/minpeter/et.rs/pull/31) /
 displace on failure; unix-socket listen/connect as the session user).
 Wire stays protocol v6.
 
+[`50b961d`](https://github.com/MisterTea/EternalTerminal/commit/50b961d9e9eb6daf57d8a5ce9cae8f9209bffe44) (`#798`) is `status: ported`.
+It is a server lock/availability bug, not a protocol bump. Upstream held
+`classMutex` across blocking recover I/O so one stuck reconnect stopped
+every accept. et.rs already accepted on a dedicated thread and ran recover
+off the session-table lock with a single-flight permit; this port adds the
+remaining #798 semantics: refuse recover on a shutting-down session, and
+raise the TCP listen backlog from 32 to 128 (INI `[Networking] backlog`,
+non-positive falls back to 128). Wire stays protocol v6.
+
 Upstream left reconnect passkey-before-recover for a future
 `PROTOCOL_VERSION` bump; that residual is still unported. Do **not** treat
 this pin as a green light to bump `PROTOCOL_VERSION` or land a v7 port.
 
 [`b74a12e`](https://github.com/MisterTea/EternalTerminal/commit/b74a12efc567dbc1360ac0846f889c945a2eba60) (`#788`) stays `status: skip`
 (product, not wire/security).
+[`fcce839`](https://github.com/MisterTea/EternalTerminal/commit/fcce83924326ab5743878f2d58a534bd8a6bc22c) (`#801`),
+[`3e8db00`](https://github.com/MisterTea/EternalTerminal/commit/3e8db00cdccba4906ca1b995d3fd7c0650a9fac9) (`#803`), and
+[`342c0df`](https://github.com/MisterTea/EternalTerminal/commit/342c0dfb32882c94df6aa18092fc897015222c0b) (`#802`) stay `status: skip`
+(HTM/Windows/coverage, TIOCGWINSZ, Windows build).
 
 et.rs still claims **protocol v6**. EternalTerminal’s latest product release is
-**v7.0.0**, and `master` is eleven classified commits past that tag.
+**v7.0.0**, and `master` is fifteen classified commits past that tag.
 
 Review ports against the conflict policy in
 [`docs/upstream-factory.md`](upstream-factory.md). Gate any later port with

--- a/docs/upstream-pin.md
+++ b/docs/upstream-pin.md
@@ -12,7 +12,7 @@ Canonical machine files:
 
 Recorded 2026-08-21 from GitHub (`gh` / REST). Ledger classified 2026-09-02.
 `#784` marked `ported` after et.rs [#31](https://github.com/minpeter/et.rs/pull/31) / `906a7ca86691f00a82f88b99b21d7afceb07bf97`.
-`#798` marked `ported` in the et.rs accept-starvation port (this tree).
+`#798` marked `ported` after et.rs [#77](https://github.com/minpeter/et.rs/pull/77).
 
 | Field | Value |
 | --- | --- |
@@ -42,7 +42,7 @@ Recorded 2026-08-21 from GitHub (`gh` / REST). Ledger classified 2026-09-02.
 | [`69b3353`](https://github.com/MisterTea/EternalTerminal/commit/69b33537ab12f324cf619aca04dc483728dc30c3) | 2026-07-30 | security | **ported** | #784 handshake 4KiB, recover, unix-socket LPE. Landed in et.rs via #31 / 906a7ca. |
 | [`b74a12e`](https://github.com/MisterTea/EternalTerminal/commit/b74a12efc567dbc1360ac0846f889c945a2eba60) | 2026-08-07 | product | skip | #788 non-tty console keep-alive; not wire/security |
 | [`fcce839`](https://github.com/MisterTea/EternalTerminal/commit/fcce83924326ab5743878f2d58a534bd8a6bc22c) | 2026-09-01 | other | skip | #801 HTM/Windows/coverage; not et.rs server accept/reconnect |
-| [`50b961d`](https://github.com/MisterTea/EternalTerminal/commit/50b961d9e9eb6daf57d8a5ce9cae8f9209bffe44) | 2026-09-01 | security | **ported** | #798 accept starvation / stuck reconnect. PROTOCOL_VERSION stays 6. |
+| [`50b961d`](https://github.com/MisterTea/EternalTerminal/commit/50b961d9e9eb6daf57d8a5ce9cae8f9209bffe44) | 2026-09-01 | security | **ported** | #798 accept starvation / stuck reconnect. Landed in et.rs via #77. PROTOCOL_VERSION stays 6. |
 | [`3e8db00`](https://github.com/MisterTea/EternalTerminal/commit/3e8db00cdccba4906ca1b995d3fd7c0650a9fac9) | 2026-09-01 | product | skip | #803 TIOCGWINSZ; Unix terminal-size observation only |
 | [`342c0df`](https://github.com/MisterTea/EternalTerminal/commit/342c0dfb32882c94df6aa18092fc897015222c0b) | 2026-09-02 | ci | skip | #802 Windows build/test parity; not a wire or server-lock change |
 
@@ -56,6 +56,7 @@ displace on failure; unix-socket listen/connect as the session user).
 Wire stays protocol v6.
 
 [`50b961d`](https://github.com/MisterTea/EternalTerminal/commit/50b961d9e9eb6daf57d8a5ce9cae8f9209bffe44) (`#798`) is `status: ported`.
+It landed in et.rs via [#77](https://github.com/minpeter/et.rs/pull/77).
 It is a server lock/availability bug, not a protocol bump. Upstream held
 `classMutex` across blocking recover I/O so one stuck reconnect stopped
 every accept. et.rs already accepted on a dedicated thread and ran recover


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports [MisterTea/EternalTerminal#798](https://github.com/MisterTea/EternalTerminal/pull/798) (`50b961d`) into the Rust et.rs server. This is a **server lock/availability** bug, not a protocol bump. `PROTOCOL_VERSION` stays **6**.

Upstream `etserver` held a process-wide `classMutex` across blocking recover I/O, so one stuck reconnect stopped every accept. et.rs already:

- accepts on a dedicated thread (no `classMutex` around recover)
- runs recover off the session-table lock
- refuses a second in-flight recover for the same id (`RecoverBusy`)
- bounds the initial-payload wait (8s, stricter than upstream’s new 600s)

This PR adds the remaining #798 semantics:

- **Refuse recover only after full session teardown** (`torn_down`). Terminal HUP still uses `finish_terminal` so an in-flight reconnect can drain buffered output (et.rs-kept behavior; see `terminal_hup_after_returning_status_delivers_final_output_only_to_recovered_connection`).
- **Listen backlog 32 → 128**, overridable with `backlog` in `[Networking]` (non-positive falls back to 128).

## Upstream ledger

Classified the four `master` commits since pin `b74a12e` and moved the pin tip to `342c0df` (`#802`). Tags remain `et-v7.0.0`. No GHSA.

| SHA | PR | Status |
| --- | --- | --- |
| `fcce839` | #801 HTM/Windows/coverage | **skip** |
| `50b961d` | #798 accept starvation | **ported** (this PR) |
| `3e8db00` | #803 TIOCGWINSZ | **skip** |
| `342c0df` | #802 Windows build | **skip** |

Does not mix in #76 MOTD or #74 Version Packages. Does not merge C++ into Rust.

## Tests

- `recover_refuses_to_revive_a_shutting_down_session` (HUP still allowed; teardown refused)
- `stuck_recover_still_accepts_unrelated_new_client` (AcceptStarvationTest shape)
- listen-backlog default / explicit / non-positive fallback
- INI `[Networking] backlog` parsing

macOS CI flakes (not #798 semantics):

- `jumphost_drains_buffered_destination_packets_after_hup` now closes with a write-side FIN instead of linger-0 RST
- `real_tty_restores_termios_and_propagates_resize` retries when the helper wins the TCP handshake before registration

Gate: `cargo test --workspace`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6869949-7aa7-4479-84e3-d2f92f6315a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6869949-7aa7-4479-84e3-d2f92f6315a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports EternalTerminal #798 so a stuck reconnect no longer blocks unrelated accepts or revives a fully torn-down session. Recoveries during terminal HUP can still finish draining buffered output; if teardown wins the race, the candidate stream is closed.

- Raises the TCP listen backlog from 32 to 128; `[Networking] backlog` accepts positive overrides and falls back to 128 for non-positive values.
- Updates upstream tracking through #802: #798 is ported, while #801, #803, and #802 are skipped.
- `PROTOCOL_VERSION` remains 6; no migration is needed.
- Fixes two macOS CI flakes: the jumphost HUP fixture closes with a write-side FIN instead of linger-0 RST, which was dropping buffered bytes, and the TTY termios test retries when the helper wins the TCP handshake before registration.

<sup>Written for commit 09b8dbc7255a798299b7f97042859717e242a144. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

