### PR TITLE
fix(terminal): show previous login details

### DIFF
--- a/.tegami/fix-last-login-output.md
+++ b/.tegami/fix-last-login-output.md
@@ -1,0 +1,12 @@
+---
+packages:
+  et:
+    type: patch
+---
+
+## Show the previous login before the shell prompt
+
+New Linux terminal sessions now show the authenticated user's previous login
+time and remote host after the MOTD, matching SSH's login details. Missing or
+unreadable accounting data remains advisory, and `.hushlogin` suppresses the
+complete greeting.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +418,7 @@ dependencies = [
  "et-htm",
  "et-net",
  "et-server",
+ "jiff",
  "nix 0.31.3",
  "portable-pty",
  "prost",
@@ -469,7 +501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 1.0.69",
  "winapi",
 ]
 
@@ -599,6 +631,43 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "js-sys"
@@ -835,6 +904,21 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -1275,7 +1359,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -1287,6 +1380,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/crates/et-bin/Cargo.toml
+++ b/crates/et-bin/Cargo.toml
@@ -51,6 +51,9 @@ windows-spawn = "0.1.0"
 [target.'cfg(target_os = "linux")'.dependencies]
 tikv-jemallocator = "0.7.0"
 
+[target.'cfg(all(target_os = "linux", target_env = "gnu", any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
+jiff = { version = "0.2.35", default-features = false, features = ["tz-system", "tzdb-zoneinfo"] }
+
 [dev-dependencies]
 socket2 = "0.6.1"
 

--- a/crates/et-bin/src/main.rs
+++ b/crates/et-bin/src/main.rs
@@ -119,6 +119,12 @@ mod terminal_credentials;
 mod terminal_daemon;
 // The message of the day comes from `pam_motd`'s files, which exist only on
 // POSIX systems.
+#[cfg(all(
+    target_os = "linux",
+    target_env = "gnu",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
+mod terminal_last_login;
 #[cfg(unix)]
 mod terminal_motd;
 mod terminal_protocol;

--- a/crates/et-bin/src/terminal_last_login.rs
+++ b/crates/et-bin/src/terminal_last_login.rs
@@ -1,0 +1,116 @@
+//! OpenSSH-compatible previous-login output for new Linux terminal sessions.
+
+use std::fs::File;
+use std::os::unix::fs::FileExt;
+use std::path::{Path, PathBuf};
+
+use jiff::fmt::strtime;
+#[cfg(test)]
+use jiff::tz::Offset;
+use jiff::tz::TimeZone;
+use jiff::Timestamp;
+use rustix::fs::{Mode, OFlags};
+
+const DEFAULT_PATH: &str = "/var/log/lastlog";
+const HOST_BYTES: usize = 256;
+const OVERRIDE_VARIABLE: &str = "ET_LASTLOG_PATH";
+
+#[derive(Clone, Copy)]
+struct Layout {
+    record_bytes: usize,
+    timestamp_bytes: usize,
+    host_offset: usize,
+}
+
+// glibc's x86_64 ABI keeps a 32-bit lastlog time for compatibility, while
+// aarch64 uses its native 64-bit time_t. These are the two GNU/Linux
+// architectures shipped by et.rs.
+#[cfg(target_arch = "x86_64")]
+const NATIVE_LAYOUT: Layout = Layout {
+    record_bytes: 292,
+    timestamp_bytes: 4,
+    host_offset: 36,
+};
+#[cfg(target_arch = "aarch64")]
+const NATIVE_LAYOUT: Layout = Layout {
+    record_bytes: 296,
+    timestamp_bytes: 8,
+    host_offset: 40,
+};
+
+pub fn load() -> Option<Vec<u8>> {
+    let path = std::env::var_os(OVERRIDE_VARIABLE)
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_PATH));
+    let uid = rustix::process::geteuid().as_raw();
+    let time_zone = TimeZone::try_system().ok()?;
+    load_from_time_zone(&path, uid, &time_zone, NATIVE_LAYOUT)
+}
+
+#[cfg(test)]
+fn load_from(path: &Path, uid: u32, utc_offset_seconds: i32) -> Option<Vec<u8>> {
+    let offset = Offset::from_seconds(utc_offset_seconds).ok()?;
+    load_from_time_zone(path, uid, &TimeZone::fixed(offset), NATIVE_LAYOUT)
+}
+
+fn load_from_time_zone(
+    path: &Path,
+    uid: u32,
+    time_zone: &TimeZone,
+    layout: Layout,
+) -> Option<Vec<u8>> {
+    let descriptor = rustix::fs::open(
+        path,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NONBLOCK,
+        Mode::empty(),
+    )
+    .ok()?;
+    let file = File::from(descriptor);
+    if !file.metadata().ok()?.is_file() {
+        return None;
+    }
+
+    let offset = u64::from(uid).checked_mul(u64::try_from(layout.record_bytes).ok()?)?;
+    let mut record = vec![0u8; layout.record_bytes];
+    file.read_exact_at(&mut record, offset).ok()?;
+    let timestamp = match layout.timestamp_bytes {
+        4 => i64::from(u32::from_ne_bytes(record.get(..4)?.try_into().ok()?)),
+        8 => i64::from_ne_bytes(record.get(..8)?.try_into().ok()?),
+        _ => return None,
+    };
+    if timestamp <= 0 {
+        return None;
+    }
+    let host = sanitize_host(record.get(layout.host_offset..layout.host_offset + HOST_BYTES)?);
+    format_line(timestamp, host, time_zone)
+}
+
+fn sanitize_host(bytes: &[u8]) -> Option<&str> {
+    let end = bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(bytes.len());
+    let host = bytes.get(..end)?;
+    if host.is_empty() || !host.iter().all(|byte| matches!(byte, 0x20..=0x7e)) {
+        return None;
+    }
+    std::str::from_utf8(host).ok()
+}
+
+fn format_line(timestamp: i64, host: Option<&str>, time_zone: &TimeZone) -> Option<Vec<u8>> {
+    let timestamp = Timestamp::from_second(timestamp).ok()?;
+    let zoned = timestamp.to_zoned(time_zone.clone());
+    let ctime = strtime::format("%a %b %e %T %Y", &zoned).ok()?;
+    let mut output = format!("Last login: {ctime}").into_bytes();
+    if let Some(host) = host {
+        output.extend_from_slice(b" from ");
+        output.extend_from_slice(host.as_bytes());
+    }
+    output.extend_from_slice(b"\r\n");
+    Some(output)
+}
+
+#[cfg(test)]
+#[path = "terminal_last_login_tests.rs"]
+mod tests;

