### PR TITLE
fix(release): include all high-load changelogs

### DIFF
--- a/.tegami/fix-bootstrap-ssh-fanout.md
+++ b/.tegami/fix-bootstrap-ssh-fanout.md
@@ -1,6 +1,10 @@
 ---
-et: patch
+packages:
+  et:
+    type: patch
 ---
+
+## Share SSH bootstrap connections under load
 
 Share SSH bootstrap transport connections across ET processes targeting the
 same effective destination. ET first runs the configuration-only query, then

--- a/.tegami/fix-forwarding-deadlock.md
+++ b/.tegami/fix-forwarding-deadlock.md
@@ -4,6 +4,8 @@ packages:
     type: patch
 ---
 
+## Keep saturated full-duplex forwards moving
+
 Keep a saturated port forward moving in both directions at once. A large
 full-duplex transfer through a local tunnel could wedge: each endpoint stopped
 reading its transport while it held a forwarding packet for a full worker

--- a/.tegami/fix-forwarding-half-close.md
+++ b/.tegami/fix-forwarding-half-close.md
@@ -1,6 +1,10 @@
 ---
-et: patch
+packages:
+  et:
+    type: patch
 ---
+
+## Preserve replies after a forwarding half-close
 
 Preserve forwarded TCP replies after a local client half-closes its write side.
 ET now drains the reverse direction before closing the forwarded socket.


### PR DESCRIPTION
## Summary

- migrate the D2 and D3 changelog frontmatter to the current Tegami package schema
- add release-note headings for D1-D3 so Tegami recognizes every high-load fix
- keep the 0.0.21 release from omitting D1-D3

## Verification

- RED on `ec679e9`: `tegami version --no-checks` planned 1 changelog
- GREEN after this patch: the same command planned 4 changelogs and wrote a lock containing D1-D4
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the `.tegami` high-load changelogs to the current Tegami package schema and adds release-note headings so the 0.0.21 release includes the D1-D3 fixes instead of only D1.

<sup>Written for commit b9dd5225072676bc93623a071c3fc615e59b3516. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

