### PR TITLE
fix(release): publish channels after recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
 
   homebrew:
     needs: [release, binaries]
-    if: needs.release.outputs.tag != '' && github.event_name == 'push'
+    if: needs.release.outputs.tag != ''
     runs-on: ubuntu-latest
     env:
       TAG: ${{ needs.release.outputs.tag }}
@@ -196,7 +196,7 @@ jobs:
 
   aur:
     needs: [release, binaries]
-    if: needs.release.outputs.tag != '' && github.event_name == 'push'
+    if: needs.release.outputs.tag != ''
     runs-on: ubuntu-latest
     # AUR publishing must not block a release (e.g. AUR maintenance windows).
     continue-on-error: true


### PR DESCRIPTION
## Summary

- run the existing idempotent Homebrew publisher after a successful tag recovery
- run the non-blocking AUR publisher after recovery as well
- prevent a recovered GitHub release from leaving package channels on the previous version

## RED

Recovery run `33855727498` rebuilt all 14 assets successfully, but Homebrew and AUR were skipped and both remained on 0.0.20.

## Verification

- `actionlint`
- `git diff --check`
- GREEN gate: recovery dispatch updates Homebrew and AUR to 0.0.21

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release workflow so Homebrew and AUR packages publish after tag recovery, preventing package channels from staying on the previous version.

Previously, both publishers only ran on push events, so recovery runs rebuilt release assets but skipped Homebrew and AUR. Now they run whenever a tag is present, matching the existing idempotent publisher behavior. AUR publishing remains non-blocking.

<sup>Written for commit 99a3a1883efd0ab2af3da0015df5f28f677b11ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

