### PR TITLE
fix(release): recover aarch64 musl assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,31 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - run: cargo build -p et
+
+  # The release matrix builds jemalloc on native ARM against musl. Ubuntu's
+  # aarch64 musl GCC needs outlined atomics disabled so libgcc does not retain
+  # a glibc-only __getauxval reference (jemalloc issue #2782).
+  build-linux-musl:
+    name: build (aarch64-unknown-linux-musl)
+    runs-on: ubuntu-24.04-arm
+    env:
+      CFLAGS_aarch64_unknown_linux_musl: -mno-outline-atomics
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-musl
+
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ github.token }}
+
+      - name: Install musl tools
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: aarch64-unknown-linux-musl
+
+      - run: cargo build --release --locked -p et --target aarch64-unknown-linux-musl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing et release tag whose binary assets should be rebuilt
+        required: true
+        default: et@0.0.21
+        type: string
 
 permissions:
   contents: write
@@ -24,18 +31,22 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/setup-node@v4
+        if: github.event_name == 'push'
         with:
           node-version: 24
           cache: npm
 
       # Needed for `cargo update --workspace` after version bumps.
       - uses: dtolnay/rust-toolchain@stable
+        if: github.event_name == 'push'
 
-      - run: npm ci
+      - if: github.event_name == 'push'
+        run: npm ci
 
       # With pending changelogs: bump versions and open a "Version Packages" PR.
       # After that PR merges: create the `et@x.y.z` git tag and GitHub release.
       - name: Version & release
+        if: github.event_name == 'push'
         run: node scripts/tegami.mts ci
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -43,13 +54,25 @@ jobs:
       - name: Detect released tag
         id: tag
         run: |
-          tag="$(git tag --points-at HEAD 'et@*' | head -n 1)"
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            tag="$INPUT_TAG"
+            if [[ ! "$tag" =~ ^et@[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+              echo "Invalid release tag: $tag" >&2
+              exit 1
+            fi
+            gh release view "$tag" >/dev/null
+          else
+            tag="$(git tag --points-at HEAD 'et@*' | head -n 1)"
+          fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           if [ -n "$tag" ]; then
             echo "Released: $tag"
           else
             echo "No release tag on HEAD, skipping binary build."
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_TAG: ${{ inputs.tag }}
 
   binaries:
     needs: release
@@ -99,6 +122,10 @@ jobs:
 
       - name: Build
         run: cargo build --release --locked -p et --target ${{ matrix.target }}
+        env:
+          # Ubuntu aarch64's musl GCC otherwise emits libgcc outlined atomics
+          # that reference glibc-only __getauxval (jemalloc issue #2782).
+          CFLAGS_aarch64_unknown_linux_musl: ${{ matrix.target == 'aarch64-unknown-linux-musl' && '-mno-outline-atomics' || '' }}
 
       - name: Package
         id: package
@@ -142,7 +169,7 @@ jobs:
 
   homebrew:
     needs: [release, binaries]
-    if: needs.release.outputs.tag != ''
+    if: needs.release.outputs.tag != '' && github.event_name == 'push'
     runs-on: ubuntu-latest
     env:
       TAG: ${{ needs.release.outputs.tag }}
@@ -169,7 +196,7 @@ jobs:
 
   aur:
     needs: [release, binaries]
-    if: needs.release.outputs.tag != ''
+    if: needs.release.outputs.tag != '' && github.event_name == 'push'
     runs-on: ubuntu-latest
     # AUR publishing must not block a release (e.g. AUR maintenance windows).
     continue-on-error: true


### PR DESCRIPTION
## Summary

- pass `-mno-outline-atomics` to jemalloc only for the aarch64-musl C build
- add the exact native ARM musl release build to PR CI
- allow rebuilding assets for an existing immutable release tag without rerunning Tegami, Homebrew, or AUR publication

## Root cause

Release run `33852417146` failed only for `aarch64-unknown-linux-musl`. The selected compiler was correct, but jemalloc atomic probes linked libgcc outlined atomics against glibc-only `__getauxval`. This exactly matches upstream jemalloc issue #2782, where `-mno-outline-atomics` is the confirmed build toggle.

## Verification

- RED: release job `100959325905`, exit 101
- `actionlint`
- `git diff --check`
- GREEN gate: new `build (aarch64-unknown-linux-musl)` PR job must pass on `ubuntu-24.04-arm`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failed `aarch64-unknown-linux-musl` release build and adds a PR CI job to catch the failure early.

- Passes `-mno-outline-atomics` to jemalloc for the aarch64 musl target to avoid linking glibc-only `__getauxval` (jemalloc issue #2782).
- Adds a `build (aarch64-unknown-linux-musl)` PR job on `ubuntu-24.04-arm`.
- Allows `workflow_dispatch` to rebuild assets for an existing release tag without rerunning Tegami, Homebrew, or AUR publication.

<sup>Written for commit bd8436acd1ecc94f02c91d7eacd5a1f36c14cfc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

