### PR TITLE
fix(client): reuse an existing SSH ControlMaster

### DIFF
--- a/.tegami/fix-bootstrap-ssh-fanout.md
+++ b/.tegami/fix-bootstrap-ssh-fanout.md
@@ -2,8 +2,27 @@
 et: patch
 ---
 
-Reuse an existing SSH ControlMaster during probe and bootstrap instead of
-forcing a fresh sshd connection for every ET session. Isolation of
-`RemoteCommand`, `PermitLocalCommand`, `SessionType`, and
-`ClearAllForwardings` is unchanged; ET still refuses to own or override a
-control socket from user `-o` flags.
+Give each ET SSH bootstrap a private ControlMaster and route its configuration
+query, login-shell probe, and terminal bootstrap through the ET-owned socket.
+The socket lives at `<short-temp>/et-ssh-<pid>-<serial>/master` in a mode-0700
+directory. ET asks OpenSSH to stop the master after bootstrap and removes the
+whole private directory; a startup failure falls back to ordinary independent
+SSH invocations. Long Unix temporary-directory paths fall back to `/tmp` so the
+socket remains below conservative `sockaddr_un` limits.
+
+User `ControlMaster` and `ControlPath` options remain filtered, so ET neither
+reuses nor removes a user's socket. Isolation remains forced with
+`ClearAllForwardings=yes`, `RemoteCommand=none`, `PermitLocalCommand=no`, and
+`SessionType=default`.
+
+Local OpenSSH 10.2 diagnosis against the machine's localhost sshd:
+
+- Baseline `ssh -vvv -G -T ... localhost` emitted no `Connecting to` or mux
+  line: `-G` is configuration-only and opens no TCP connection.
+- Baseline shell-probe and bootstrap-shaped commands each emitted
+  `debug1: Connecting to localhost [::1] port 22.`
+- Starting the ET-shaped master emitted one `Connecting to` line and
+  `new mux listener [.../master]`.
+- The probe and bootstrap through that socket emitted
+  `mux_client_request_session` and no `Connecting to` line.
+- `ssh -O exit` emitted `Exit request sent.`; the socket was absent afterward.

--- a/.tegami/fix-bootstrap-ssh-fanout.md
+++ b/.tegami/fix-bootstrap-ssh-fanout.md
@@ -1,0 +1,9 @@
+---
+et: patch
+---
+
+Reuse an existing SSH ControlMaster during probe and bootstrap instead of
+forcing a fresh sshd connection for every ET session. Isolation of
+`RemoteCommand`, `PermitLocalCommand`, `SessionType`, and
+`ClearAllForwardings` is unchanged; ET still refuses to own or override a
+control socket from user `-o` flags.

--- a/.tegami/fix-bootstrap-ssh-fanout.md
+++ b/.tegami/fix-bootstrap-ssh-fanout.md
@@ -2,27 +2,35 @@
 et: patch
 ---
 
-Give each ET SSH bootstrap a private ControlMaster and route its configuration
-query, login-shell probe, and terminal bootstrap through the ET-owned socket.
-The socket lives at `<short-temp>/et-ssh-<pid>-<serial>/master` in a mode-0700
-directory. ET asks OpenSSH to stop the master after bootstrap and removes the
-whole private directory; a startup failure falls back to ordinary independent
-SSH invocations. Long Unix temporary-directory paths fall back to `/tmp` so the
-socket remains below conservative `sockaddr_un` limits.
+Share SSH bootstrap transport connections across ET processes targeting the
+same effective destination. ET first runs the configuration-only query, then
+checks for a working user-configured ControlMaster without supplying a
+ControlPath. A working user master remains preferred and ET's operational
+commands use it unchanged.
 
-User `ControlMaster` and `ControlPath` options remain filtered, so ET neither
-reuses nor removes a user's socket. Isolation remains forced with
-`ClearAllForwardings=yes`, `RemoteCommand=none`, `PermitLocalCommand=no`, and
-`SessionType=default`.
+When no user master exists, ET hashes the effective SSH user, resolved host,
+resolved port, and jumphost into a stable 32-hex-character socket name under a
+mode-0700 per-user `et-ssh-<uid>` directory. Long Unix temporary-directory
+paths fall back to `/tmp`, keeping the complete socket path below a conservative
+90-byte `sockaddr_un` limit.
 
-Local OpenSSH 10.2 diagnosis against the machine's localhost sshd:
+An atomic destination-specific `.lock` directory serializes master startup.
+The lock holder checks the socket again before starting OpenSSH; contenders
+check that exact socket until the winner publishes it or releases the lock.
+This converges concurrent ET processes on one master rather than allowing a
+ControlMaster bind race. Master setup failures fall back to ordinary SSH
+invocations.
 
-- Baseline `ssh -vvv -G -T ... localhost` emitted no `Connecting to` or mux
-  line: `-G` is configuration-only and opens no TCP connection.
-- Baseline shell-probe and bootstrap-shaped commands each emitted
-  `debug1: Connecting to localhost [::1] port 22.`
-- Starting the ET-shaped master emitted one `Connecting to` line and
-  `new mux listener [.../master]`.
-- The probe and bootstrap through that socket emitted
-  `mux_client_request_session` and no `Connecting to` line.
-- `ssh -O exit` emitted `Exit request sent.`; the socket was absent afterward.
+The ET master uses `ControlPersist=15`. Sessions never send `ssh -O exit` and
+never unlink the shared socket, so one ET process cannot tear down transport
+used by another. OpenSSH removes the socket after the persisted master becomes
+idle; the private parent directory is retained for later destination masters.
+
+User `ControlMaster` and `ControlPath` command-line options remain filtered.
+Isolation remains forced with `ClearAllForwardings=yes`, `RemoteCommand=none`,
+`PermitLocalCommand=no`, and `SessionType=default`.
+
+Local OpenSSH diagnosis against localhost showed configuration and `-O check`
+operations open no TCP connections. A master start emitted one `Connecting to`
+line and a mux listener; probe and bootstrap operations emitted
+`mux_client_request_session` without a new `Connecting to` line.

--- a/crates/et-bin/Cargo.toml
+++ b/crates/et-bin/Cargo.toml
@@ -12,6 +12,13 @@ repository.workspace = true
 name = "et"
 path = "src/main.rs"
 
+# Test-only helper: binds a real UNIX socket for the fake ssh control master.
+[[bin]]
+name = "mksocket"
+path = "testbin/mksocket.rs"
+test = false
+doc = false
+
 [lints]
 workspace = true
 

--- a/crates/et-bin/src/bootstrap.rs
+++ b/crates/et-bin/src/bootstrap.rs
@@ -5,13 +5,19 @@ use crate::error::ClientError;
 const MARKER: &[u8] = b"IDPASSKEY:";
 const CREDENTIAL_LEN: usize = 16 + 1 + 32;
 pub const WINDOWS_SHELL_PROBE_SENTINEL: &str = "__ET_COMSPEC__";
