### PR TITLE
fix(terminal): trim MOTD blank lines before prompt

### DIFF
--- a/.tegami/fix-motd-trailing-blank-lines.md
+++ b/.tegami/fix-motd-trailing-blank-lines.md
@@ -1,0 +1,11 @@
+---
+packages:
+  et:
+    type: patch
+---
+
+## Remove blank lines before the login prompt
+
+Collapse trailing blank lines after assembling the server's complete MOTD so
+new ET sessions place the shell prompt directly below the final login message.
+Blank lines within a message and between separate MOTD sources remain intact.

--- a/crates/et-bin/src/terminal_motd.rs
+++ b/crates/et-bin/src/terminal_motd.rs
@@ -164,17 +164,15 @@ fn try_read_message(path: &Path) -> Result<Option<Vec<u8>>, ()> {
     Ok(Some(bytes))
 }
 
-/// Preserve existing CRLF and make lone LF render from column zero.
+/// Preserve internal CRLF, normalize lone LF, and end with one CRLF.
 fn append_terminal_bytes(output: &mut Vec<u8>, bytes: &[u8]) {
     if bytes.is_empty() {
         return;
     }
-    let body = bytes.strip_suffix(b"\n").unwrap_or(bytes);
-    let body = if bytes.ends_with(b"\r\n") {
-        body.strip_suffix(b"\r").unwrap_or(body)
-    } else {
-        body
-    };
+    let mut body = bytes;
+    while let Some(without_lf) = body.strip_suffix(b"\n") {
+        body = without_lf.strip_suffix(b"\r").unwrap_or(without_lf);
+    }
     let content_limit = MAX_MOTD_TOTAL.saturating_sub(2);
     let mut previous = 0u8;
     for byte in body {

--- a/crates/et-bin/src/terminal_motd.rs
+++ b/crates/et-bin/src/terminal_motd.rs
@@ -66,7 +66,7 @@ fn load_from(
         let mut output = Vec::new();
         let message = read_message(path)?;
         append_terminal_bytes(&mut output, &message);
-        return (!output.is_empty()).then_some(output);
+        return finish_output(output);
     }
     load_defaults_from(&[], files, directories, home)
 }
@@ -96,7 +96,7 @@ fn load_defaults_from(
             append_terminal_bytes(&mut output, &message);
         }
     }