--- a/crates/et-bin/src/terminal_last_login_tests.rs
+++ b/crates/et-bin/src/terminal_last_login_tests.rs
@@ -1,0 +1,177 @@
+use std::fs::{self, OpenOptions};
+use std::os::unix::fs::FileExt;
+use std::path::PathBuf;
+
+use super::*;
+
+const RECORD_BYTES: usize = 292;
+const TEST_UID: u32 = 2;
+const TEST_TIMESTAMP: u32 = 1_788_475_267;
+
+struct Sandbox(PathBuf);
+
+impl Sandbox {
+    fn new(label: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "et-rs-last-login-{label}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).unwrap();
+        Self(path)
+    }
+
+    fn record(&self, timestamp: u32, host: &[u8]) -> PathBuf {
+        let path = self.0.join("lastlog");
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        let mut record = [0u8; RECORD_BYTES];
+        record[..4].copy_from_slice(&timestamp.to_ne_bytes());
+        let host = &host[..host.len().min(256)];
+        record[36..36 + host.len()].copy_from_slice(host);
+        file.write_all_at(
+            &record,
+            u64::from(TEST_UID) * u64::try_from(RECORD_BYTES).unwrap(),
+        )
+        .unwrap();
+        path
+    }
+}
+
+impl Drop for Sandbox {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn load_formats_host_record_with_fixed_offset() {
+    let sandbox = Sandbox::new("host");
+    let path = sandbox.record(TEST_TIMESTAMP, b"127.0.0.1");
+
+    assert_eq!(
+        load_from(&path, TEST_UID, 0).unwrap(),
+        b"Last login: Thu Sep  3 22:41:07 2026 from 127.0.0.1\r\n"
+    );
+}
+
+#[test]
+fn load_omits_from_clause_when_host_is_empty() {
+    let sandbox = Sandbox::new("empty-host");
+    let path = sandbox.record(TEST_TIMESTAMP, b"");
+
+    assert_eq!(
+        load_from(&path, TEST_UID, 0).unwrap(),
+        b"Last login: Thu Sep  3 22:41:07 2026\r\n"
+    );
+}
+
+#[test]
+fn load_applies_server_timezone_offset() {
+    let sandbox = Sandbox::new("offset");
+    let path = sandbox.record(TEST_TIMESTAMP, b"127.0.0.1");
+
+    assert_eq!(
+        load_from(&path, TEST_UID, 9 * 60 * 60).unwrap(),
+        b"Last login: Fri Sep  4 07:41:07 2026 from 127.0.0.1\r\n"
+    );
+}
+
+#[test]
+fn load_omits_missing_source() {
+    let sandbox = Sandbox::new("missing");
+
+    assert_eq!(load_from(&sandbox.0.join("missing"), TEST_UID, 0), None);
+}
+
+#[test]
+fn load_omits_zero_timestamp() {
+    let sandbox = Sandbox::new("zero");
+    let path = sandbox.record(0, b"127.0.0.1");
+
+    assert_eq!(load_from(&path, TEST_UID, 0), None);
+}
+
+#[test]
+fn load_omits_short_record() {
+    let sandbox = Sandbox::new("short");
+    let path = sandbox.0.join("lastlog");
+    fs::write(&path, b"short").unwrap();
+
+    assert_eq!(load_from(&path, TEST_UID, 0), None);
+}
+
+#[test]
+fn load_omits_nonregular_source() {
+    let sandbox = Sandbox::new("nonregular");
+    let path = sandbox.0.join("directory");
+    fs::create_dir(&path).unwrap();
+
+    assert_eq!(load_from(&path, TEST_UID, 0), None);
+}
+
+#[test]
+fn load_drops_host_clause_for_control_bytes() {
+    let sandbox = Sandbox::new("control-host");
+    let path = sandbox.record(TEST_TIMESTAMP, b"bad\r\n\x1b[31mhost");
+
+    assert_eq!(
+        load_from(&path, TEST_UID, 0).unwrap(),
+        b"Last login: Thu Sep  3 22:41:07 2026\r\n"
+    );
+}
+
+#[test]
+fn load_preserves_ipv6_literal_host() {
+    let sandbox = Sandbox::new("ipv6");
+    let path = sandbox.record(TEST_TIMESTAMP, b"2001:db8::1");
+
+    assert_eq!(
+        load_from(&path, TEST_UID, 0).unwrap(),
+        b"Last login: Thu Sep  3 22:41:07 2026 from 2001:db8::1\r\n"
+    );
+}
+
+#[test]
+fn load_bounds_full_host_field() {
+    let sandbox = Sandbox::new("full-host");
+    let host = [b'x'; 256];
+    let path = sandbox.record(TEST_TIMESTAMP, &host);
+    let output = load_from(&path, TEST_UID, 0).unwrap();
+
+    assert_eq!(output.len(), 12 + 24 + 6 + 256 + 2);
+    assert!(output.ends_with(b"\r\n"));
+}
+
+#[test]
+fn aarch64_layout_decodes_independent_literal_fixture() {
+    let sandbox = Sandbox::new("aarch64");
+    let path = sandbox.0.join("lastlog");
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&path)
+        .unwrap();
+    let mut record = [0u8; 296];
+    record[..8].copy_from_slice(&i64::from(TEST_TIMESTAMP).to_ne_bytes());
+    record[40..48].copy_from_slice(b"10.0.0.1");
+    file.write_all_at(&record, u64::from(TEST_UID) * 296)
+        .unwrap();
+    let layout = Layout {
+        record_bytes: 296,
+        timestamp_bytes: 8,
+        host_offset: 40,
+    };
+    let output = load_from_time_zone(&path, TEST_UID, &TimeZone::UTC, layout).unwrap();
+
+    assert_eq!(
+        output,
+        b"Last login: Thu Sep  3 22:41:07 2026 from 10.0.0.1\r\n"
+    );
+}

