### PR TITLE
chore(upstream): pin ET #792 SO_LINGER (skip)

### DIFF
--- a/.github/upstream-ledger.yml
+++ b/.github/upstream-ledger.yml
@@ -10,10 +10,10 @@
 #   note: short string
 #   et_pr: optional upstream PR number
 #
-# Classified 2026-09-02. #798 marked ported in this et.rs PR.
+# Classified 2026-09-04. #798 marked ported in this et.rs PR.
 
 baseline_sha: 7656a32a5bc15c6746726a27a5a4ba1e468fab6e
-classified: "2026-09-02"
+classified: "2026-09-04"
 
 commits:
   - sha: f6cf43707bde07eb6d11495586a35b9f2d64b032
@@ -101,3 +101,9 @@ commits:
     status: skip
     note: "#802 Windows build/test parity; not a wire or server-lock change"
     et_pr: 802
+  - sha: 584a68b4b54c74de7035e6108f49151ebce6a191
+    date: "2026-09-03"
+    kind: security
+    status: skip
+    note: "#792 disable SO_LINGER. et.rs never sets SO_LINGER and has no globalMutex-on-close; default linger-off already matches."
+    et_pr: 792

--- a/.github/upstream-pin.yml
+++ b/.github/upstream-pin.yml
@@ -10,8 +10,8 @@ upstream_repo: EternalTerminal
 reviewed_release_tag: et-v7.0.0
 reviewed_release_sha: 7656a32a5bc15c6746726a27a5a4ba1e468fab6e
 reviewed_default_branch: master
-reviewed_default_branch_sha: 342c0dfb32882c94df6aa18092fc897015222c0b
-reviewed_date: "2026-09-02"
+reviewed_default_branch_sha: 584a68b4b54c74de7035e6108f49151ebce6a191
+reviewed_date: "2026-09-04"
 
 # et.rs still claims protocol v6. ET product is v7.0.0; ET wire is still v6.
 et_rs_protocol_version: 6

--- a/docs/upstream-pin.md
+++ b/docs/upstream-pin.md
@@ -10,7 +10,7 @@ Canonical machine files:
 - Ledger (every `master` commit after baseline):
   [`.github/upstream-ledger.yml`](../.github/upstream-ledger.yml)
 