-const OPERATIONAL_SSH_OPTIONS: [&str; 6] = [
+const OPERATIONAL_SSH_OPTIONS: [&str; 4] = [
     "ClearAllForwardings=yes",
     "RemoteCommand=none",
     "PermitLocalCommand=no",
-    "ControlMaster=no",
-    "ControlPath=none",
     "SessionType=default",
+];
+const FILTERED_SSH_OPTION_KEYS: [&str; 6] = [
+    "ClearAllForwardings",
+    "RemoteCommand",
+    "PermitLocalCommand",
+    "ControlMaster",
+    "ControlPath",
+    "SessionType",
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -221,11 +227,9 @@ fn is_forced_operational_option(option: &str) -> bool {
         .split(|character: char| character == '=' || character.is_ascii_whitespace())
         .next()
         .unwrap_or(option);
-    OPERATIONAL_SSH_OPTIONS.iter().any(|forced| {
-        forced
-            .split_once('=')
-            .is_some_and(|(forced_key, _)| key.eq_ignore_ascii_case(forced_key))
-    })
+    FILTERED_SSH_OPTION_KEYS
+        .iter()
+        .any(|filtered| key.eq_ignore_ascii_case(filtered))
 }
 
 pub fn parse_shell_probe(stdout: &[u8]) -> Result<RemoteShell, ClientError> {
@@ -435,8 +439,6 @@ mod tests {
             "ClearAllForwardings=yes",
             "RemoteCommand=none",
             "PermitLocalCommand=no",
-            "ControlMaster=no",
-            "ControlPath=none",
             "SessionType=default",
         ] {
             assert_eq!(
@@ -447,6 +449,98 @@ mod tests {
                     .count(),
                 1,
                 "operational SSH argv must force {option} exactly once: {:?}",
+                invocation.args
+            );
+        }
+        for key in ["ControlMaster", "ControlPath"] {
+            assert!(
+                !invocation.args.iter().any(|argument| {
+                    argument
+                        .trim_start_matches("-o")
+                        .split(['=', ' ', '\t'])
+                        .next()
+                        .is_some_and(|option_key| option_key.eq_ignore_ascii_case(key))
+                }),
+                "operational SSH argv must not disable or own {key}: {:?}",
+                invocation.args
+            );
+        }
+    }
+
+    #[test]
+    fn bootstrap_ssh_argv_does_not_disable_control_master_reuse() {
+        let mut request = request();
+        request.ssh_options.extend([
+            "ControlMaster=auto".to_owned(),
+            "ControlPath=~/.ssh/et-master".to_owned(),
+            "controlmaster yes".to_owned(),
+            "CONTROLPATH /tmp/et.sock".to_owned(),
+        ]);
+        let credentials = provisional_credentials().unwrap();
+        let destination = build_invocation(&request, &credentials);
+        let probe = build_shell_probe(&request);
+        let jump = build_jump_invocation(
+            &JumpBootstrapRequest {
+                jumphost: "jump.example".to_owned(),
+                destination_host: "destination.example".to_owned(),
+                destination_port: 2022,
+                jump_server_fifo: None,
+                terminal_path: None,
+                kill_other_sessions: false,
+                verbose: 0,
+                ssh_options: request.ssh_options.clone(),
+                term: "xterm-256color".to_owned(),
+            },
+            &credentials,
+        );
+
+        assert_eq!(
+            destination.args[0..6],
+            [
+                "-oClearAllForwardings=yes",
+                "-oRemoteCommand=none",
+                "-oPermitLocalCommand=no",
+                "-oSessionType=default",
+                "-oPort=2222",
+                "alice@server",
+            ]
+        );
+        assert_eq!(
+            &probe.args[0..7],
+            [
+                "-oClearAllForwardings=yes",
+                "-oRemoteCommand=none",
+                "-oPermitLocalCommand=no",
+                "-oSessionType=default",
+                "-oPort=2222",
+                "-oLogLevel=ERROR",
+                "alice@server",
+            ]
+        );
+        assert_eq!(
+            &jump.args[0..6],
+            [
+                "-oClearAllForwardings=yes",
+                "-oRemoteCommand=none",
+                "-oPermitLocalCommand=no",
+                "-oSessionType=default",
+                "-oPort=2222",
+                "jump.example",
+            ]
+        );
+        for invocation in [&destination, &probe, &jump] {
+            assert!(
+                !invocation.args.iter().any(|argument| {
+                    argument
+                        .trim_start_matches("-o")
+                        .split(['=', ' ', '\t'])
+                        .next()
+                        .is_some_and(|key| {
+                            key.eq_ignore_ascii_case("ControlMaster")
+                                || key.eq_ignore_ascii_case("ControlPath")
+                        })
+                }),
+                "bootstrap argv must not disable or own SSH multiplexing: {:?}",
                 invocation.args
             );
         }
@@ -579,20 +673,18 @@ mod tests {
         let invocation = build_invocation(&request(), &credentials);
         assert_eq!(invocation.program, "ssh");
         assert_eq!(
-            invocation.args[0..8],
+            invocation.args[0..6],
             [
                 "-oClearAllForwardings=yes",
                 "-oRemoteCommand=none",
                 "-oPermitLocalCommand=no",
-                "-oControlMaster=no",
-                "-oControlPath=none",
                 "-oSessionType=default",
                 "-oPort=2222",
                 "alice@server",
             ]
         );
         assert_eq!(
-            invocation.args[8],
+            invocation.args[6],
             "printf '%s\\n' 'XXXdefghijklmnop/ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef_xterm-256color' | 'etterminal' '--verbose=2'"
         );
     }
@@ -607,15 +699,13 @@ mod tests {
         req.jumphost = Some("jump.example,user@hop2".into());
         let invocation = build_invocation(&req, &credentials);
         assert_eq!(
-            invocation.args[0..10],
+            invocation.args[0..8],
             [
                 "-J",
                 "jump.example,user@hop2",
                 "-oClearAllForwardings=yes",
                 "-oRemoteCommand=none",
                 "-oPermitLocalCommand=no",
-                "-oControlMaster=no",
-                "-oControlPath=none",
                 "-oSessionType=default",
                 "-oPort=2222",
                 "alice@server",
@@ -770,21 +860,19 @@ mod tests {
         };
         let invocation = build_jump_invocation(&request, &credentials);
         assert_eq!(
-            invocation.args[0..10],
+            invocation.args[0..8],
             [
                 "-p",
                 "2200",
                 "-oClearAllForwardings=yes",
                 "-oRemoteCommand=none",
                 "-oPermitLocalCommand=no",
-                "-oControlMaster=no",
-                "-oControlPath=none",
                 "-oSessionType=default",
                 "-oStrictHostKeyChecking=no",
                 "user@jump.example"
             ]
         );
-        let command = &invocation.args[10];
+        let command = &invocation.args[8];
         assert!(command.contains("'--serverfifo=/tmp/jump.fifo'"));
         assert!(command.contains("'--jump'"));
         assert!(command.contains("'--dsthost=dst.internal'"));

--- a/crates/et-bin/src/bootstrap.rs
+++ b/crates/et-bin/src/bootstrap.rs
@@ -97,6 +97,7 @@ pub fn build_jump_invocation(
         args,
         operation: "starting the jumphost etterminal",
         completion: InvocationCompletion::Credentials,
+        control_path: None,
     }
 }
 
@@ -151,6 +152,9 @@ pub struct SshInvocation {
     pub args: Vec<String>,
     pub operation: &'static str,
     pub completion: InvocationCompletion,
+    /// An ET-owned multiplexing socket. SystemSsh must not kill arbitrary
+    /// holders of its stdout pipe, because the holder can be this master.
+    pub control_path: Option<std::path::PathBuf>,
 }
 
 pub fn provisional_credentials() -> Result<Credentials, ClientError> {
@@ -182,6 +186,7 @@ pub fn build_invocation(request: &BootstrapRequest, credentials: &Credentials) -
         args,
         operation: "starting the remote etterminal",
         completion: InvocationCompletion::Credentials,
+        control_path: None,
     }
 }
 
@@ -204,6 +209,7 @@ pub fn build_shell_probe(request: &BootstrapRequest) -> SshInvocation {
         args,
         operation: "detecting the remote login shell",
         completion: InvocationCompletion::ShellProbe,
+        control_path: None,
     }
 }
 
@@ -221,15 +227,24 @@ fn append_operational_options(args: &mut Vec<String>, options: &[String]) {
     );
 }
 
-fn is_forced_operational_option(option: &str) -> bool {
-    let key = option
-        .trim_start()
-        .split(|character: char| character == '=' || character.is_ascii_whitespace())
-        .next()
-        .unwrap_or(option);
+pub(crate) fn is_forced_operational_option(option: &str) -> bool {
+    let key = ssh_option_key(option);
     FILTERED_SSH_OPTION_KEYS
         .iter()
         .any(|filtered| key.eq_ignore_ascii_case(filtered))
+}
+
+pub(crate) fn is_control_option(option: &str) -> bool {
+    let key = ssh_option_key(option);
+    key.eq_ignore_ascii_case("ControlMaster") || key.eq_ignore_ascii_case("ControlPath")
+}
+
+fn ssh_option_key(option: &str) -> &str {
+    option
+        .trim_start()
+        .split(|character: char| character == '=' || character.is_ascii_whitespace())
+        .next()
+        .unwrap_or(option)
 }
 
 pub fn parse_shell_probe(stdout: &[u8]) -> Result<RemoteShell, ClientError> {

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -20,7 +20,9 @@ use crate::error::ClientError;
 use crate::initial_connect::{connect_initial, reconnect, Endpoint, ReconnectOutcome};
 use crate::resolver::{EndpointResolver, SystemResolver};
 use crate::ssh_config::resolve_ssh_config;
-use crate::ssh_process::{run_bootstrap, run_shell_probe, SshRunner, SshSession, SystemSsh};
+use crate::ssh_process::{
+    run_bootstrap, run_shell_probe, SshMasterTarget, SshRunner, SshSession, SystemSsh,
+};
 
 const RECONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const RECONNECT_RETRY_DELAY: Duration = Duration::from_secs(1);
@@ -136,22 +138,27 @@ fn run_client(
 
     let requested_user = command_user(destination.user, args.username.clone());
     validate_ssh_destination(&destination.host, requested_user.as_deref())?;
-    let mut ssh_session = SshSession::start(
-        runner,
-        &destination.host,
-        requested_user.as_deref(),
-        args.jumphost.as_deref(),
-        &args.ssh_option,
-        deadline,
-    );
     let resolved = resolve_ssh_config(
-        &ssh_session,
+        runner,
         &destination.host,
         requested_user.as_deref(),
         &args.ssh_option,
         true,
         deadline,
     )?;
+    let user = requested_user.or_else(|| resolved.user.clone());
+    let ssh_session = SshSession::start(
+        runner,
+        SshMasterTarget {
+            host_alias: &destination.host,
+            user: user.as_deref(),
+            resolved_host: &resolved.hostname,
+            resolved_port: resolved.port,
+            jumphost: args.jumphost.as_deref(),
+        },
+        &args.ssh_option,
+        deadline,
+    );
     forward_config.apply_ssh_config(&resolved)?;
     if args.jumphost.is_some() {
         bound_jumphost_locale_environment(
@@ -167,7 +174,6 @@ fn run_client(
     // tunnels can be multiplexed immediately (avoids pre-handshake accept races).
     let local_sources = forward_config.local_sources;
     let mut initial_payload = forward_config.initial_payload;
-    let user = requested_user.or(resolved.user);
     validate_ssh_destination(&destination.host, user.as_deref())?;
     let probe_request = BootstrapRequest {
         user: user.clone(),
@@ -240,23 +246,29 @@ fn run_client(
             .to_owned();
         let jump_user = Some(parsed_jump.user.as_str()).filter(|user| !user.is_empty());
         validate_ssh_destination(&jump_host, jump_user)?;
-        ssh_session.close();
-        ssh_session = SshSession::start(
-            runner,
-            &jump_host,
-            jump_user,
-            None,
-            &args.ssh_option,
-            deadline,
-        );
         let jump_resolved = resolve_ssh_config(
-            &ssh_session,
+            runner,
             &jump_host,
             jump_user,
             &args.ssh_option,
             false,
             deadline,
         )?;
+        let jump_effective_user = jump_user
+            .map(str::to_owned)
+            .or_else(|| jump_resolved.user.clone());
+        let jump_session = SshSession::start(
+            runner,
+            SshMasterTarget {
+                host_alias: &jump_host,
+                user: jump_effective_user.as_deref(),
+                resolved_host: &jump_resolved.hostname,
+                resolved_port: jump_resolved.port,
+                jumphost: None,
+            },
+            &args.ssh_option,
+            deadline,
+        );
         let jump_request = JumpBootstrapRequest {
             jumphost: jumphost.to_owned(),
             destination_host: endpoint.host.clone(),
@@ -269,7 +281,7 @@ fn run_client(
             term: request.term.clone(),
         };
         let jump_invocation = build_jump_invocation(&jump_request, &provisional);
-        credentials = run_bootstrap(&ssh_session, &jump_invocation, deadline)?;
+        credentials = run_bootstrap(&jump_session, &jump_invocation, deadline)?;
         endpoint = Endpoint {
             host: jump_resolved.hostname,
             port: args.jport,
@@ -278,7 +290,6 @@ fn run_client(
         // to the jump terminal instead of starting a shell.
         initial_payload.jumphost = Some(true);
     }
-    ssh_session.close();
     if remote_mode.terminal_shell == RemoteShellKind::Posix {
         initial_payload
             .environmentvariables

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -20,7 +20,7 @@ use crate::error::ClientError;
 use crate::initial_connect::{connect_initial, reconnect, Endpoint, ReconnectOutcome};
 use crate::resolver::{EndpointResolver, SystemResolver};
 use crate::ssh_config::resolve_ssh_config;
-use crate::ssh_process::{run_bootstrap, run_shell_probe, SshRunner, SystemSsh};
+use crate::ssh_process::{run_bootstrap, run_shell_probe, SshRunner, SshSession, SystemSsh};
 
 const RECONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const RECONNECT_RETRY_DELAY: Duration = Duration::from_secs(1);
@@ -136,8 +136,16 @@ fn run_client(
 
     let requested_user = command_user(destination.user, args.username.clone());
     validate_ssh_destination(&destination.host, requested_user.as_deref())?;
-    let resolved = resolve_ssh_config(
+    let mut ssh_session = SshSession::start(
         runner,
+        &destination.host,
+        requested_user.as_deref(),
+        args.jumphost.as_deref(),
+        &args.ssh_option,
+        deadline,
+    );
+    let resolved = resolve_ssh_config(
+        &ssh_session,
         &destination.host,
         requested_user.as_deref(),
         &args.ssh_option,
@@ -178,7 +186,7 @@ fn run_client(
         None
     } else {
         let probe = build_shell_probe(&probe_request);
-        Some(run_shell_probe(runner, &probe, deadline)?)
+        Some(run_shell_probe(&ssh_session, &probe, deadline)?)
     };
     let remote_mode = resolve_remote_mode(args, detected_shell);
     let provisional = provisional_credentials()?;
@@ -214,7 +222,7 @@ fn run_client(
     }
     let invocation = build_invocation(&request, &provisional);
     et_cli::logging::verbose(1, bootstrap_log_message(&request));
-    let mut credentials = run_bootstrap(runner, &invocation, deadline)?;
+    let mut credentials = run_bootstrap(&ssh_session, &invocation, deadline)?;
     et_cli::logging::info("etserver started");
     // Without a jumphost the ET connection goes straight to the destination.
     // With one, upstream starts a second `etterminal --jump` on the jumphost
@@ -232,8 +240,17 @@ fn run_client(
             .to_owned();
         let jump_user = Some(parsed_jump.user.as_str()).filter(|user| !user.is_empty());
         validate_ssh_destination(&jump_host, jump_user)?;
-        let jump_resolved = resolve_ssh_config(
+        ssh_session.close();
+        ssh_session = SshSession::start(
             runner,
+            &jump_host,
+            jump_user,
+            None,
+            &args.ssh_option,
+            deadline,
+        );
+        let jump_resolved = resolve_ssh_config(
+            &ssh_session,
             &jump_host,
             jump_user,
             &args.ssh_option,
@@ -252,7 +269,7 @@ fn run_client(
             term: request.term.clone(),
         };
         let jump_invocation = build_jump_invocation(&jump_request, &provisional);
-        credentials = run_bootstrap(runner, &jump_invocation, deadline)?;
+        credentials = run_bootstrap(&ssh_session, &jump_invocation, deadline)?;
         endpoint = Endpoint {
             host: jump_resolved.hostname,
             port: args.jport,
@@ -261,6 +278,7 @@ fn run_client(
         // to the jump terminal instead of starting a shell.
         initial_payload.jumphost = Some(true);
     }
+    ssh_session.close();
     if remote_mode.terminal_shell == RemoteShellKind::Posix {
         initial_payload
             .environmentvariables

--- a/crates/et-bin/src/client.rs
+++ b/crates/et-bin/src/client.rs
@@ -19,7 +19,7 @@ use crate::deadline::Deadline;
 use crate::error::ClientError;
 use crate::initial_connect::{connect_initial, reconnect, Endpoint, ReconnectOutcome};
 use crate::resolver::{EndpointResolver, SystemResolver};
-use crate::ssh_config::resolve_ssh_config;
+use crate::ssh_config::{resolve_ssh_config, resolve_ssh_config_on_port};
 use crate::ssh_process::{
     run_bootstrap, run_shell_probe, SshMasterTarget, SshRunner, SshSession, SystemSsh,
 };
@@ -138,6 +138,9 @@ fn run_client(
 
     let requested_user = command_user(destination.user, args.username.clone());
     validate_ssh_destination(&destination.host, requested_user.as_deref())?;
+    // The positional `host:port` is the ET server port, not an SSH port, so it
+    // must not be forwarded to the config query. Only the jumphost grammar
+    // below carries an explicit SSH port.
     let resolved = resolve_ssh_config(
         runner,
         &destination.host,
@@ -246,10 +249,24 @@ fn run_client(
             .to_owned();
         let jump_user = Some(parsed_jump.user.as_str()).filter(|user| !user.is_empty());
         validate_ssh_destination(&jump_host, jump_user)?;
-        let jump_resolved = resolve_ssh_config(
+        // An explicit `jump:2200` must reach the config query, because the
+        // resolved port is part of the control-master identity and the jump
+        // bootstrap emits `-p 2200`. Resolving without it would hash (and
+        // start) a master for port 22 and then force the 2200 session onto it.
+        let jump_explicit_port = parsed_jump
+            .port_suffix
+            .strip_prefix(':')
+            .map(|port| {
+                port.parse::<u16>()
+                    .map_err(|_| et_cli::host::HostError::BadPort(port.to_owned()))
+            })
+            .transpose()
+            .map_err(ClientError::Host)?;
+        let jump_resolved = resolve_ssh_config_on_port(
             runner,
             &jump_host,
             jump_user,
+            jump_explicit_port,
             &args.ssh_option,
             false,
             deadline,

--- a/crates/et-bin/src/forward_config_tests.rs
+++ b/crates/et-bin/src/forward_config_tests.rs
@@ -60,6 +60,7 @@ fn applying_ssh_config_preserves_agent_forwarding() {
     let resolved = ResolvedSshConfig {
         hostname: "host".to_owned(),
         user: None,
+        port: 22,
         exit_on_forward_failure: false,
         local_forwards: Vec::new(),
     };
@@ -106,6 +107,7 @@ fn exit_on_forward_failure_selects_local_bind_policy() {
             .apply_ssh_config(&ResolvedSshConfig {
                 hostname: "host".to_owned(),
                 user: None,
+                port: 22,
                 exit_on_forward_failure: strict,
                 local_forwards: vec![request.clone()],
             })
@@ -140,6 +142,7 @@ fn ssh_config_forwards_are_cumulative_stable_and_exactly_deduplicated() {
     let resolved = ResolvedSshConfig {
         hostname: "host".to_owned(),
         user: None,
+        port: 22,
         exit_on_forward_failure: false,
         local_forwards: vec![
             local_duplicate.clone(),

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -47,11 +47,39 @@ pub fn resolve_ssh_config(
     parse_local_forwards: bool,
     deadline: Deadline,
 ) -> Result<ResolvedSshConfig, ClientError> {
+    resolve_ssh_config_on_port(
+        runner,
+        host_alias,
+        requested_user,
+        None,
+        ssh_options,
+        parse_local_forwards,
+        deadline,
+    )
+}
+
+/// Resolve SSH configuration, honouring a port given explicitly on the command
+/// line (`host:port`). The explicit port must reach `ssh -G`, because the
+/// resolved port becomes part of the control-master identity: resolving
+/// without it yields the config/default port and would multiplex a session for
+/// `host:2200` through a master established for `host:22`.
+pub fn resolve_ssh_config_on_port(
+    runner: &dyn SshRunner,
+    host_alias: &str,
+    requested_user: Option<&str>,
+    explicit_port: Option<u16>,
+    ssh_options: &[String],
+    parse_local_forwards: bool,
+    deadline: Deadline,
+) -> Result<ResolvedSshConfig, ClientError> {
     validate_ssh_destination(host_alias, requested_user)?;
     // Config expansion never opens a remote session. Disable PTY allocation
     // so Windows OpenSSH completes reliably when stdout is a pipe, preserving
     // the bounded SystemSsh capture path.
     let mut args = vec!["-G".to_string(), "-T".to_string()];
+    if let Some(port) = explicit_port {
+        args.extend(["-p".to_string(), port.to_string()]);
+    }
     args.extend(
         ssh_options
             .iter()
@@ -442,6 +470,57 @@ mod tests {
                 exit_on_forward_failure: false,
                 local_forwards: Vec::new(),
             }
+        );
+    }
+
+    struct PortCapturingRunner {
+        args: std::sync::Mutex<Vec<String>>,
+    }
+
+    impl SshRunner for PortCapturingRunner {
+        fn run(&self, invocation: &SshInvocation, _: Deadline) -> Result<SshOutput, ClientError> {
+            self.args.lock().unwrap().clone_from(&invocation.args);
+            // `ssh -G` echoes the port it actually resolved. When an explicit
+            // `-p` is supplied, that is the port it reports.
+            let port = invocation
+                .args
+                .iter()
+                .position(|arg| arg == "-p")
+                .and_then(|index| invocation.args.get(index + 1))
+                .map_or("22", String::as_str);
+            Ok(SshOutput {
+                status: Some(success_status()),
+                stdout: format!(
+                    "host jump-alias\nuser config-user\nhostname 127.0.0.1\nport {port}\n"
+                )
+                .into_bytes(),
+            })
+        }
+    }
+
+    #[test]
+    fn explicit_port_reaches_the_config_query_and_the_resolved_port() {
+        let runner = PortCapturingRunner {
+            args: std::sync::Mutex::new(Vec::new()),
+        };
+        let resolved = resolve_ssh_config_on_port(
+            &runner,
+            "jump-alias",
+            None,
+            Some(2200),
+            &[],
+            false,
+            Deadline::after(Duration::from_secs(1)),
+        )
+        .unwrap();
+        let args = runner.args.lock().unwrap().clone();
+        assert!(
+            args.windows(2).any(|pair| pair == ["-p", "2200"]),
+            "explicit port must be passed to `ssh -G`: {args:?}"
+        );
+        assert_eq!(
+            resolved.port, 2200,
+            "resolved port must honour the explicit port, not the default"
         );
     }
 

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -29,6 +29,7 @@ struct ForwardPolicies {
 pub struct ResolvedSshConfig {
     pub hostname: String,
     pub user: Option<String>,
+    pub port: u16,
     pub exit_on_forward_failure: bool,
     pub local_forwards: Vec<PortForwardSourceRequest>,
 }
@@ -113,6 +114,7 @@ fn parse_ssh_config(
         .unwrap_or(false);
     let mut hostname = None;
     let mut user = None;
+    let mut port = None;
     let mut local_forwards = Vec::new();
     if parse_local_forwards {
         for _ in unsupported_dynamic_forwards(text) {
@@ -129,6 +131,9 @@ fn parse_ssh_config(
             }
             Some(key) if key.eq_ignore_ascii_case("user") => {
                 user = fields.next().map(str::to_string);
+            }
+            Some(key) if key.eq_ignore_ascii_case("port") => {
+                port = fields.next().and_then(|port| port.parse::<u16>().ok());
             }
             Some(key) if parse_local_forwards && key.eq_ignore_ascii_case("dynamicforward") => {}
             Some(key) if parse_local_forwards && key.eq_ignore_ascii_case("localforward") => {
@@ -150,6 +155,7 @@ fn parse_ssh_config(
     Ok(ResolvedSshConfig {
         hostname,
         user,
+        port: port.unwrap_or(22),
         exit_on_forward_failure,
         local_forwards,
     })
@@ -432,6 +438,7 @@ mod tests {
             ResolvedSshConfig {
                 hostname: "127.0.0.1".to_string(),
                 user: Some("config-user".to_string()),
+                port: 22,
                 exit_on_forward_failure: false,
                 local_forwards: Vec::new(),
             }

--- a/crates/et-bin/src/ssh_config.rs
+++ b/crates/et-bin/src/ssh_config.rs
@@ -1,4 +1,6 @@
-use crate::bootstrap::{validate_ssh_destination, InvocationCompletion, SshInvocation};
+use crate::bootstrap::{
+    is_control_option, validate_ssh_destination, InvocationCompletion, SshInvocation,
+};
 use crate::deadline::Deadline;
 use crate::error::ClientError;
 use crate::ssh_process::{run_checked, SshRunner};
@@ -49,7 +51,12 @@ pub fn resolve_ssh_config(
     // so Windows OpenSSH completes reliably when stdout is a pipe, preserving
     // the bounded SystemSsh capture path.
     let mut args = vec!["-G".to_string(), "-T".to_string()];
-    args.extend(ssh_options.iter().map(|option| format!("-o{option}")));
+    args.extend(
+        ssh_options
+            .iter()
+            .filter(|option| !is_control_option(option))
+            .map(|option| format!("-o{option}")),
+    );
     let destination = match requested_user {
         Some(user) => format!("{user}@{host_alias}"),
         None => host_alias.to_string(),
@@ -60,6 +67,7 @@ pub fn resolve_ssh_config(
         args,
         operation: "resolving SSH configuration",
         completion: InvocationCompletion::Exit,
+        control_path: None,
     };
     parse_ssh_config(
         &run_checked(runner, &invocation, deadline)?,

--- a/crates/et-bin/src/ssh_process.rs
+++ b/crates/et-bin/src/ssh_process.rs
@@ -105,6 +105,18 @@ impl<'a> SshSession<'a> {
             target.resolved_port,
             jumphost,
         ));
+        // Never hand ssh a path that already exists as something other than a
+        // socket, or as a symlink: fall back rather than "repairing" it, since
+        // removing another party's file is itself an attack primitive.
+        if !usable_control_socket(&path) {
+            et_cli::logging::warn(
+                "SSH control socket path is not a private socket; continuing without ET multiplexing",
+            );
+            return Self {
+                runner,
+                control_path: None,
+            };
+        }
         if check_master(
             runner,
             &destination,
@@ -359,11 +371,37 @@ fn create_private_directory(path: &Path) -> io::Result<()> {
 #[cfg(unix)]
 fn private_directory(path: &Path) -> bool {
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
+    // symlink_metadata, never metadata: the control root can live in a
+    // world-writable /tmp, where another user may plant a symlink under the
+    // name we expect. Following it would validate their target, not our path.
     std::fs::symlink_metadata(path).is_ok_and(|metadata| {
         metadata.is_dir()
             && metadata.uid() == rustix::process::getuid().as_raw()
             && metadata.permissions().mode() & 0o777 == 0o700
     })
+}
+
+/// Whether the multiplexing socket path is safe to hand to ssh.
+///
+/// An absent path is fine: ssh's own master creates it. Anything that already
+/// exists must be a real Unix socket and must not be a symlink, so a planted
+/// file, directory, or link cannot redirect our sessions. The parent directory
+/// is separately proven to be a uid-owned 0700 real directory, which is what
+/// keeps another *user* out; a same-uid process is inside our trust boundary
+/// either way (it can ptrace us), exactly as OpenSSH's own predictable
+/// `~/.ssh/cm-%r@%h:%p` ControlPaths already assume.
+#[cfg(unix)]
+fn usable_control_socket(path: &Path) -> bool {
+    use std::os::unix::fs::FileTypeExt;
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata.file_type().is_socket(),
+        Err(error) => error.kind() == io::ErrorKind::NotFound,
+    }
+}
+
+#[cfg(not(unix))]
+fn usable_control_socket(_path: &Path) -> bool {
+    true
 }
 
 #[cfg(not(unix))]
@@ -867,7 +905,17 @@ mod tests {
         let _ = std::fs::remove_dir_all(&temp);
         std::fs::create_dir(&temp).unwrap();
         let directory = control_directory_root(&temp);
-        create_private_directory(&directory).unwrap();
+        // `control_directory_root` falls back to the SHARED `/tmp/et-ssh-<uid>`
+        // when the temp path is too long for a socket, so this directory may
+        // already exist from another test or an earlier run. Only the resulting
+        // ownership and mode matter here, not who created it.
+        match create_private_directory(&directory) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                assert!(private_directory(&directory), "{directory:?}");
+            }
+            Err(error) => panic!("{directory:?}: {error}"),
+        }
         let path = directory.join(destination_hash("user", "host", 22, None));
         assert_eq!(
             std::fs::metadata(&directory).unwrap().permissions().mode() & 0o777,
@@ -877,6 +925,77 @@ mod tests {
             control_path_len(&path) <= MAX_CONTROL_PATH_BYTES,
             "{path:?}"
         );
+        std::fs::remove_dir_all(temp).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_control_root_is_refused() {
+        let temp = std::env::temp_dir().join(format!("et-symlink-root-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp);
+        std::fs::create_dir(&temp).unwrap();
+        // A directory the attacker owns, reached through a name we would trust.
+        let elsewhere = temp.join("elsewhere");
+        create_private_directory(&elsewhere).unwrap();
+        let link = temp.join("link");
+        std::os::unix::fs::symlink(&elsewhere, &link).unwrap();
+        // The symlink target is a perfectly good private directory, so any
+        // check that follows links is satisfied. It must still be refused.
+        assert!(
+            !private_directory(&link),
+            "a symlink must never be accepted as the control root"
+        );
+        std::fs::remove_dir_all(temp).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn control_socket_must_be_a_socket_and_not_a_symlink() {
+        let temp = std::env::temp_dir().join(format!("et-socket-check-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp);
+        create_private_directory(&temp).unwrap();
+
+        // Nothing there yet: usable, because ssh is the one that creates it.
+        let absent = temp.join("a".repeat(32));
+        assert!(usable_control_socket(&absent), "absent path must be usable");
+
+        // A planted regular file must not be handed to ssh.
+        let regular = temp.join("b".repeat(32));
+        std::fs::write(&regular, b"not a socket").unwrap();
+        assert!(
+            !usable_control_socket(&regular),
+            "a regular file must be refused"
+        );
+
+        // A directory must not be handed to ssh either.
+        let directory = temp.join("c".repeat(32));
+        std::fs::create_dir(&directory).unwrap();
+        assert!(
+            !usable_control_socket(&directory),
+            "a directory must be refused"
+        );
+
+        // A dangling symlink resolves to nothing, but must be refused on its
+        // own type rather than treated as an absent (creatable) path.
+        let dangling = temp.join("d".repeat(32));
+        std::os::unix::fs::symlink(temp.join("nowhere"), &dangling).unwrap();
+        assert!(
+            !usable_control_socket(&dangling),
+            "a dangling symlink must be refused"
+        );
+
+        // A symlink pointing at a real socket is the interesting case: the
+        // target passes every type check, so only symlink_metadata catches it.
+        let real = temp.join("e".repeat(32));
+        let _listener = std::os::unix::net::UnixListener::bind(&real).unwrap();
+        assert!(usable_control_socket(&real), "a real socket must be usable");
+        let to_socket = temp.join("f".repeat(32));
+        std::os::unix::fs::symlink(&real, &to_socket).unwrap();
+        assert!(
+            !usable_control_socket(&to_socket),
+            "a symlink to a socket must still be refused"
+        );
+
         std::fs::remove_dir_all(temp).unwrap();
     }
 

--- a/crates/et-bin/src/ssh_process.rs
+++ b/crates/et-bin/src/ssh_process.rs
@@ -1,5 +1,7 @@
 use std::io::{self, Read};
+use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdout, Command, ExitStatus, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, RecvTimeoutError};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
@@ -7,8 +9,8 @@ use std::time::Duration;
 use wait_timeout::ChildExt;
 
 use crate::bootstrap::{
-    parse_id_passkey, parse_shell_probe, Credentials, InvocationCompletion, RemoteShell,
-    SshInvocation,
+    is_forced_operational_option, parse_id_passkey, parse_shell_probe, Credentials,
+    InvocationCompletion, RemoteShell, SshInvocation,
 };
 use crate::deadline::Deadline;
 use crate::error::ClientError;
@@ -18,6 +20,10 @@ pub const MAX_SSH_STDOUT: usize = 1024 * 1024;
 // budget for SSH configuration, authentication, propagation of a structured
 // remote timeout, and cancellation cleanup.
 pub const DEFAULT_BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(120);
+// Darwin's sockaddr_un limit is 104 bytes and Linux's is 108. Keep room for
+// OpenSSH's trailing NUL and platform-specific handling.
+#[cfg(unix)]
+const MAX_CONTROL_PATH_BYTES: usize = 90;
 
 #[derive(Debug)]
 pub struct SshOutput {
@@ -51,6 +57,186 @@ impl SystemSsh {
     pub fn deadline(self) -> Deadline {
         Deadline::after(self.timeout)
     }
+}
+
+/// SSH runner scoped to one ET bootstrap. When its private master starts,
+/// every config query, probe, and bootstrap invocation is directed to that
+/// socket. A startup failure leaves the wrapped runner unchanged.
+pub struct SshSession<'a> {
+    runner: &'a dyn SshRunner,
+    master: Option<OwnedControlMaster>,
+}
+
+struct OwnedControlMaster {
+    directory: PathBuf,
+    path: PathBuf,
+    destination: String,
+}
+
+impl<'a> SshSession<'a> {
+    pub fn start(
+        runner: &'a dyn SshRunner,
+        host: &str,
+        user: Option<&str>,
+        jumphost: Option<&str>,
+        ssh_options: &[String],
+        deadline: Deadline,
+    ) -> Self {
+        let destination = user.map_or_else(|| host.to_owned(), |user| format!("{user}@{host}"));
+        let Some(directory) = create_control_directory() else {
+            et_cli::logging::warn("could not create private SSH control directory; continuing without ET multiplexing");
+            return Self {
+                runner,
+                master: None,
+            };
+        };
+        let path = directory.join("master");
+        let mut args = vec!["-MNf".to_owned()];
+        if let Some(jumphost) = jumphost {
+            args.extend(["-J".to_owned(), jumphost.to_owned()]);
+        }
+        args.extend([
+            "-oControlMaster=yes".to_owned(),
+            format!("-oControlPath={}", path.display()),
+            "-oControlPersist=no".to_owned(),
+            "-oClearAllForwardings=yes".to_owned(),
+            "-oRemoteCommand=none".to_owned(),
+            "-oPermitLocalCommand=no".to_owned(),
+            "-oSessionType=default".to_owned(),
+        ]);
+        args.extend(
+            ssh_options
+                .iter()
+                .filter(|option| !is_forced_operational_option(option))
+                .map(|option| format!("-o{option}")),
+        );
+        args.push(destination.clone());
+        let start = SshInvocation {
+            program: "ssh".to_owned(),
+            args,
+            operation: "starting the private SSH control master",
+            completion: InvocationCompletion::Exit,
+            control_path: None,
+        };
+        if run_checked(runner, &start, deadline).is_err() {
+            et_cli::logging::warn(
+                "private SSH control master failed to start; continuing without ET multiplexing",
+            );
+            let _ = std::fs::remove_dir_all(directory);
+            return Self {
+                runner,
+                master: None,
+            };
+        }
+        Self {
+            runner,
+            master: Some(OwnedControlMaster {
+                directory,
+                path,
+                destination,
+            }),
+        }
+    }
+
+    pub fn close(&mut self) {
+        let Some(master) = self.master.take() else {
+            return;
+        };
+        let stop = SshInvocation {
+            program: "ssh".to_owned(),
+            args: vec![
+                "-O".to_owned(),
+                "exit".to_owned(),
+                "-oControlMaster=no".to_owned(),
+                format!("-oControlPath={}", master.path.display()),
+                master.destination,
+            ],
+            operation: "stopping the private SSH control master",
+            completion: InvocationCompletion::Exit,
+            control_path: Some(master.path.clone()),
+        };
+        if run_checked(self.runner, &stop, Deadline::after(Duration::from_secs(5))).is_err() {
+            et_cli::logging::warn("private SSH control master did not stop cleanly");
+        }
+        let _ = std::fs::remove_dir_all(master.directory);
+    }
+}
+
+impl SshRunner for SshSession<'_> {
+    fn run(
+        &self,
+        invocation: &SshInvocation,
+        deadline: Deadline,
+    ) -> Result<SshOutput, ClientError> {
+        let Some(master) = self.master.as_ref() else {
+            return self.runner.run(invocation, deadline);
+        };
+        let mut invocation = invocation.clone();
+        let insertion = usize::from(invocation.args.first().is_some_and(|arg| arg == "-G")) * 2;
+        invocation.args.splice(
+            insertion..insertion,
+            [
+                "-oControlMaster=no".to_owned(),
+                format!("-oControlPath={}", master.path.display()),
+            ],
+        );
+        invocation.control_path = Some(master.path.clone());
+        self.runner.run(&invocation, deadline)
+    }
+}
+
+impl Drop for SshSession<'_> {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+fn create_control_directory() -> Option<PathBuf> {
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    let root = control_directory_root(&std::env::temp_dir());
+    for _ in 0..16 {
+        let serial = NEXT.fetch_add(1, Ordering::Relaxed);
+        let path = root.join(format!("et-ssh-{}-{serial}", std::process::id()));
+        if create_private_directory(&path).is_ok() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn control_directory_root(temp: &Path) -> PathBuf {
+    #[cfg(unix)]
+    {
+        let longest_path = temp
+            .join(format!("et-ssh-{}-{}", u32::MAX, u64::MAX))
+            .join("master");
+        if control_path_len(&longest_path) <= MAX_CONTROL_PATH_BYTES {
+            return temp.to_owned();
+        }
+        PathBuf::from("/tmp")
+    }
+    #[cfg(not(unix))]
+    {
+        temp.to_owned()
+    }
+}
+
+#[cfg(unix)]
+fn control_path_len(path: &Path) -> usize {
+    use std::os::unix::ffi::OsStrExt;
+    path.as_os_str().as_bytes().len()
+}
+
+#[cfg(unix)]
+fn create_private_directory(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+    let mut builder = std::fs::DirBuilder::new();
+    builder.mode(0o700).create(path)
+}
+
+#[cfg(not(unix))]
+fn create_private_directory(path: &Path) -> io::Result<()> {
+    std::fs::create_dir(path)
 }
 
 impl SshRunner for SystemSsh {
@@ -87,7 +273,11 @@ impl SshRunner for SystemSsh {
         };
         // Identify the stdout pipe so descendants that outlive ssh while still
         // holding it can be found even after they re-parent to init.
-        let pipe = pipe_identity(&stdout);
+        let pipe = invocation
+            .control_path
+            .is_none()
+            .then(|| pipe_identity(&stdout))
+            .flatten();
         let (receiver, reader) = match spawn_reader(stdout, invocation.completion) {
             Ok(reader) => reader,
             Err(error) => {
@@ -531,6 +721,31 @@ mod tests {
         ExitStatus::from_raw(code as u32)
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn private_control_directory_is_restrictive_and_socket_path_is_short() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = create_control_directory().unwrap();
+        let path = directory.join("master");
+        assert_eq!(
+            std::fs::metadata(&directory).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        assert!(
+            control_path_len(&path) <= MAX_CONTROL_PATH_BYTES,
+            "{path:?}"
+        );
+        std::fs::remove_dir(directory).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn long_temporary_directory_uses_short_control_root() {
+        let long_temp = PathBuf::from("/").join("x".repeat(MAX_CONTROL_PATH_BYTES + 1));
+        assert_eq!(control_directory_root(&long_temp), Path::new("/tmp"));
+    }
+
     struct ProbeRunner {
         status: i32,
         stdout: &'static [u8],
@@ -560,6 +775,7 @@ mod tests {
             args: Vec::new(),
             operation: "probe",
             completion: InvocationCompletion::ShellProbe,
+            control_path: None,
         };
         assert_eq!(
             run_shell_probe(
@@ -583,6 +799,7 @@ mod tests {
             args: Vec::new(),
             operation: "probe",
             completion: InvocationCompletion::ShellProbe,
+            control_path: None,
         };
         assert_eq!(
             run_shell_probe(
@@ -606,6 +823,7 @@ mod tests {
             args: Vec::new(),
             operation: "probe",
             completion: InvocationCompletion::ShellProbe,
+            control_path: None,
         };
         assert!(matches!(
             run_shell_probe(
@@ -685,6 +903,7 @@ mod tests {
             args: args.iter().map(|arg| (*arg).to_string()).collect(),
             operation: "testing bootstrap",
             completion: InvocationCompletion::Exit,
+            control_path: None,
         }
     }
 

--- a/crates/et-bin/src/ssh_process.rs
+++ b/crates/et-bin/src/ssh_process.rs
@@ -1,7 +1,6 @@
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdout, Command, ExitStatus, Stdio};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, RecvTimeoutError};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
@@ -59,106 +58,127 @@ impl SystemSsh {
     }
 }
 
-/// SSH runner scoped to one ET bootstrap. When its private master starts,
-/// every config query, probe, and bootstrap invocation is directed to that
-/// socket. A startup failure leaves the wrapped runner unchanged.
+/// SSH runner scoped to one ET bootstrap. It first preserves any working
+/// user-configured master, then converges on ET's destination-wide master.
 pub struct SshSession<'a> {
     runner: &'a dyn SshRunner,
-    master: Option<OwnedControlMaster>,
+    control_path: Option<PathBuf>,
 }
 
-struct OwnedControlMaster {
-    directory: PathBuf,
-    path: PathBuf,
-    destination: String,
+pub struct SshMasterTarget<'a> {
+    pub host_alias: &'a str,
+    pub user: Option<&'a str>,
+    pub resolved_host: &'a str,
+    pub resolved_port: u16,
+    pub jumphost: Option<&'a str>,
 }
 
 impl<'a> SshSession<'a> {
     pub fn start(
         runner: &'a dyn SshRunner,
-        host: &str,
-        user: Option<&str>,
-        jumphost: Option<&str>,
+        target: SshMasterTarget<'_>,
         ssh_options: &[String],
         deadline: Deadline,
     ) -> Self {
-        let destination = user.map_or_else(|| host.to_owned(), |user| format!("{user}@{host}"));
-        let Some(directory) = create_control_directory() else {
+        let destination = target.user.map_or_else(
+            || target.host_alias.to_owned(),
+            |user| format!("{user}@{}", target.host_alias),
+        );
+        let jumphost = target.jumphost;
+        if check_master(runner, &destination, jumphost, ssh_options, None, deadline) {
+            return Self {
+                runner,
+                control_path: None,
+            };
+        }
+
+        let Some(directory) = ensure_control_directory() else {
             et_cli::logging::warn("could not create private SSH control directory; continuing without ET multiplexing");
             return Self {
                 runner,
-                master: None,
+                control_path: None,
             };
         };
-        let path = directory.join("master");
-        let mut args = vec!["-MNf".to_owned()];
-        if let Some(jumphost) = jumphost {
-            args.extend(["-J".to_owned(), jumphost.to_owned()]);
-        }
-        args.extend([
-            "-oControlMaster=yes".to_owned(),
-            format!("-oControlPath={}", path.display()),
-            "-oControlPersist=no".to_owned(),
-            "-oClearAllForwardings=yes".to_owned(),
-            "-oRemoteCommand=none".to_owned(),
-            "-oPermitLocalCommand=no".to_owned(),
-            "-oSessionType=default".to_owned(),
-        ]);
-        args.extend(
-            ssh_options
-                .iter()
-                .filter(|option| !is_forced_operational_option(option))
-                .map(|option| format!("-o{option}")),
-        );
-        args.push(destination.clone());
-        let start = SshInvocation {
-            program: "ssh".to_owned(),
-            args,
-            operation: "starting the private SSH control master",
-            completion: InvocationCompletion::Exit,
-            control_path: None,
-        };
-        if run_checked(runner, &start, deadline).is_err() {
-            et_cli::logging::warn(
-                "private SSH control master failed to start; continuing without ET multiplexing",
-            );
-            let _ = std::fs::remove_dir_all(directory);
+        let path = directory.join(destination_hash(
+            target.user.unwrap_or(""),
+            target.resolved_host,
+            target.resolved_port,
+            jumphost,
+        ));
+        if check_master(
+            runner,
+            &destination,
+            jumphost,
+            ssh_options,
+            Some(&path),
+            deadline,
+        ) {
             return Self {
                 runner,
-                master: None,
+                control_path: Some(path),
             };
         }
+
+        let lock_path = path.with_extension("lock");
+        match StartupLock::acquire(lock_path.clone()) {
+            Some(_lock) => {
+                if !check_master(
+                    runner,
+                    &destination,
+                    jumphost,
+                    ssh_options,
+                    Some(&path),
+                    deadline,
+                ) && !start_master(runner, &destination, jumphost, ssh_options, &path, deadline)
+                {
+                    et_cli::logging::warn(
+                        "private SSH control master failed to start; continuing without ET multiplexing",
+                    );
+                    return Self {
+                        runner,
+                        control_path: None,
+                    };
+                }
+            }
+            None => {
+                let wait_started = std::time::Instant::now();
+                while lock_path.exists() && wait_started.elapsed() < Duration::from_secs(5) {
+                    if check_master(
+                        runner,
+                        &destination,
+                        jumphost,
+                        ssh_options,
+                        Some(&path),
+                        deadline,
+                    ) {
+                        return Self {
+                            runner,
+                            control_path: Some(path),
+                        };
+                    }
+                    let Some(remaining) = deadline.remaining() else {
+                        break;
+                    };
+                    let race_remaining =
+                        Duration::from_secs(5).saturating_sub(wait_started.elapsed());
+                    thread::sleep(remaining.min(race_remaining).min(Duration::from_millis(25)));
+                }
+            }
+        }
+
+        let control_path = check_master(
+            runner,
+            &destination,
+            jumphost,
+            ssh_options,
+            Some(&path),
+            deadline,
+        )
+        .then_some(path);
         Self {
             runner,
-            master: Some(OwnedControlMaster {
-                directory,
-                path,
-                destination,
-            }),
+            control_path,
         }
-    }
-
-    pub fn close(&mut self) {
-        let Some(master) = self.master.take() else {
-            return;
-        };
-        let stop = SshInvocation {
-            program: "ssh".to_owned(),
-            args: vec![
-                "-O".to_owned(),
-                "exit".to_owned(),
-                "-oControlMaster=no".to_owned(),
-                format!("-oControlPath={}", master.path.display()),
-                master.destination,
-            ],
-            operation: "stopping the private SSH control master",
-            completion: InvocationCompletion::Exit,
-            control_path: Some(master.path.clone()),
-        };
-        if run_checked(self.runner, &stop, Deadline::after(Duration::from_secs(5))).is_err() {
-            et_cli::logging::warn("private SSH control master did not stop cleanly");
-        }
-        let _ = std::fs::remove_dir_all(master.directory);
     }
 }
 
@@ -168,57 +188,159 @@ impl SshRunner for SshSession<'_> {
         invocation: &SshInvocation,
         deadline: Deadline,
     ) -> Result<SshOutput, ClientError> {
-        let Some(master) = self.master.as_ref() else {
+        let Some(path) = self.control_path.as_ref() else {
             return self.runner.run(invocation, deadline);
         };
         let mut invocation = invocation.clone();
-        let insertion = usize::from(invocation.args.first().is_some_and(|arg| arg == "-G")) * 2;
         invocation.args.splice(
-            insertion..insertion,
+            0..0,
             [
                 "-oControlMaster=no".to_owned(),
-                format!("-oControlPath={}", master.path.display()),
+                format!("-oControlPath={}", path.display()),
             ],
         );
-        invocation.control_path = Some(master.path.clone());
+        invocation.control_path = Some(path.clone());
         self.runner.run(&invocation, deadline)
     }
 }
 
-impl Drop for SshSession<'_> {
-    fn drop(&mut self) {
-        self.close();
+fn check_master(
+    runner: &dyn SshRunner,
+    destination: &str,
+    jumphost: Option<&str>,
+    ssh_options: &[String],
+    control_path: Option<&Path>,
+    deadline: Deadline,
+) -> bool {
+    let mut args = vec!["-O".to_owned(), "check".to_owned()];
+    if let Some(jumphost) = jumphost {
+        args.extend(["-J".to_owned(), jumphost.to_owned()]);
+    }
+    if let Some(path) = control_path {
+        args.extend([
+            "-oControlMaster=no".to_owned(),
+            format!("-oControlPath={}", path.display()),
+        ]);
+    }
+    append_master_options(&mut args, ssh_options);
+    args.push("-oLogLevel=QUIET".to_owned());
+    args.push(destination.to_owned());
+    run_checked(
+        runner,
+        &SshInvocation {
+            program: "ssh".to_owned(),
+            args,
+            operation: "checking for an SSH control master",
+            completion: InvocationCompletion::Exit,
+            control_path: control_path.map(Path::to_owned),
+        },
+        deadline,
+    )
+    .is_ok()
+}
+
+fn start_master(
+    runner: &dyn SshRunner,
+    destination: &str,
+    jumphost: Option<&str>,
+    ssh_options: &[String],
+    path: &Path,
+    deadline: Deadline,
+) -> bool {
+    let mut args = vec!["-MNf".to_owned()];
+    if let Some(jumphost) = jumphost {
+        args.extend(["-J".to_owned(), jumphost.to_owned()]);
+    }
+    args.extend([
+        "-oControlMaster=yes".to_owned(),
+        format!("-oControlPath={}", path.display()),
+        "-oControlPersist=15".to_owned(),
+    ]);
+    append_master_options(&mut args, ssh_options);
+    args.push(destination.to_owned());
+    run_checked(
+        runner,
+        &SshInvocation {
+            program: "ssh".to_owned(),
+            args,
+            operation: "starting the private SSH control master",
+            completion: InvocationCompletion::Exit,
+            control_path: None,
+        },
+        deadline,
+    )
+    .is_ok()
+}
+
+fn append_master_options(args: &mut Vec<String>, ssh_options: &[String]) {
+    args.extend([
+        "-oClearAllForwardings=yes".to_owned(),
+        "-oRemoteCommand=none".to_owned(),
+        "-oPermitLocalCommand=no".to_owned(),
+        "-oSessionType=default".to_owned(),
+    ]);
+    args.extend(
+        ssh_options
+            .iter()
+            .filter(|option| !is_forced_operational_option(option))
+            .map(|option| format!("-o{option}")),
+    );
+}
+
+struct StartupLock(PathBuf);
+
+impl StartupLock {
+    fn acquire(path: PathBuf) -> Option<Self> {
+        std::fs::create_dir(&path).ok().map(|()| Self(path))
     }
 }
 
-fn create_control_directory() -> Option<PathBuf> {
-    static NEXT: AtomicU64 = AtomicU64::new(0);
-    let root = control_directory_root(&std::env::temp_dir());
-    for _ in 0..16 {
-        let serial = NEXT.fetch_add(1, Ordering::Relaxed);
-        let path = root.join(format!("et-ssh-{}-{serial}", std::process::id()));
-        if create_private_directory(&path).is_ok() {
-            return Some(path);
-        }
+impl Drop for StartupLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir(&self.0);
     }
-    None
+}
+
+fn ensure_control_directory() -> Option<PathBuf> {
+    let path = control_directory_root(&std::env::temp_dir());
+    match create_private_directory(&path) {
+        Ok(()) => Some(path),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists && private_directory(&path) => {
+            Some(path)
+        }
+        Err(_) => None,
+    }
 }
 
 fn control_directory_root(temp: &Path) -> PathBuf {
     #[cfg(unix)]
-    {
-        let longest_path = temp
-            .join(format!("et-ssh-{}-{}", u32::MAX, u64::MAX))
-            .join("master");
-        if control_path_len(&longest_path) <= MAX_CONTROL_PATH_BYTES {
-            return temp.to_owned();
-        }
-        PathBuf::from("/tmp")
-    }
+    let suffix = format!("et-ssh-{}", rustix::process::getuid().as_raw());
     #[cfg(not(unix))]
-    {
-        temp.to_owned()
+    let suffix = "et-ssh";
+    let path = temp.join(&suffix);
+    #[cfg(unix)]
+    if control_path_len(&path.join("0".repeat(32))) > MAX_CONTROL_PATH_BYTES {
+        return PathBuf::from("/tmp").join(suffix);
     }
+    path
+}
+
+fn destination_hash(user: &str, host: &str, port: u16, jumphost: Option<&str>) -> String {
+    const OFFSET: u128 = 0x6c62_272e_07bb_0142_62b8_2175_6295_c58d;
+    const PRIME: u128 = 0x0000_0000_0100_0000_0000_0000_0000_013b;
+    let mut hash = OFFSET;
+    for value in [
+        user,
+        &host.to_ascii_lowercase(),
+        &port.to_string(),
+        jumphost.unwrap_or(""),
+    ] {
+        for byte in value.len().to_be_bytes().into_iter().chain(value.bytes()) {
+            hash ^= u128::from(byte);
+            hash = hash.wrapping_mul(PRIME);
+        }
+    }
+    format!("{hash:032x}")
 }
 
 #[cfg(unix)]
@@ -234,9 +356,24 @@ fn create_private_directory(path: &Path) -> io::Result<()> {
     builder.mode(0o700).create(path)
 }
 
+#[cfg(unix)]
+fn private_directory(path: &Path) -> bool {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+    std::fs::symlink_metadata(path).is_ok_and(|metadata| {
+        metadata.is_dir()
+            && metadata.uid() == rustix::process::getuid().as_raw()
+            && metadata.permissions().mode() & 0o777 == 0o700
+    })
+}
+
 #[cfg(not(unix))]
 fn create_private_directory(path: &Path) -> io::Result<()> {
     std::fs::create_dir(path)
+}
+
+#[cfg(not(unix))]
+fn private_directory(path: &Path) -> bool {
+    path.is_dir()
 }
 
 impl SshRunner for SystemSsh {
@@ -726,8 +863,12 @@ mod tests {
     fn private_control_directory_is_restrictive_and_socket_path_is_short() {
         use std::os::unix::fs::PermissionsExt;
 
-        let directory = create_control_directory().unwrap();
-        let path = directory.join("master");
+        let temp = std::env::temp_dir().join(format!("et-control-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp);
+        std::fs::create_dir(&temp).unwrap();
+        let directory = control_directory_root(&temp);
+        create_private_directory(&directory).unwrap();
+        let path = directory.join(destination_hash("user", "host", 22, None));
         assert_eq!(
             std::fs::metadata(&directory).unwrap().permissions().mode() & 0o777,
             0o700
@@ -736,14 +877,17 @@ mod tests {
             control_path_len(&path) <= MAX_CONTROL_PATH_BYTES,
             "{path:?}"
         );
-        std::fs::remove_dir(directory).unwrap();
+        std::fs::remove_dir_all(temp).unwrap();
     }
 
     #[cfg(unix)]
     #[test]
     fn long_temporary_directory_uses_short_control_root() {
         let long_temp = PathBuf::from("/").join("x".repeat(MAX_CONTROL_PATH_BYTES + 1));
-        assert_eq!(control_directory_root(&long_temp), Path::new("/tmp"));
+        assert_eq!(
+            control_directory_root(&long_temp),
+            Path::new("/tmp").join(format!("et-ssh-{}", rustix::process::getuid().as_raw()))
+        );
     }
 
     struct ProbeRunner {

--- a/crates/et-bin/testbin/mksocket.rs
+++ b/crates/et-bin/testbin/mksocket.rs
@@ -1,0 +1,33 @@
+//! Binds a UNIX socket at the given path so the fake `ssh` in the bootstrap
+//! tests creates the same object type real `ssh -MNf` does. A regular file is
+//! refused by the client's socket validation, which would make every later
+//! session fall back and stop exercising multiplexing.
+
+fn main() {
+    let mut args = std::env::args_os().skip(1);
+    let Some(path) = args.next() else {
+        eprintln!("usage: mksocket <path>");
+        std::process::exit(2);
+    };
+
+    #[cfg(unix)]
+    {
+        let listener = match std::os::unix::net::UnixListener::bind(&path) {
+            Ok(listener) => listener,
+            Err(error) => {
+                eprintln!("mksocket: bind failed: {error}");
+                std::process::exit(1);
+            }
+        };
+        // The socket file must outlive this process, like a real master's does.
+        std::mem::forget(listener);
+    }
+
+    #[cfg(not(unix))]
+    {
+        if let Err(error) = std::fs::write(&path, []) {
+            eprintln!("mksocket: write failed: {error}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -49,6 +49,22 @@ struct FakeSsh {
     stdin: PathBuf,
 }
 
+impl Drop for FakeSsh {
+    fn drop(&mut self) {
+        for invocation in self.invocations() {
+            for argument in invocation {
+                if let Some(path) = argument.strip_prefix("-oControlPath=") {
+                    let path = std::path::Path::new(path);
+                    let _ = fs::remove_file(path);
+                    if let Some(parent) = path.parent() {
+                        let _ = fs::remove_dir(parent);
+                    }
+                }
+            }
+        }
+    }
+}
+
 impl FakeSsh {
     fn new() -> Self {
         let dir = TestDir::new("ssh");
@@ -64,6 +80,13 @@ for arg in "$@"; do
   case "$arg" in -oControlPath=*) control_path=${arg#-oControlPath=} ;; esac
 done
 printf "\0" >> "$ET_FAKE_ARGV"
+if [ "$1" = "-O" ] && [ "$2" = "check" ]; then
+  if [ -n "$control_path" ]; then
+    [ -e "$control_path" ] && exit 0
+    exit 255
+  fi
+  exit "${ET_FAKE_USER_MASTER_EXIT:-255}"
+fi
 if [ "$1" = "-MNf" ]; then
   if [ "${ET_FAKE_MASTER_EXIT:-0}" -ne 0 ]; then
     exit "$ET_FAKE_MASTER_EXIT"
@@ -103,6 +126,7 @@ exit "$ET_FAKE_EXIT"
         command
             .env_clear()
             .env("PATH", &self.dir.0)
+            .env("TMPDIR", &self.dir.0)
             .env("ET_FAKE_ARGV", &self.argv)
             .env("ET_FAKE_STDIN", &self.stdin)
             .env("ET_FAKE_CONFIG", config)
@@ -112,6 +136,7 @@ exit "$ET_FAKE_EXIT"
             .env("ET_FAKE_PROBE_STDOUT", "__ET_COMSPEC__%ComSpec%\n")
             .env("ET_FAKE_PROBE_EXIT", "0")
             .env("ET_FAKE_MASTER_EXIT", "0")
+            .env("ET_FAKE_USER_MASTER_EXIT", "255")
             .stdin(Stdio::null());
         command
     }
@@ -494,18 +519,22 @@ fn bootstrap_ssh_invocations_share_a_private_session_control_path() {
     assert!(output.status.success(), "{}", stderr(&output));
 
     let invocations = fake.invocations();
-    assert_eq!(invocations.len(), 5, "{invocations:?}");
+    assert_eq!(invocations.len(), 8, "{invocations:?}");
+    assert_eq!(invocations[0], ["-G", "-T", "server-alias"]);
+    assert_eq!(&invocations[1][..2], ["-O", "check"]);
+    assert!(invocations[1]
+        .iter()
+        .all(|arg| !arg.starts_with("-oControlPath=")));
 
-    let control_argument = invocations[0]
+    let control_argument = invocations[4]
         .iter()
         .find(|arg| arg.starts_with("-oControlPath="))
         .expect("master start must name a ControlPath");
     let control_path = control_argument.strip_prefix("-oControlPath=").unwrap();
     let path = std::path::Path::new(control_path);
-    assert_eq!(
-        path.file_name().and_then(|name| name.to_str()),
-        Some("master")
-    );
+    let file_name = path.file_name().and_then(|name| name.to_str()).unwrap();
+    assert_eq!(file_name.len(), 32);
+    assert!(file_name.bytes().all(|byte| byte.is_ascii_hexdigit()));
     assert!(path
         .parent()
         .and_then(|dir| dir.file_name())
@@ -513,47 +542,80 @@ fn bootstrap_ssh_invocations_share_a_private_session_control_path() {
         .is_some_and(|name| name.starts_with("et-ssh-")));
     assert!(path.is_absolute(), "{path:?}");
 
-    assert_eq!(invocations[0][0], "-MNf");
-    assert!(invocations[0]
+    assert_eq!(invocations[4][0], "-MNf");
+    assert!(invocations[4]
         .iter()
         .any(|arg| arg == "-oControlMaster=yes"));
-    assert!(invocations[0]
+    assert!(invocations[4]
         .iter()
-        .any(|arg| arg == "-oControlPersist=no"));
-    assert_eq!(invocations[0].last().unwrap(), "server-alias");
+        .any(|arg| arg == "-oControlPersist=15"));
+    assert_eq!(invocations[4].last().unwrap(), "config-user@server-alias");
 
     let private_options = ["-oControlMaster=no", control_argument.as_str()];
-    assert_eq!(
-        &invocations[1][..4],
-        ["-G", "-T", private_options[0], private_options[1]]
-    );
-    for invocation in &invocations[2..=3] {
+    for invocation in [&invocations[2], &invocations[3], &invocations[5]] {
+        assert_eq!(
+            &invocation[..4],
+            ["-O", "check", private_options[0], private_options[1]]
+        );
+    }
+    for invocation in &invocations[6..=7] {
         assert_eq!(&invocation[..2], private_options);
     }
-    assert!(invocations[2]
+    assert!(invocations[6]
         .last()
         .unwrap()
         .contains(WINDOWS_PROBE_SENTINEL));
-    assert!(invocations[3].last().unwrap().starts_with("printf '%s\\n'"));
+    assert!(invocations[7].last().unwrap().starts_with("printf '%s\\n'"));
+    assert!(
+        path.exists(),
+        "ControlPersist socket did not survive the session"
+    );
+}
 
-    assert_eq!(
-        invocations[4],
-        [
-            "-O",
-            "exit",
-            "-oControlMaster=no",
-            control_argument,
-            "server-alias",
-        ]
-    );
-    assert!(
-        !path.exists(),
-        "private control path survived cleanup: {path:?}"
-    );
-    assert!(
-        !path.parent().unwrap().exists(),
-        "private control directory survived cleanup: {path:?}"
-    );
+#[test]
+fn control_path_is_stable_for_a_destination_and_distinct_between_destinations() {
+    let fake = FakeSsh::new();
+    let mut paths = Vec::new();
+    for (destination, config) in [
+        ("server-alias", RESOLVED_CONFIG),
+        ("server-alias", RESOLVED_CONFIG),
+        (
+            "other-alias",
+            "host other-alias\nuser other-user\nhostname 127.0.0.1\nport 22\n",
+        ),
+    ] {
+        let before = fake.invocations().len();
+        let (port, server) = initial_payload_server();
+        let output = fake
+            .command(config, VALID_MARKER, 0, "")
+            .args(["-N", &format!("{destination}:{port}")])
+            .output()
+            .unwrap();
+        server.join().unwrap();
+        assert!(output.status.success(), "{}", stderr(&output));
+        let invocation = fake.invocations();
+        let session_paths = invocation[before..]
+            .iter()
+            .flat_map(|argv| argv.iter())
+            .filter_map(|arg| arg.strip_prefix("-oControlPath="))
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(session_paths.len(), 1, "{invocation:?}");
+        paths.push((*session_paths.first().unwrap()).to_owned());
+    }
+    assert_eq!(paths.len(), 3, "{paths:?}");
+    assert_eq!(paths[0], paths[1], "same destination: {paths:?}");
+    assert_ne!(paths[0], paths[2], "different destinations: {paths:?}");
+    for path in paths {
+        let file_name = std::path::Path::new(&path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap();
+        assert_eq!(file_name.len(), 32, "{path}");
+        assert!(
+            file_name.bytes().all(|byte| byte.is_ascii_hexdigit()),
+            "{path}"
+        );
+    }
 }
 
 #[test]
@@ -570,9 +632,11 @@ fn bootstrap_falls_back_when_private_control_master_fails() {
     assert!(output.status.success(), "{}", stderr(&output));
 
     let invocations = fake.invocations();
-    assert_eq!(invocations.len(), 4, "{invocations:?}");
-    assert_eq!(invocations[0][0], "-MNf");
-    for invocation in &invocations[1..] {
+    assert_eq!(invocations.len(), 7, "{invocations:?}");
+    assert_eq!(invocations[0][0], "-G");
+    assert_eq!(&invocations[1][..2], ["-O", "check"]);
+    assert_eq!(invocations[4][0], "-MNf");
+    for invocation in &invocations[5..] {
         assert!(
             invocation
                 .iter()
@@ -580,15 +644,34 @@ fn bootstrap_falls_back_when_private_control_master_fails() {
             "fallback invocation unexpectedly uses ET control socket: {invocation:?}"
         );
     }
-    let control_path = invocations[0]
+    let control_path = invocations[4]
         .iter()
         .find_map(|arg| arg.strip_prefix("-oControlPath="))
         .unwrap();
     assert!(!std::path::Path::new(control_path).exists());
-    assert!(!std::path::Path::new(control_path)
-        .parent()
-        .unwrap()
-        .exists());
+}
+
+#[test]
+fn working_user_control_master_is_preferred_without_overriding_its_path() {
+    let (port, server) = initial_payload_server();
+    let fake = FakeSsh::new();
+    let output = fake
+        .command(RESOLVED_CONFIG, VALID_MARKER, 0, "")
+        .env("ET_FAKE_USER_MASTER_EXIT", "0")
+        .args(["-N", &format!("server-alias:{port}")])
+        .output()
+        .unwrap();
+    server.join().unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+
+    let invocations = fake.invocations();
+    assert_eq!(invocations.len(), 4, "{invocations:?}");
+    assert_eq!(invocations[0], ["-G", "-T", "server-alias"]);
+    assert_eq!(&invocations[1][..2], ["-O", "check"]);
+    assert!(invocations
+        .iter()
+        .flatten()
+        .all(|arg| arg != "-MNf" && !arg.starts_with("-oControlPath=")));
 }
 
 const WINDOWS_PROBE_SENTINEL: &str = "__ET_COMSPEC__";

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -92,7 +92,9 @@ if [ "$1" = "-MNf" ]; then
     exit "$ET_FAKE_MASTER_EXIT"
   fi
   if [ -n "$control_path" ]; then
-    : > "$control_path"
+    # Real ssh -MNf creates a UNIX SOCKET, and the client refuses anything
+    # else, so a regular file here would make every later session fall back.
+    "$ET_FAKE_MKSOCKET" "$control_path" || exit 255
   fi
 fi
 if [ "$1" = "-G" ]; then
@@ -137,6 +139,7 @@ exit "$ET_FAKE_EXIT"
             .env("ET_FAKE_PROBE_EXIT", "0")
             .env("ET_FAKE_MASTER_EXIT", "0")
             .env("ET_FAKE_USER_MASTER_EXIT", "255")
+            .env("ET_FAKE_MKSOCKET", env!("CARGO_BIN_EXE_mksocket"))
             .stdin(Stdio::null());
         command
     }
@@ -605,6 +608,24 @@ fn control_path_is_stable_for_a_destination_and_distinct_between_destinations() 
     assert_eq!(paths.len(), 3, "{paths:?}");
     assert_eq!(paths[0], paths[1], "same destination: {paths:?}");
     assert_ne!(paths[0], paths[2], "different destinations: {paths:?}");
+    // Equality alone cannot prove the path is pid-free: every case above runs
+    // in ONE `et` process per invocation, and repeated invocations would each
+    // embed their own pid, so a pid-bearing path could still compare equal to
+    // itself. Assert the absence of any per-process or per-call component
+    // directly, so a master cannot silently become per-session again.
+    let pids = fake
+        .invocations()
+        .iter()
+        .flat_map(|argv| argv.iter())
+        .filter_map(|arg| arg.strip_prefix("-oControlPath="))
+        .filter_map(|path| std::path::Path::new(path).file_name()?.to_str())
+        .map(str::to_owned)
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        pids.len(),
+        2,
+        "exactly two distinct destinations were used: {pids:?}"
+    );
     for path in paths {
         let file_name = std::path::Path::new(&path)
             .file_name()
@@ -615,7 +636,92 @@ fn control_path_is_stable_for_a_destination_and_distinct_between_destinations() 
             file_name.bytes().all(|byte| byte.is_ascii_hexdigit()),
             "{path}"
         );
+        // The 32-hex basename is a hash, so a decimal pid cannot appear
+        // literally; check the whole path, which is where a pid or a serial
+        // would realistically be appended.
+        assert!(
+            !path.contains(&std::process::id().to_string()),
+            "ControlPath must not embed the client pid: {path}"
+        );
+        for serial in 0..4u32 {
+            assert!(
+                !file_name.ends_with(&format!(".{serial}")),
+                "ControlPath must not embed a per-call serial: {path}"
+            );
+        }
     }
+}
+
+/// A hostile (or merely stale-and-wrong) object at the control socket path is
+/// refused, and the session still completes over unmultiplexed SSH instead of
+/// failing. Runs the real client end-to-end, so it proves the refusal is wired
+/// into the bootstrap path and not just into the helper.
+#[cfg(unix)]
+#[test]
+fn bootstrap_falls_back_when_control_socket_path_is_not_a_socket() {
+    // First run: learn the exact path this destination hashes to.
+    let fake = FakeSsh::new();
+    let (probe_port, probe_server) = initial_payload_server();
+    let probe = fake
+        .command(RESOLVED_CONFIG, VALID_MARKER, 0, "")
+        .args(["-N", &format!("server-alias:{probe_port}")])
+        .output()
+        .unwrap();
+    probe_server.join().unwrap();
+    assert!(probe.status.success(), "{}", stderr(&probe));
+    let control_path = fake
+        .invocations()
+        .iter()
+        .flat_map(|argv| argv.iter())
+        .find_map(|arg| arg.strip_prefix("-oControlPath="))
+        .expect("first run must establish an ET control path")
+        .to_owned();
+    // Replace the socket with a regular file: exactly what a planted or stale
+    // non-socket object looks like at the predictable path. The guard removes
+    // it even if an assertion below panics, because the control root may be
+    // the shared /tmp fallback where a leftover non-socket would make sibling
+    // tests refuse their own correctly hashed path.
+    struct Planted(String);
+    impl Drop for Planted {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+    let _ = std::fs::remove_file(&control_path);
+    std::fs::write(&control_path, b"not a socket").unwrap();
+    let planted_guard = Planted(control_path.clone());
+
+    // Second run: must refuse the path and still succeed unmultiplexed.
+    let (port, server) = initial_payload_server();
+    let before = fake.invocations().len();
+    let output = fake
+        .command(RESOLVED_CONFIG, VALID_MARKER, 0, "")
+        .args(["-N", &format!("server-alias:{port}")])
+        .output()
+        .unwrap();
+    server.join().unwrap();
+    assert!(
+        output.status.success(),
+        "a refused control socket must not fail the session: {}",
+        stderr(&output)
+    );
+    let invocations = fake.invocations();
+    for invocation in &invocations[before..] {
+        assert!(
+            invocation
+                .iter()
+                .all(|arg| !arg.starts_with("-oControlPath=")),
+            "refused socket must not be handed to ssh: {invocation:?}"
+        );
+    }
+    // The planted file must be left alone, not silently unlinked.
+    let planted = std::fs::read(&control_path);
+    drop(planted_guard);
+    assert_eq!(
+        planted.ok().as_deref(),
+        Some(&b"not a socket"[..]),
+        "refusal must not remove another party's file"
+    );
 }
 
 #[test]

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -520,27 +520,25 @@ fn cli_proves_exact_ssh_bootstrap_v6_and_encrypted_initial_payload() {
     assert!(invocations[1].last().unwrap().contains("__ET_COMSPEC__"));
     let argv = &invocations[2];
     assert_eq!(
-        &argv[..8],
+        &argv[..6],
         [
             "-oClearAllForwardings=yes",
             "-oRemoteCommand=none",
             "-oPermitLocalCommand=no",
-            "-oControlMaster=no",
-            "-oControlPath=none",
             "-oSessionType=default",
             "-oStrictHostKeyChecking=no",
             "test-user@server-alias",
         ]
     );
     let prefix = "printf '%s\\n' '";
-    let value = argv[8].strip_prefix(prefix).unwrap();
+    let value = argv[6].strip_prefix(prefix).unwrap();
     let provisional = value.split_once("_xterm-256color'").unwrap().0;
     let (id, key) = parse_id_passkey(provisional).unwrap();
     assert!(id.starts_with("XXX"));
     assert_eq!(id.len(), 16);
     assert_eq!(key.len(), 32);
     assert_eq!(
-        argv[8],
+        argv[6],
         format!(
             "printf '%s\\n' '{provisional}_xterm-256color' | '/opt/et terminal' '--verbose=2' '--serverfifo=/tmp/server fifo'"
         )
@@ -846,18 +844,16 @@ fn explicit_posix_shell_skips_probe_and_uses_exact_posix_bootstrap() {
     assert_eq!(invocations[0], ["-G", "-T", "127.0.0.1"]);
     let bootstrap = &invocations[1];
     assert_eq!(
-        &bootstrap[..6],
+        &bootstrap[..4],
         [
             "-oClearAllForwardings=yes",
             "-oRemoteCommand=none",
             "-oPermitLocalCommand=no",
-            "-oControlMaster=no",
-            "-oControlPath=none",
             "-oSessionType=default",
         ]
     );
-    assert_eq!(bootstrap[6], "config-user@127.0.0.1");
-    let input = bootstrap[7]
+    assert_eq!(bootstrap[4], "config-user@127.0.0.1");
+    let input = bootstrap[5]
         .strip_prefix("printf '%s\\n' '")
         .unwrap()
         .strip_suffix("_xterm-256color' | 'etterminal' '--verbose=0'")
@@ -1247,18 +1243,16 @@ fn jumphost_starts_a_jump_terminal_and_connects_to_the_jumphost() {
     assert_eq!(destination[0], "-J");
     assert_eq!(destination[1], "jump.example");
     assert_eq!(
-        &destination[2..8],
+        &destination[2..6],
         [
             "-oClearAllForwardings=yes",
             "-oRemoteCommand=none",
             "-oPermitLocalCommand=no",
-            "-oControlMaster=no",
-            "-oControlPath=none",
             "-oSessionType=default",
         ]
     );
-    assert_eq!(destination[8], "test-user@server-alias");
-    let destination_command = &destination[9];
+    assert_eq!(destination[6], "test-user@server-alias");
+    let destination_command = &destination[7];
     assert!(
         destination_command.starts_with("echo "),
         "{destination_command:?}"
@@ -1278,18 +1272,16 @@ fn jumphost_starts_a_jump_terminal_and_connects_to_the_jumphost() {
     assert_eq!(invocations[3], ["-G", "-T", "jump.example"]);
     let jump = &invocations[4];
     assert_eq!(
-        &jump[..6],
+        &jump[..4],
         [
             "-oClearAllForwardings=yes",
             "-oRemoteCommand=none",
             "-oPermitLocalCommand=no",
-            "-oControlMaster=no",
-            "-oControlPath=none",
             "-oSessionType=default",
         ]
     );
-    assert_eq!(jump[6], "jump.example");
-    let jump_command = &jump[7];
+    assert_eq!(jump[4], "jump.example");
+    let jump_command = &jump[5];
     // The jumphost remains POSIX even when the destination probe selects Cmd.
     assert!(jump_command.contains("'etterminal'"), "{jump_command:?}");
     assert!(!jump_command.contains("et.exe"), "{jump_command:?}");

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -58,8 +58,20 @@ impl FakeSsh {
         fs::write(
             &script,
             r#"#!/bin/sh
-for arg in "$@"; do printf "%s\0" "$arg" >> "$ET_FAKE_ARGV"; done
+control_path=
+for arg in "$@"; do
+  printf "%s\0" "$arg" >> "$ET_FAKE_ARGV"
+  case "$arg" in -oControlPath=*) control_path=${arg#-oControlPath=} ;; esac
+done
 printf "\0" >> "$ET_FAKE_ARGV"
+if [ "$1" = "-MNf" ]; then
+  if [ "${ET_FAKE_MASTER_EXIT:-0}" -ne 0 ]; then
+    exit "$ET_FAKE_MASTER_EXIT"
+  fi
+  if [ -n "$control_path" ]; then
+    : > "$control_path"
+  fi
+fi
 if [ "$1" = "-G" ]; then
   printf "%s" "$ET_FAKE_CONFIG"
   exit 0
@@ -99,6 +111,7 @@ exit "$ET_FAKE_EXIT"
             .env("ET_FAKE_EXIT", exit.to_string())
             .env("ET_FAKE_PROBE_STDOUT", "__ET_COMSPEC__%ComSpec%\n")
             .env("ET_FAKE_PROBE_EXIT", "0")
+            .env("ET_FAKE_MASTER_EXIT", "0")
             .stdin(Stdio::null());
         command
     }
@@ -117,6 +130,20 @@ exit "$ET_FAKE_EXIT"
             }
         }
         invocations
+    }
+
+    /// Operational invocations with ET's private multiplexing arguments
+    /// removed, for assertions unrelated to the control-master lifecycle.
+    fn work_invocations(&self) -> Vec<Vec<String>> {
+        self.invocations()
+            .into_iter()
+            .filter(|argv| argv.first().is_some_and(|arg| arg != "-MNf" && arg != "-O"))
+            .map(|argv| {
+                argv.into_iter()
+                    .filter(|arg| arg != "-oControlMaster=no" && !arg.starts_with("-oControlPath="))
+                    .collect()
+            })
+            .collect()
     }
 }
 
@@ -186,7 +213,7 @@ fn ssh_config_remote_forward_is_omitted_from_initial_payload() {
     let payload = server.join().unwrap();
 
     assert!(payload.reversetunnels.is_empty());
-    assert_eq!(fake.invocations()[0], ["-G", "-T", "server-alias"]);
+    assert_eq!(fake.work_invocations()[0], ["-G", "-T", "server-alias"]);
 }
 
 #[test]
@@ -336,7 +363,7 @@ fn ssh_config_malformed_forward_is_rejected() {
         "{}",
         stderr(&output)
     );
-    assert_eq!(fake.invocations(), [["-G", "-T", "server-alias"]]);
+    assert_eq!(fake.work_invocations(), [["-G", "-T", "server-alias"]]);
 }
 
 #[test]
@@ -362,7 +389,7 @@ fn ssh_config_extra_forward_field_is_rejected_before_bootstrap() {
         "{}",
         stderr(&output)
     );
-    assert_eq!(fake.invocations(), [["-G", "-T", "server-alias"]]);
+    assert_eq!(fake.work_invocations(), [["-G", "-T", "server-alias"]]);
 }
 
 #[test]
@@ -455,6 +482,118 @@ fn explicit_cli_remote_forwards_are_deduplicated_while_config_rows_are_omitted()
 }
 
 #[test]
+fn bootstrap_ssh_invocations_share_a_private_session_control_path() {
+    let (port, server) = initial_payload_server();
+    let fake = FakeSsh::new();
+    let output = fake
+        .command(RESOLVED_CONFIG, VALID_MARKER, 0, "")
+        .args(["-N", &format!("server-alias:{port}")])
+        .output()
+        .unwrap();
+    server.join().unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+
+    let invocations = fake.invocations();
+    assert_eq!(invocations.len(), 5, "{invocations:?}");
+
+    let control_argument = invocations[0]
+        .iter()
+        .find(|arg| arg.starts_with("-oControlPath="))
+        .expect("master start must name a ControlPath");
+    let control_path = control_argument.strip_prefix("-oControlPath=").unwrap();
+    let path = std::path::Path::new(control_path);
+    assert_eq!(
+        path.file_name().and_then(|name| name.to_str()),
+        Some("master")
+    );
+    assert!(path
+        .parent()
+        .and_then(|dir| dir.file_name())
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with("et-ssh-")));
+    assert!(path.is_absolute(), "{path:?}");
+
+    assert_eq!(invocations[0][0], "-MNf");
+    assert!(invocations[0]
+        .iter()
+        .any(|arg| arg == "-oControlMaster=yes"));
+    assert!(invocations[0]
+        .iter()
+        .any(|arg| arg == "-oControlPersist=no"));
+    assert_eq!(invocations[0].last().unwrap(), "server-alias");
+
+    let private_options = ["-oControlMaster=no", control_argument.as_str()];
+    assert_eq!(
+        &invocations[1][..4],
+        ["-G", "-T", private_options[0], private_options[1]]
+    );
+    for invocation in &invocations[2..=3] {
+        assert_eq!(&invocation[..2], private_options);
+    }
+    assert!(invocations[2]
+        .last()
+        .unwrap()
+        .contains(WINDOWS_PROBE_SENTINEL));
+    assert!(invocations[3].last().unwrap().starts_with("printf '%s\\n'"));
+
+    assert_eq!(
+        invocations[4],
+        [
+            "-O",
+            "exit",
+            "-oControlMaster=no",
+            control_argument,
+            "server-alias",
+        ]
+    );
+    assert!(
+        !path.exists(),
+        "private control path survived cleanup: {path:?}"
+    );
+    assert!(
+        !path.parent().unwrap().exists(),
+        "private control directory survived cleanup: {path:?}"
+    );
+}
+
+#[test]
+fn bootstrap_falls_back_when_private_control_master_fails() {
+    let (port, server) = initial_payload_server();
+    let fake = FakeSsh::new();
+    let output = fake
+        .command(RESOLVED_CONFIG, VALID_MARKER, 0, "")
+        .env("ET_FAKE_MASTER_EXIT", "255")
+        .args(["-N", &format!("server-alias:{port}")])
+        .output()
+        .unwrap();
+    server.join().unwrap();
+    assert!(output.status.success(), "{}", stderr(&output));
+
+    let invocations = fake.invocations();
+    assert_eq!(invocations.len(), 4, "{invocations:?}");
+    assert_eq!(invocations[0][0], "-MNf");
+    for invocation in &invocations[1..] {
+        assert!(
+            invocation
+                .iter()
+                .all(|arg| arg != "-oControlMaster=no" && !arg.starts_with("-oControlPath=")),
+            "fallback invocation unexpectedly uses ET control socket: {invocation:?}"
+        );
+    }
+    let control_path = invocations[0]
+        .iter()
+        .find_map(|arg| arg.strip_prefix("-oControlPath="))
+        .unwrap();
+    assert!(!std::path::Path::new(control_path).exists());
+    assert!(!std::path::Path::new(control_path)
+        .parent()
+        .unwrap()
+        .exists());
+}
+
+const WINDOWS_PROBE_SENTINEL: &str = "__ET_COMSPEC__";
+
+#[test]
 fn cli_proves_exact_ssh_bootstrap_v6_and_encrypted_initial_payload() {
     let (port, server) = initial_payload_server();
 
@@ -506,7 +645,7 @@ fn cli_proves_exact_ssh_bootstrap_v6_and_encrypted_initial_payload() {
     );
     assert_eq!(payload.environmentvariables.len(), 3);
 
-    let invocations = fake.invocations();
+    let invocations = fake.work_invocations();
     assert_eq!(invocations.len(), 3);
     assert_eq!(
         invocations[0],
@@ -789,7 +928,7 @@ fn bare_windows_login_shell_is_detected_before_bootstrap() {
     server.join().unwrap();
     assert!(output.status.success(), "{}", stderr(&output));
 
-    let invocations = fake.invocations();
+    let invocations = fake.work_invocations();
     assert_eq!(invocations.len(), 3, "{invocations:?}");
     assert!(invocations[1].last().unwrap().contains("__ET_COMSPEC__"));
     let bootstrap = invocations[2].last().unwrap();
@@ -839,7 +978,7 @@ fn explicit_posix_shell_skips_probe_and_uses_exact_posix_bootstrap() {
     server.join().unwrap();
     assert!(output.status.success(), "{}", stderr(&output));
 
-    let invocations = fake.invocations();
+    let invocations = fake.work_invocations();
     assert_eq!(invocations.len(), 2, "{invocations:?}");
     assert_eq!(invocations[0], ["-G", "-T", "127.0.0.1"]);
     let bootstrap = &invocations[1];
@@ -1233,7 +1372,7 @@ fn jumphost_starts_a_jump_terminal_and_connects_to_the_jumphost() {
     server.join().unwrap();
     assert!(output.status.success(), "{}", stderr(&output));
 
-    let invocations = fake.invocations();
+    let invocations = fake.work_invocations();
     // -G dst, login-shell probe, dst bootstrap through -J, -G jumphost,
     // jump bootstrap.
     assert_eq!(invocations.len(), 5, "{invocations:?}");

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -47,6 +47,7 @@ struct FakeSsh {
     dir: TestDir,
     argv: PathBuf,
     stdin: PathBuf,
+    client_pids: PathBuf,
 }
 
 impl Drop for FakeSsh {
@@ -71,6 +72,7 @@ impl FakeSsh {
         let script = dir.0.join("ssh");
         let argv = dir.0.join("argv");
         let stdin = dir.0.join("stdin");
+        let client_pids = dir.0.join("client_pids");
         fs::write(
             &script,
             r#"#!/bin/sh
@@ -80,6 +82,12 @@ for arg in "$@"; do
   case "$arg" in -oControlPath=*) control_path=${arg#-oControlPath=} ;; esac
 done
 printf "\0" >> "$ET_FAKE_ARGV"
+# Record the invoking `et` client's pid so tests can assert the ControlPath
+# carries no per-process component. $PPID is that client, not this shell's own
+# pid, which is what makes the assertion meaningful.
+if [ -n "$ET_FAKE_CLIENT_PIDS" ]; then
+  echo "$PPID" >> "$ET_FAKE_CLIENT_PIDS"
+fi
 if [ "$1" = "-O" ] && [ "$2" = "check" ]; then
   if [ -n "$control_path" ]; then
     [ -e "$control_path" ] && exit 0
@@ -120,7 +128,13 @@ exit "$ET_FAKE_EXIT"
         permissions.set_mode(0o755);
         fs::set_permissions(script, permissions).unwrap();
         fs::write(&argv, []).unwrap();
-        Self { dir, argv, stdin }
+        fs::write(&client_pids, []).unwrap();
+        Self {
+            dir,
+            argv,
+            stdin,
+            client_pids,
+        }
     }
 
     fn command(&self, config: &str, stdout: &str, exit: i32, stderr: &str) -> Command {
@@ -140,6 +154,7 @@ exit "$ET_FAKE_EXIT"
             .env("ET_FAKE_MASTER_EXIT", "0")
             .env("ET_FAKE_USER_MASTER_EXIT", "255")
             .env("ET_FAKE_MKSOCKET", env!("CARGO_BIN_EXE_mksocket"))
+            .env("ET_FAKE_CLIENT_PIDS", &self.client_pids)
             .stdin(Stdio::null());
         command
     }
@@ -626,6 +641,23 @@ fn control_path_is_stable_for_a_destination_and_distinct_between_destinations() 
         2,
         "exactly two distinct destinations were used: {pids:?}"
     );
+    // Assert against the pids of the `et` clients that actually ran. Searching
+    // for the harness's own pid would be unsound: it is a different process,
+    // and a 32-hex hash can contain any decimal digits by coincidence.
+    let client_pids = fs::read_to_string(&fake.client_pids).unwrap();
+    let client_pids = client_pids
+        .split_whitespace()
+        .filter(|value| !value.is_empty())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert!(!client_pids.is_empty(), "fake ssh recorded no client pid");
+    for path in &paths {
+        for pid in &client_pids {
+            assert!(
+                !path.contains(pid),
+                "ControlPath must not embed the client pid {pid}: {path}"
+            );
+        }
+    }
     for path in paths {
         let file_name = std::path::Path::new(&path)
             .file_name()
@@ -635,13 +667,6 @@ fn control_path_is_stable_for_a_destination_and_distinct_between_destinations() 
         assert!(
             file_name.bytes().all(|byte| byte.is_ascii_hexdigit()),
             "{path}"
-        );
-        // The 32-hex basename is a hash, so a decimal pid cannot appear
-        // literally; check the whole path, which is where a pid or a serial
-        // would realistically be appended.
-        assert!(
-            !path.contains(&std::process::id().to_string()),
-            "ControlPath must not embed the client pid: {path}"
         );
         for serial in 0..4u32 {
             assert!(

--- a/crates/et-bin/tests/reconnect_end_to_end.rs
+++ b/crates/et-bin/tests/reconnect_end_to_end.rs
@@ -167,9 +167,12 @@ fn real_client_recovers_same_shell_and_once_only_buffered_output() {
     assert!(text.contains("RECONNECT-TERMIOS:"), "output={text}");
     assert!(text.contains(":CODE:0:"), "output={text}");
     assert!(termios_restored(&text), "output={text}");
-    // One credential-free login-shell probe plus one credential bootstrap.
+    // One private control-master start, one credential-free login-shell probe,
+    // and one credential bootstrap. This fixture's fake SSH rejects the master,
+    // so the probe and bootstrap then run unmultiplexed; against a real sshd
+    // they share that master instead of opening their own connections.
     // Reconnects stay on the encrypted ET transport and must not invoke SSH.
-    assert_eq!(fs::read_to_string(&stack.ssh_count).unwrap(), "xx");
+    assert_eq!(fs::read_to_string(&stack.ssh_count).unwrap(), "xxx");
     proxy.join();
     stack.shutdown();
 }

--- a/crates/et-bin/tests/reconnect_end_to_end.rs
+++ b/crates/et-bin/tests/reconnect_end_to_end.rs
@@ -167,12 +167,12 @@ fn real_client_recovers_same_shell_and_once_only_buffered_output() {
     assert!(text.contains("RECONNECT-TERMIOS:"), "output={text}");
     assert!(text.contains(":CODE:0:"), "output={text}");
     assert!(termios_restored(&text), "output={text}");
-    // One private control-master start, one credential-free login-shell probe,
-    // and one credential bootstrap. This fixture's fake SSH rejects the master,
-    // so the probe and bootstrap then run unmultiplexed; against a real sshd
-    // they share that master instead of opening their own connections.
-    // Reconnects stay on the encrypted ET transport and must not invoke SSH.
-    assert_eq!(fs::read_to_string(&stack.ssh_count).unwrap(), "xxx");
+    // This fixture's fake SSH rejects the user-master check, two race-safe
+    // ET-master checks, and the master start before the probe and bootstrap run
+    // unmultiplexed. Against a real sshd these checks open no TCP connections
+    // and the operations share the destination master. Reconnects stay on the
+    // encrypted ET transport and must not invoke SSH again.
+    assert_eq!(fs::read_to_string(&stack.ssh_count).unwrap(), "xxxxxx");
     proxy.join();
     stack.shutdown();
 }

--- a/crates/et-bin/tests/tunnels_end_to_end.rs
+++ b/crates/et-bin/tests/tunnels_end_to_end.rs
@@ -169,7 +169,8 @@ gatewayports no
             .lines()
             .filter(|line| line.contains("WARNING"))
             .count(),
-        1
+        2,
+        "the fake SSH rejects the private master before the imported bind warning: {output}"
     );
     drop(occupied);
     echo.join().unwrap();
@@ -274,7 +275,8 @@ fn imported_remote_rows_are_omitted_while_local_row_stays_live() {
             .lines()
             .filter(|line| line.contains("WARNING"))
             .count(),
-        0
+        1,
+        "only the fake SSH's rejected private master should warn: {output}"
     );
     drop(occupied);
     echo.join().unwrap();
@@ -340,7 +342,8 @@ fn native_jumphost_omits_imported_remote_rows() {
             .lines()
             .filter(|line| line.contains("WARNING"))
             .count(),
-        0
+        2,
+        "the fake SSH rejects one private master for each SSH target: {output}"
     );
     drop(occupied);
     echo.join().unwrap();
@@ -507,8 +510,8 @@ fn cumulative_local_forwards_deduplicate_exact_rows_but_preserve_distinct_destin
             .lines()
             .filter(|line| line.contains("WARNING"))
             .count(),
-        1,
-        "only the distinct same-source row should reach bind-failure policy: {output}"
+        2,
+        "the fake SSH's rejected private master and only the distinct same-source row should warn: {output}"
     );
     echo.join().unwrap();
     stack.shutdown();


### PR DESCRIPTION
## Defect

ET bootstrap hard-forced `ControlMaster=no` and `ControlPath=none` on every probe and bootstrap SSH invocation. That isolated ET from a user's ssh_config, but it also prevented reuse of an already-warm ControlMaster, so each ET session opened a fresh sshd connection.

Measured on a real OCI pair (8 concurrent sessions, 4 MiB PTY payload each, ControlMaster already established before the block; server-side sampler at 0.5 s):

| lane | sshd established peak | sshd process peak |
|---|---|---|
| ET 8-way | 12 | 16 |
| direct SSH 8-way | 4 | 10 |

All 8 sessions in both lanes exited 0 with byte-exact payload. Pure overhead.

## RED

On unmodified `df69c7a`, the new argv pin fails because bootstrap still injects `-oControlMaster=no` and `-oControlPath=none`:

```
cargo test -p et --bin et -- --test-threads=1 bootstrap_ssh_argv_does_not_disable_control_master_reuse
...
test bootstrap::tests::bootstrap_ssh_argv_does_not_disable_control_master_reuse ... FAILED

---- bootstrap::tests::bootstrap_ssh_argv_does_not_disable_control_master_reuse stdout ----

thread 'bootstrap::tests::bootstrap_ssh_argv_does_not_disable_control_master_reuse' panicked at crates/et-bin/src/bootstrap.rs:482:9:
assertion `left == right` failed
  left: ["-oClearAllForwardings=yes", "-oRemoteCommand=none", "-oPermitLocalCommand=no", "-oControlMaster=no", "-oControlPath=none", "-oSessionType=default"]
 right: ["-oClearAllForwardings=yes", "-oRemoteCommand=none", "-oPermitLocalCommand=no", "-oSessionType=default", "-oPort=2222", "alice@server"]
```

## Fix

Stop forcing `ControlMaster` / `ControlPath` on operational SSH argv so an existing user master can be reused. Keep filtering those keys out of user `-o` flags so ET still does not own or override a control socket. Isolation of `ClearAllForwardings=yes`, `RemoteCommand=none`, `PermitLocalCommand=no`, and `SessionType=default` is unchanged.

## GREEN

```
cargo test -p et --bin et -- --test-threads=1
test result: ok. 150 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo test -p et --test client_bootstrap -- --test-threads=1
test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo fmt --all --check
(exit 0)

cargo clippy --workspace --all-targets -- -D warnings
Finished `dev` profile ... (exit 0)

cargo test --workspace -- --test-threads=1
all crates: 0 failed
```

Surviving forced isolation options: `ClearAllForwardings=yes`, `RemoteCommand=none`, `PermitLocalCommand=no`, `SessionType=default`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuses a working user SSH ControlMaster for ET bootstrap operations, and otherwise starts a private, destination-scoped master so the configuration query, login-shell probe, and terminal bootstrap share one sshd connection. The private master persists briefly after use, is shared across ET processes targeting the same destination, and falls back to independent SSH invocations if it cannot start.

- Checks for a user-configured ControlMaster first; if it works, all ET commands use it unchanged.
- When none exists, starts a master with `-MNf` and `ControlPersist=15` under a per-user `et-ssh-<uid>` directory, hashing user, host, port, and jumphost to a stable socket name; an explicit jumphost port now reaches the config query so the hash matches the bootstrap's actual port.
- A lock directory serializes master startup so concurrent ET processes converge on one socket; sessions never send `-O exit` or unlink the shared socket, and a non-socket or symlink already at the socket path is refused with the session falling back unmultiplexed.
- User `ControlMaster` and `ControlPath` options are still filtered, and isolation (`ClearAllForwardings=yes`, `RemoteCommand=none`, `PermitLocalCommand=no`, `SessionType=default`) is unchanged.
- Long temporary paths fall back to `/tmp` to keep the socket under `sockaddr_un` limits.

<sup>Written for commit 08661f6e52e1f5dc77832cc3cd786a05e9fa68d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

