### PR TITLE
chore: pin Rust 1.97.1 toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.97.1
           components: clippy, rustfmt
 
       # prost-build (et-core) requires protoc.
@@ -45,7 +46,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
 
       - uses: arduino/setup-protoc@v3
         with:
@@ -89,7 +92,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
 
       - uses: arduino/setup-protoc@v3
         with:
@@ -110,8 +115,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.97.1
           targets: aarch64-unknown-linux-musl
 
       - uses: arduino/setup-protoc@v3

--- a/.github/workflows/qa-published-release.yml
+++ b/.github/workflows/qa-published-release.yml
@@ -27,7 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
 
       - uses: arduino/setup-protoc@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,10 @@ jobs:
           cache: npm
 
       # Needed for `cargo update --workspace` after version bumps.
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         if: github.event_name == 'push'
+        with:
+          toolchain: 1.97.1
 
       - if: github.event_name == 'push'
         run: npm ci
@@ -103,8 +105,9 @@ jobs:
         with:
           ref: ${{ needs.release.outputs.tag }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.97.1
           targets: ${{ matrix.target }}
 
       # prost-build (et-core) requires protoc.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.97.1"
+profile = "minimal"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

- track the repository Rust toolchain using the standard `rust-toolchain.toml` format
- pin Rust 1.97.1 with the minimal profile, rustfmt, and clippy
- align every CI, release, and published-QA installer with the same exact toolchain so cross-targets are installed where Cargo uses them

## Verification

- RED without the file: the workstation selected its default Rust 1.88.0
- GREEN with the file: rustc/cargo 1.97.1, rustfmt 1.9.0, clippy 0.1.97
- local `cargo fmt --all --check`
- local `cargo clippy --workspace --all-targets -- -D warnings`
- `actionlint`

## CI regression caught

The first run installed `aarch64-unknown-linux-musl` on moving `stable` (1.98.1) while the new TOML made Cargo use 1.97.1. The exact ARM-musl job correctly failed with `E0463`; the follow-up commit makes all workflow installers explicitly install 1.97.1.