--- a/crates/et-bin/src/terminal_motd.rs
+++ b/crates/et-bin/src/terminal_motd.rs
@@ -28,11 +28,38 @@ const DEFAULT_FILES: [&str; 3] = ["/etc/motd", "/run/motd", "/usr/lib/motd"];
 /// `pam_motd(8)`'s default directories, highest priority first.
 const DEFAULT_DIRS: [&str; 3] = ["/etc/motd.d", "/run/motd.d", "/usr/lib/motd.d"];
 
-/// Load the message of the day, if there is one to show.
+/// Load the complete new-session greeting before the login shell starts.
 ///
 /// File-level failures are advisory and never fail the session.
-pub fn load() -> Option<Vec<u8>> {
+pub fn load_startup_prefix() -> Option<Vec<u8>> {
     let home = std::env::var_os("HOME").map(PathBuf::from);
+    if home.is_some_and(|home| home.join(".hushlogin").exists()) {
+        return None;
+    }
+
+    let mut output = load_with_home(None).unwrap_or_default();
+    #[cfg(all(
+        target_os = "linux",
+        target_env = "gnu",
+        any(target_arch = "x86_64", target_arch = "aarch64")
+    ))]
+    let last_login = crate::terminal_last_login::load();
+    #[cfg(not(all(
+        target_os = "linux",
+        target_env = "gnu",
+        any(target_arch = "x86_64", target_arch = "aarch64")
+    )))]
+    let last_login: Option<Vec<u8>> = None;
+    if let Some(last_login) = last_login {
+        if !output.is_empty() {
+            output.extend_from_slice(b"\r\n");
+        }
+        output.extend_from_slice(&last_login);
+    }
+    (!output.is_empty()).then_some(output)
+}
+
+fn load_with_home(home: Option<&Path>) -> Option<Vec<u8>> {
     let override_path = std::env::var_os(OVERRIDE_VARIABLE)
         .filter(|path| !path.is_empty())
         .map(PathBuf::from);
@@ -40,14 +67,9 @@ pub fn load() -> Option<Vec<u8>> {
     let directories: Vec<PathBuf> = DEFAULT_DIRS.iter().map(PathBuf::from).collect();
     let dynamic_files: Vec<PathBuf> = DYNAMIC_FILES.iter().map(PathBuf::from).collect();
     let text = if override_path.is_some() {
-        load_from(
-            &files,
-            &directories,
-            override_path.as_deref(),
-            home.as_deref(),
-        )
+        load_from(&files, &directories, override_path.as_deref(), home)
     } else {
-        load_defaults_from(&dynamic_files, &files, &directories, home.as_deref())
+        load_defaults_from(&dynamic_files, &files, &directories, home)
     };
     text
 }

--- a/crates/et-bin/src/terminal_pty.rs
+++ b/crates/et-bin/src/terminal_pty.rs
@@ -62,7 +62,7 @@ where
             .map_err(|error| format!("could not bound terminal output buffering: {error}"))?;
     }
     #[cfg(unix)]
