### PR TITLE
fix(forwarding): preserve replies after write half-close

### DIFF
--- a/.tegami/fix-forwarding-half-close.md
+++ b/.tegami/fix-forwarding-half-close.md
@@ -1,0 +1,6 @@
+---
+et: patch
+---
+
+Preserve forwarded TCP replies after a local client half-closes its write side.
+ET now drains the reverse direction before closing the forwarded socket.

--- a/crates/et-net/src/forward_io.rs
+++ b/crates/et-net/src/forward_io.rs
@@ -1,4 +1,5 @@
 use std::io::{self, Read, Write};
+use std::net::Shutdown;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
@@ -28,6 +29,8 @@ pub(crate) struct ActiveIo {
     pub(crate) cancel: channel::Receiver<()>,
     pub(crate) pending_bytes: Arc<AtomicUsize>,
     pub(crate) abandoned: Arc<AtomicBool>,
+    pub(crate) read_closed: bool,
+    pub(crate) write_closed: bool,
 }
 
 pub(crate) enum WriteCommand {
@@ -260,7 +263,7 @@ pub(crate) fn spawn_io(
                 WriteCommand::Stop => {
                     // Perform the final shutdown here so every Data command
                     // queued before Stop is flushed to the socket first.
-                    writer.shutdown();
+                    shutdown_write(&writer);
                     break;
                 }
             }
@@ -276,9 +279,19 @@ pub(crate) fn spawn_io(
             cancel,
             pending_bytes,
             abandoned,
+            read_closed: false,
+            write_closed: false,
         },
         [reader_handle, writer_handle],
     ))
+}
+
+fn shutdown_write(stream: &ForwardStream) {
+    let _ = match stream {
+        ForwardStream::Tcp(stream) => stream.shutdown(Shutdown::Write),
+        #[cfg(unix)]
+        ForwardStream::Unix(stream) => stream.shutdown(Shutdown::Write),
+    };
 }
 
 #[cfg(windows)]
@@ -310,14 +323,24 @@ fn cancellation_requested(cancel: &channel::Receiver<()>) -> bool {
     !matches!(cancel.try_recv(), Err(channel::TryRecvError::Empty))
 }
 