-    (!output.is_empty()).then_some(output)
+    finish_output(output)
 }
 
 fn append_first_message(output: &mut Vec<u8>, paths: &[PathBuf]) {
@@ -164,15 +164,17 @@ fn try_read_message(path: &Path) -> Result<Option<Vec<u8>>, ()> {
     Ok(Some(bytes))
 }
 
-/// Preserve internal CRLF, normalize lone LF, and end with one CRLF.
+/// Preserve existing CRLF and make lone LF render from column zero.
 fn append_terminal_bytes(output: &mut Vec<u8>, bytes: &[u8]) {
     if bytes.is_empty() {
         return;
     }
-    let mut body = bytes;
-    while let Some(without_lf) = body.strip_suffix(b"\n") {
-        body = without_lf.strip_suffix(b"\r").unwrap_or(without_lf);
-    }
+    let body = bytes.strip_suffix(b"\n").unwrap_or(bytes);
+    let body = if bytes.ends_with(b"\r\n") {
+        body.strip_suffix(b"\r").unwrap_or(body)
+    } else {
+        body
+    };
     let content_limit = MAX_MOTD_TOTAL.saturating_sub(2);
     let mut previous = 0u8;
     for byte in body {
@@ -190,6 +192,14 @@ fn append_terminal_bytes(output: &mut Vec<u8>, bytes: &[u8]) {
     if output.len().saturating_add(2) <= MAX_MOTD_TOTAL {
         output.extend_from_slice(b"\r\n");
     }
+}
+
+/// Remove blank lines only after every MOTD source has been assembled.
+fn finish_output(mut output: Vec<u8>) -> Option<Vec<u8>> {
+    while output.ends_with(b"\r\n\r\n") {
+        output.truncate(output.len() - 2);
+    }
+    (!output.is_empty()).then_some(output)
 }
 
 #[cfg(test)]

--- a/crates/et-bin/src/terminal_motd_tests.rs
+++ b/crates/et-bin/src/terminal_motd_tests.rs
@@ -140,6 +140,24 @@ fn load_shows_dynamic_message_before_static_defaults() {
 }
 
 #[test]
+fn load_preserves_source_spacing_and_trims_only_final_blank_lines() {
+    let sandbox = Sandbox::new("source-spacing");
+    let dynamic = sandbox.file("motd.dynamic", b"dynamic\n\n");
+    let static_message = sandbox.file("motd", b"static\n\n\n");
+
+    assert_eq!(
+        load_defaults_from(
+            std::slice::from_ref(&dynamic),
+            std::slice::from_ref(&static_message),
+            &[],
+            None,
+        )
+        .unwrap(),
+        b"dynamic\r\n\r\nstatic\r\n"
+    );
+}
+
+#[test]
 fn load_orders_directory_union_and_honors_priority_overrides() {
     let sandbox = Sandbox::new("directories");
     let high = sandbox.directory("etc");

--- a/crates/et-bin/tests/terminal_runtime.rs
+++ b/crates/et-bin/tests/terminal_runtime.rs
@@ -30,10 +30,11 @@ const PROMPT_MARKER: &[u8] = b"ET-PROMPT> ";
 
 fn assert_motd_prompt_spacing(
     fixture_name: &str,
+    motd_contents: &[u8],
     shell_factory: fn(&Fixture) -> std::path::PathBuf,
 ) {
     let fixture = Fixture::new(fixture_name);
-    let motd = fixture.file("motd", b"ET-MOTD-MARKER\n");
+    let motd = fixture.file("motd", motd_contents);
     let shell = shell_factory(&fixture);
     let mut child = fixture.spawn_session(
         shell.to_str().unwrap(),
@@ -602,14 +603,28 @@ fn real_terminal_emits_motd_before_login_shell_output() {
 
 #[test]
 fn real_terminal_places_prompt_on_line_after_motd() {
-    assert_motd_prompt_spacing("motd-prompt-spacing", Fixture::prompt_probe_shell);
+    assert_motd_prompt_spacing(
+        "motd-prompt-spacing",
+        b"ET-MOTD-MARKER\n",
+        Fixture::prompt_probe_shell,
+    );
 }
 
 #[test]
 fn real_terminal_does_not_stack_motd_newline_with_shell_startup_newline() {
     assert_motd_prompt_spacing(
         "motd-leading-shell-newline",
+        b"ET-MOTD-MARKER\n",
         Fixture::leading_newline_prompt_shell,
+    );
+}
+
+#[test]
+fn real_terminal_removes_trailing_blank_lines_from_motd() {
+    assert_motd_prompt_spacing(
+        "motd-trailing-blank-lines",
+        b"ET-MOTD-MARKER\n\n\n",
+        Fixture::prompt_probe_shell,
     );
 }
 


### PR DESCRIPTION
## Summary
- collapse trailing blank lines only after the complete server MOTD is assembled
- preserve blank lines inside messages and between distinct MOTD sources
- add unit and real-PTY regression coverage plus a patch changeset

## Verification
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1` (683 passed)
- five-lane review: goal, hands-on QA, code quality, security, and release context all PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trims trailing blank lines from the assembled MOTD so the shell prompt sits directly below the last login message. Previously trailing blank lines from any MOTD source would stack with the prompt, adding unwanted vertical space; blank lines inside a message or between separate MOTD sources are preserved.

Adds unit and real-PTY regression tests plus a patch changeset.

<sup>Written for commit 67e86f2de42f2de37cfa36c1d4f6cf8987c83eae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