-    let motd = crate::terminal_motd::load();
+    let motd = crate::terminal_motd::load_startup_prefix();
     let pair = native_pty_system()
         .openpty(PtySize {
             rows: 24,

--- a/crates/et-bin/tests/terminal_runtime.rs
+++ b/crates/et-bin/tests/terminal_runtime.rs
@@ -3,7 +3,10 @@
 #[path = "terminal_runtime_support/mod.rs"]
 mod terminal_runtime_support;
 
+use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader, Read, Write};
+use std::os::unix::fs::FileExt;
+use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
@@ -25,6 +28,8 @@ const ID: &str = "abcdefghijklmnop";
 const KEY: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef";
 const TIMEOUT: Duration = Duration::from_secs(5);
 const LOGIN_TERM_COMPLETION: &[u8] = b"__ET_LOGIN_TERM_COMPLETE__\r\n";
+const LAST_LOGIN_MARKER: &[u8] = b"Last login:";
+const LASTLOG_RECORD_BYTES: usize = 292;
 const MOTD_MARKER: &[u8] = b"ET-MOTD-MARKER";
 const PROMPT_MARKER: &[u8] = b"ET-PROMPT> ";
 
@@ -76,6 +81,21 @@ fn assert_motd_prompt_spacing(
     );
     let status = child.wait_timeout(TIMEOUT).unwrap().unwrap();
     assert!(status.success());
+}
+
+fn write_lastlog_record(path: &Path, timestamp: u32, host: &[u8]) {
+    let mut record = [0u8; LASTLOG_RECORD_BYTES];
+    record[..4].copy_from_slice(&timestamp.to_ne_bytes());
+    let host = &host[..host.len().min(256)];
+    record[36..36 + host.len()].copy_from_slice(host);
+    let file = OpenOptions::new()
+        .write(true)
+        .truncate(false)
+        .open(path)
+        .unwrap();
+    let offset =
+        u64::from(rustix::process::geteuid().as_raw()) * u64::try_from(record.len()).unwrap();
+    file.write_all_at(&record, offset).unwrap();
 }
 
 #[test]
@@ -629,10 +649,65 @@ fn real_terminal_removes_trailing_blank_lines_from_motd() {
 }
 
 #[test]