-Recorded 2026-08-21 from GitHub (`gh` / REST). Ledger classified 2026-09-02.
+Recorded 2026-08-21 from GitHub (`gh` / REST). Ledger classified 2026-09-04.
 `#784` marked `ported` after et.rs [#31](https://github.com/minpeter/et.rs/pull/31) / `906a7ca86691f00a82f88b99b21d7afceb07bf97`.
 `#798` marked `ported` after et.rs [#77](https://github.com/minpeter/et.rs/pull/77).
 
@@ -20,13 +20,13 @@ Recorded 2026-08-21 from GitHub (`gh` / REST). Ledger classified 2026-09-02.
 | Baseline / latest release tag | [`et-v7.0.0`](https://github.com/MisterTea/EternalTerminal/releases/tag/et-v7.0.0) |
 | Baseline / release commit | [`7656a32a5bc15c6746726a27a5a4ba1e468fab6e`](https://github.com/MisterTea/EternalTerminal/commit/7656a32a5bc15c6746726a27a5a4ba1e468fab6e) |
 | Default branch | `master` |
-| Pin tip (last classified) | [`342c0dfb32882c94df6aa18092fc897015222c0b`](https://github.com/MisterTea/EternalTerminal/commit/342c0dfb32882c94df6aa18092fc897015222c0b) (`#802`, 2026-09-02) |
+| Pin tip (last classified) | [`584a68b4b54c74de7035e6108f49151ebce6a191`](https://github.com/MisterTea/EternalTerminal/commit/584a68b4b54c74de7035e6108f49151ebce6a191) (`#792`, 2026-09-03; reviewed 2026-09-04) |
 | et.rs wire version | **protocol v6** (`PROTOCOL_VERSION = 6` in `crates/et-core/src/lib.rs`, README) |
 | ET wire version at this pin | still **protocol v6** (`PROTOCOL_VERSION = 6` in `src/base/Headers.hpp` on both `et-v7.0.0` and `master`) |
 
-`7656a32...master` is `ahead_by` 15. All 15 are classified. Unclassified would be drift.
+`7656a32...master` is `ahead_by` 16. All 16 are classified. Unclassified would be drift.
 
-## Ledger (classified 2026-09-02)
+## Ledger (classified 2026-09-04)
 
 | sha | date | kind | status | note |
 | --- | --- | --- | --- | --- |
@@ -45,6 +45,7 @@ Recorded 2026-08-21 from GitHub (`gh` / REST). Ledger classified 2026-09-02.
 | [`50b961d`](https://github.com/MisterTea/EternalTerminal/commit/50b961d9e9eb6daf57d8a5ce9cae8f9209bffe44) | 2026-09-01 | security | **ported** | #798 accept starvation / stuck reconnect. Landed in et.rs via #77. PROTOCOL_VERSION stays 6. |
 | [`3e8db00`](https://github.com/MisterTea/EternalTerminal/commit/3e8db00cdccba4906ca1b995d3fd7c0650a9fac9) | 2026-09-01 | product | skip | #803 TIOCGWINSZ; Unix terminal-size observation only |
 | [`342c0df`](https://github.com/MisterTea/EternalTerminal/commit/342c0dfb32882c94df6aa18092fc897015222c0b) | 2026-09-02 | ci | skip | #802 Windows build/test parity; not a wire or server-lock change |
+| [`584a68b`](https://github.com/MisterTea/EternalTerminal/commit/584a68b4b54c74de7035e6108f49151ebce6a191) | 2026-09-03 | security | skip | #792 disable SO_LINGER. et.rs never sets SO_LINGER and has no globalMutex-on-close; default linger-off already matches. |
 
 ## Ported and residual
 
@@ -75,9 +76,12 @@ this pin as a green light to bump `PROTOCOL_VERSION` or land a v7 port.
 [`3e8db00`](https://github.com/MisterTea/EternalTerminal/commit/3e8db00cdccba4906ca1b995d3fd7c0650a9fac9) (`#803`), and
 [`342c0df`](https://github.com/MisterTea/EternalTerminal/commit/342c0dfb32882c94df6aa18092fc897015222c0b) (`#802`) stay `status: skip`
 (HTM/Windows/coverage, TIOCGWINSZ, Windows build).
+[`584a68b`](https://github.com/MisterTea/EternalTerminal/commit/584a68b4b54c74de7035e6108f49151ebce6a191) (`#792`) stays `status: skip`
+(et.rs never sets `SO_LINGER` and has no process-wide mutex around close;
+default linger-off already matches the C++ fix).
 
 et.rs still claims **protocol v6**. EternalTerminal’s latest product release is
-**v7.0.0**, and `master` is fifteen classified commits past that tag.
+**v7.0.0**, and `master` is sixteen classified commits past that tag.
 
 Review ports against the conflict policy in
 [`docs/upstream-factory.md`](upstream-factory.md). Gate any later port with


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Weekday EternalTerminal watch: classify [MisterTea/EternalTerminal#792](https://github.com/MisterTea/EternalTerminal/pull/792) (`584a68b4b54c74de7035e6108f49151ebce6a191`, 2026-09-03) as **security / skip**. Pin ≠ ported.

Upstream C++ set `SO_LINGER {l_onoff=1, l_linger=5}` on every accepted TCP socket, then held process-wide `globalMutex` across a blocking `::close()`. That froze the whole socket layer for ~5 seconds. The C++ fix only flips `l_onoff` from `1` to `0` in `src/base/TcpSocketHandler.cpp`.

et.rs already matches that outcome:

- full-tree grep: no `SO_LINGER` / `so_linger` (never enables linger)
- sockets are `socket2` / `TcpStream` with nodelay/buffer opts only
- no process-wide mutex around close like `UnixSocketHandler::close`
- default linger-off is already equivalent

Do **not** add a `SO_LINGER` setsockopt just to set it off. No C++ merge. No Rust production change. No `wire.json` edit. `PROTOCOL_VERSION` stays **6**. Tags remain `et-v7.0.0` / `7656a32…`. No GHSA found.

## Pin / ledger

| Field | Value |
| --- | --- |
| Pin tip | `584a68b4b54c74de7035e6108f49151ebce6a191` |
| Reviewed | 2026-09-04 |
| Release tag | `et-v7.0.0` @ `7656a32a5bc15c6746726a27a5a4ba1e468fab6e` |
| et.rs / ET wire | protocol v6 / protocol v6 |
| `7656a32...master` | `ahead_by` 16, all classified |

## Files

- `.github/upstream-ledger.yml` — append `584a68b`; `classified: 2026-09-04`
- `.github/upstream-pin.yml` — tip + reviewed date
- `docs/upstream-pin.md` — table row, tip SHA, dates

## Verification

- `python3 scripts/check-upstream-ledger.py --self-test`
- `python3 scripts/check-upstream-ledger.py` (compare `baseline...master` has no unclassified SHAs; pin tip == master)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8980c9a3-5aa2-440e-b19e-ee9e1787d359?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8980c9a3-5aa2-440e-b19e-ee9e1787d359&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies EternalTerminal #792 (disable `SO_LINGER`) as security/skip and updates the upstream pin.

et.rs never sets `SO_LINGER` and has no process-wide mutex around close, so the default linger-off already matches the C++ fix. No production code changes; `PROTOCOL_VERSION` stays 6.

<sup>Written for commit 32a5d666793912be6ba2be1a1055224bf4d23565. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

