### PR TITLE
Fix 0.0.20 release metadata

### DIFF
--- a/.tegami/port-eternal-terminal-798.md
+++ b/.tegami/port-eternal-terminal-798.md
@@ -1,0 +1,18 @@
+---
+packages:
+  et:
+    type: patch
+---
+
+## Port EternalTerminal #798 accept-starvation fix
+
+A stuck client reconnect no longer starves `etserver` accept. Recovery
+already ran off the session-table lock and refused a second in-flight
+reconnect for the same id; this port also refuses recover after full
+session teardown (so a torn-down session cannot be resurrected) while
+still allowing recover through terminal HUP so buffered output can
+drain. It also raises the TCP `listen(2)` backlog from 32 to 128,
+overridable with `backlog` in the `[Networking]` section of the server
+config. Non-positive values fall back to 128. `PROTOCOL_VERSION` stays
+6. Upstream `#801` / `#803` / `#802` (HTM/Windows/coverage, TIOCGWINSZ,
+Windows build) are classified `skip` and not ported.

--- a/crates/et-bin/CHANGELOG.md
+++ b/crates/et-bin/CHANGELOG.md
@@ -1,18 +1,3 @@
-## et@0.0.20
-
-### Port EternalTerminal #798 accept-starvation fix
-
-A stuck client reconnect no longer starves `etserver` accept. Recovery
-already ran off the session-table lock and refused a second in-flight
-reconnect for the same id; this port also refuses recover after full
-session teardown (so a torn-down session cannot be resurrected) while
-still allowing recover through terminal HUP so buffered output can
-drain. It also raises the TCP `listen(2)` backlog from 32 to 128,
-overridable with `backlog` in the `[Networking]` section of the server
-config. Non-positive values fall back to 128. `PROTOCOL_VERSION` stays
-6. Upstream `#801` / `#803` / `#802` (HTM/Windows/coverage, TIOCGWINSZ,
-Windows build) are classified `skip` and not ported.
-
 ## et@0.0.19
 
 ### Apply SSH configuration port forwarding


### PR DESCRIPTION
## Summary

- remove the prematurely committed 0.0.20 changelog section from PR #77
- represent PR #77 as a patch Tegami changeset
- let the Version Packages PR generate one complete 0.0.20 section

## Verification

- `python3 scripts/check-upstream-ledger.py` (15 classified, 0 unclassified)
- `node scripts/tegami.mts version --no-checks` in a clean temporary worktree
  - planned `et 0.0.19 → 0.0.20` from 5 changelogs
  - generated exactly one `## et@0.0.20` section containing all 5 notes
- `git diff --check`

Amp-Thread-ID: https://ampcode.com/threads/T-01a064f0-2995-7560-acb0-f4e550a875d8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 0.0.20 release metadata so the Version Packages PR generates one complete changelog section.

- Moves the prematurely committed 0.0.20 changelog entry from `crates/et-bin/CHANGELOG.md` into a new `.tegami/port-eternal-terminal-798.md` changeset as a patch for `et`.
- The 0.0.20 section now appears only once, generated by the versioning tooling instead of being hand-edited.

<sup>Written for commit 383da6254f37e361338bbedd20cc466451def9a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