-pub(crate) fn stop_io(io: ActiveIo) {
-    // Keep the control socket alive while Stop waits for queue capacity so
-    // hard cancellation can still abort an in-flight write and release it.
-    let stop_admitted = channel::select! {
+pub(crate) fn close_write(io: &mut ActiveIo) -> bool {
+    if io.write_closed {
+        return true;
+    }
+    let admitted = channel::select! {
         send(io.writer, WriteCommand::Stop) -> result => result.is_ok(),
         recv(io.cancel) -> _ => false,
     };
-    if stop_admitted {
+    if admitted {
+        io.write_closed = true;
+    }
+    admitted
+}
+
+pub(crate) fn stop_io(mut io: ActiveIo) {
+    // Keep the control socket alive while Stop waits for queue capacity so
+    // hard cancellation can still abort an in-flight write and release it.
+    if close_write(&mut io) {
         io.control.shutdown_read();
     } else {
         if io.pending_bytes.load(Ordering::Acquire) != 0 {

--- a/crates/et-net/src/forward_worker.rs
+++ b/crates/et-net/src/forward_worker.rs
@@ -15,8 +15,8 @@ use crossbeam_channel as channel;
 use crate::forward::{ForwardError, Outbound};
 use crate::forward_endpoint::ForwardStream;
 use crate::forward_io::{
-    abort_io, spawn_connector, spawn_io, spawn_listener, stop_io, ActiveIo, BoundSource,
-    ListenerStop, WriteCommand,
+    abort_io, close_write, spawn_connector, spawn_io, spawn_listener, stop_io, ActiveIo,
+    BoundSource, ListenerStop, WriteCommand,
 };
 use et_core::packet::Packet;
 use et_core::proto::SocketEndpoint;
@@ -370,10 +370,7 @@ impl Worker {
                     socket_id,
                     buffer,
                 } => self.send_data(role, socket_id, buffer, false, None),
-                Command::Closed { role, socket_id } => {
-                    self.remove(role, socket_id);
-                    self.send_data(role, socket_id, Vec::new(), true, None)
-                }
+                Command::Closed { role, socket_id } => self.read_closed(role, socket_id),
                 Command::IoFailed {
                     role,
                     socket_id,

--- a/crates/et-net/src/forward_worker_state.rs
+++ b/crates/et-net/src/forward_worker_state.rs
@@ -13,8 +13,8 @@ use prost::Message;
 use crate::forward_endpoint::Endpoint;
 
 use super::{
-    spawn_connector, spawn_io, ActiveIo, ForwardError, ForwardStream, Role, Worker, WriteCommand,
-    MAX_ACTIVE_SOCKETS, MAX_DATA_PACKET,
+    close_write, spawn_connector, spawn_io, ActiveIo, ForwardError, ForwardStream, Role, Worker,
+    WriteCommand, MAX_ACTIVE_SOCKETS, MAX_DATA_PACKET,
 };
 
 impl Worker {
@@ -153,8 +153,21 @@ impl Worker {
         } else {
             Role::Source
         };
-        if data.closed.unwrap_or(false) || data.error.is_some() {
+        if data.error.is_some() {
             self.remove(role, socket_id);
+            return Ok(());
+        }
+        if data.closed.unwrap_or(false) {
+            let Some(active) = self.map(role).get_mut(&socket_id) else {
+                return Ok(());
+            };
+            if !close_write(active) {
+                return Err(ForwardError::Unavailable);
+            }
+            let fully_closed = active.read_closed;
+            if fully_closed {
+                self.remove(role, socket_id);
+            }
             return Ok(());
         }
         if buffer.is_empty() {
@@ -186,6 +199,18 @@ impl Worker {
                 .fetch_sub(byte_count, std::sync::atomic::Ordering::AcqRel);
             Err(ForwardError::Unavailable)
         }
+    }
+
+    pub(super) fn read_closed(&mut self, role: Role, socket_id: i32) -> Result<(), ForwardError> {
+        let fully_closed = self.map(role).get_mut(&socket_id).is_some_and(|active| {
+            active.read_closed = true;
+            active.write_closed
+        });
+        self.send_data(role, socket_id, Vec::new(), true, None)?;
+        if fully_closed {
+            self.remove(role, socket_id);
+        }
+        Ok(())
     }
 
     pub(super) fn send_data(

--- a/crates/et-net/tests/forward.rs
+++ b/crates/et-net/tests/forward.rs
@@ -5,7 +5,7 @@ use std::io::{Read, Write};
 use std::net::SocketAddr;
 #[cfg(unix)]
 use std::net::{IpAddr, Ipv6Addr};
-use std::net::{Ipv4Addr, TcpListener, TcpStream};
+use std::net::{Ipv4Addr, Shutdown, TcpListener, TcpStream};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -59,6 +59,52 @@ fn two_forwarders_relay_a_real_tcp_round_trip() {
     assert_eq!(&echoed, b"hello");
 
     drop(application);
+    source.shutdown().unwrap();
+    destination.shutdown().unwrap();
+    echo.join().unwrap();
+}
+
+#[test]
+fn forwarded_tcp_delivers_reply_after_client_write_shutdown() {
+    // Given: a real forwarded TCP stream to an echo server that replies only
+    // after it observes EOF, then half-closes its own write side.
+    const PAYLOAD_LEN: usize = 20 * 1024;
+    let payload: Vec<u8> = (0..PAYLOAD_LEN).map(|index| index as u8).collect();
+    let destination = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let destination_port = destination.local_addr().unwrap().port();
+    let echo = thread::spawn(move || {
+        let (mut stream, _) = destination.accept().unwrap();
+        stream.set_read_timeout(Some(TIMEOUT)).unwrap();
+        stream.set_write_timeout(Some(TIMEOUT)).unwrap();
+        let mut received = Vec::new();
+        stream.read_to_end(&mut received).unwrap();
+        stream.write_all(&received).unwrap();
+        stream.shutdown(Shutdown::Write).unwrap();
+    });
+    let source_port = reserve_port();
+    let source = Forwarder::start(vec![request(source_port, destination_port)]).unwrap();
+    let destination = Forwarder::start(Vec::new()).unwrap();
+    let mut application = TcpStream::connect((Ipv4Addr::LOCALHOST, source_port)).unwrap();
+    application.set_read_timeout(Some(TIMEOUT)).unwrap();
+    application.set_write_timeout(Some(TIMEOUT)).unwrap();
+    destination
+        .receive(source.wait_outbound(TIMEOUT).unwrap())
+        .unwrap();
+    source
+        .receive(destination.wait_outbound(TIMEOUT).unwrap())
+        .unwrap();
+
+    // When: the client writes the whole payload and half-closes its write side.
+    application.write_all(&payload).unwrap();
+    application.shutdown(Shutdown::Write).unwrap();
+    relay_forward_data_until_close(&source, &destination);
+    relay_forward_data_until_close(&destination, &source);
+
+    // Then: the echoed bytes arrive byte-exact before EOF.
+    let mut reply = Vec::new();
+    application.read_to_end(&mut reply).unwrap();
+    assert_eq!(reply, payload);
+
     source.shutdown().unwrap();
     destination.shutdown().unwrap();
     echo.join().unwrap();
@@ -620,6 +666,26 @@ fn assert_authenticated_wildcard_rejected(loopback: IpAddr, wildcard: IpAddr, ow
 
 fn request(source: u16, destination: u16) -> PortForwardSourceRequest {
     request_on("127.0.0.1", source, destination)
+}
+
+fn port_forward_data_closed(packet: &Packet) -> bool {
+    if packet.header() != TerminalPacketType::PortForwardData as u8 {
+        return false;
+    }
+    et_core::proto::PortForwardData::decode(packet.payload())
+        .ok()
+        .is_some_and(|data| data.closed.unwrap_or(false) || data.error.is_some())
+}
+
+fn relay_forward_data_until_close(from: &Forwarder, to: &Forwarder) {
+    loop {
+        let packet = from.wait_outbound(TIMEOUT).unwrap();
+        let closed = port_forward_data_closed(&packet);
+        to.receive(packet).unwrap();
+        if closed {
+            break;
+        }
+    }
 }
 
 fn request_on(host: &str, source: u16, destination: u16) -> PortForwardSourceRequest {


### PR DESCRIPTION
## Defect

A forwarded TCP client that called `shutdown(SHUT_WR)` lost the entire reverse-direction reply. Reader EOF emitted `PortForwardData.closed`, but both sender and receiver immediately removed the active socket and discarded queued or not-yet-produced reply data.

## RED

On unmodified `df69c7a`, after adding the socket-level regression test:

```text
running 1 test
test forwarded_tcp_delivers_reply_after_client_write_shutdown ...
thread '<unnamed>' (...) panicked at crates/et-net/tests/forward.rs:82:42:
called `Result::unwrap()` on an `Err` value: Os { code: 107, kind: NotConnected, message: "Transport endpoint is not connected" }

thread 'forwarded_tcp_delivers_reply_after_client_write_shutdown' (...) panicked at crates/et-net/tests/forward.rs:106:5:
assertion `left == right` failed
  left: []

failures:
    forwarded_tcp_delivers_reply_after_client_write_shutdown

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s
```

## Fix

Keep `PortForwardData.closed` as the existing directional EOF signal. Its `sourcetodestination` field identifies which stream direction ended. Receiving that frame now queues a write-half shutdown behind all prior bounded writer-queue data while leaving the socket's read half active. The socket is removed only after both directional EOFs have arrived. I/O errors retain full teardown behavior, and hard cancellation still bypasses full queues and shuts both halves down.

This does not change protocol version 6, `ETerminal.proto`, or `fixtures/wire.json`.

## GREEN

```text
running 1 test
test forwarded_tcp_delivers_reply_after_client_write_shutdown ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s
```

```text
cargo test -p et-net --test forward -- --test-threads=1
running 13 tests
...
test forwarded_tcp_delivers_reply_after_client_write_shutdown ... ok
test hard_shutdown_cancels_active_destination_write_after_socket_backpressure ... ok
...
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s

cargo test -p et-net stop_io_cancellation_bypasses_a_full_writer_queue -- --nocapture --test-threads=1
running 1 test
test forward_io::tests::stop_io_cancellation_bypasses_a_full_writer_queue ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 57 filtered out; finished in 0.00s

cargo fmt --all --check
(exit 0, no output)

cargo clippy --workspace --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.48s

cargo test --workspace -- --test-threads=1
All workspace unit, integration, end-to-end, and doc tests passed; exit 0.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes forwarded TCP replies being lost after a client half-closes its write side. Previously, the socket was removed on the first directional EOF, discarding queued reply data; now the write half is shut down after draining queued data, and the socket is removed only after both directions close.

**Behavior**
- `PortForwardData.closed` now queues a write-half shutdown instead of removing the socket.
- The socket is removed only after both directional EOFs arrive; I/O errors still tear down immediately.
- Hard cancellation still bypasses full queues and shuts down both halves.
- Adds a regression test for a client write half-close followed by an echoed reply.

<sup>Written for commit a3bd1257e9138db2a00b22ca8741557b02c31daf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