+fn real_terminal_emits_last_login_between_motd_and_prompt() {
+    let fixture = Fixture::new("last-login");
+    let motd = fixture.file("motd", b"ET-MOTD-MARKER\n\n\n");
+    let lastlog = fixture.file("lastlog", b"");
+    write_lastlog_record(&lastlog, 1_788_475_267, b"127.0.0.1");
+    let shell = fixture.prompt_probe_shell();
+    let mut child = fixture.spawn_session(
+        shell.to_str().unwrap(),
+        &[
+            ("ET_MOTD_PATH", motd.as_os_str()),
+            ("ET_LASTLOG_PATH", lastlog.as_os_str()),
+            ("TZ", std::ffi::OsStr::new("UTC")),
+        ],
+    );
+    write_credentials(&mut child);
+    let mut router = fixture.accept();
+    let _ = read_local_packet(&mut router).unwrap();
+    acknowledge_registration(&mut router);
+    fixture.wait_ready();
+
+    send(
+        &mut router,
+        TerminalPacketType::TerminalInit,
+        &TermInit {
+            environmentnames: Vec::new(),
+            environmentvalues: Vec::new(),
+            flowcontrol: None,
+        },
+    );
+    expect_startup(&mut router);
+    let output = collect_until(&mut router, |output| contains(output, PROMPT_MARKER));
+
+    let motd_at = find(&output, MOTD_MARKER).unwrap();
+    let prompt_at = find(&output, PROMPT_MARKER).unwrap();
+    assert_eq!(
+        &output[motd_at + MOTD_MARKER.len()..prompt_at],
+        b"\r\n\r\nLast login: Thu Sep  3 22:41:07 2026 from 127.0.0.1\r\n",
+        "expected SSH-compatible MOTD, blank line, last-login, and prompt order; got {:?}",
+        String::from_utf8_lossy(&output),
+    );
+
+    send(
+        &mut router,
+        TerminalPacketType::TerminalBuffer,
+        &TerminalBuffer {
+            buffer: Some(b"exit\n".to_vec()),
+        },
+    );
+    let status = child.wait_timeout(TIMEOUT).unwrap().unwrap();
+    assert!(status.success());
+}
+
+#[test]
 fn real_terminal_suppresses_motd_when_home_has_hushlogin() {
     // Given: a MOTD file plus a HOME containing .hushlogin.
     let fixture = Fixture::new("motd-hushlogin");
     let motd = fixture.file("motd", b"ET-MOTD-MARKER\n");
+    let lastlog = fixture.file("lastlog", b"");
+    write_lastlog_record(&lastlog, 1_788_475_267, b"127.0.0.1");
     let home = fixture.file(".hushlogin", b"");
     let home = home.parent().unwrap().to_owned();
     let shell = fixture.login_probe_shell();
@@ -675,6 +750,11 @@ fn real_terminal_suppresses_motd_when_home_has_hushlogin() {
     assert!(
         !contains(&output, MOTD_MARKER),
         "expected .hushlogin to suppress the MOTD; got {:?}",
+        String::from_utf8_lossy(&output),
+    );
+    assert!(
+        !contains(&output, LAST_LOGIN_MARKER),
+        "expected .hushlogin to suppress last-login output; got {:?}",
         String::from_utf8_lossy(&output),
     );
 }

--- a/crates/et-bin/tests/terminal_runtime_support/mod.rs
+++ b/crates/et-bin/tests/terminal_runtime_support/mod.rs
@@ -99,6 +99,7 @@ impl Fixture {
                 "--serverfifo",
             ])
             .arg(&self.socket)
+            .env("ET_LASTLOG_PATH", self.directory.join("lastlog"))
             .env("SHELL", shell)
             .env_remove("COLORTERM");
         for (name, value) in environment {


### PR DESCRIPTION
## Summary
- show the previous login timestamp and host after the MOTD on GNU/Linux
- preserve `.hushlogin`, MOTD spacing, reconnect, jump, Windows, and protocol behavior
- support the shipped x86_64 and aarch64 glibc lastlog ABIs with bounded read-only I/O

## Verification
- RED→GREEN: `real_terminal_emits_last_login_between_motd_and_prompt`
- `terminal_last_login`: 11 passed
- `terminal_motd`: 11 passed
- `terminal_runtime`: 17 passed
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- x86_64 and aarch64 GNU checks
- mass-ulw goal/security/executable verification: PASS
- live SSH/ET PTY comparison: PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the previous login time and host in new Linux terminal sessions after the MOTD, matching SSH's login details. Previously only the MOTD was shown.

- Applies only to GNU/Linux glibc builds on x86_64 and aarch64.
- `.hushlogin` suppresses the entire greeting, including last-login output.
- Missing or unreadable lastlog records are silently skipped without failing the session.
- Adds `ET_LASTLOG_PATH` to override the lastlog file location for testing.
- Adds the `jiff` dependency for timezone-aware formatting.

<sup>Written for commit 7124e5e95a930069fddcd7ffa4bc2b2bb82e4be7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

