### PR TITLE
fix(terminal): match SSH login greeting output

### DIFF
--- a/.tegami/fix-motd-ssh-parity.md
+++ b/.tegami/fix-motd-ssh-parity.md
@@ -1,0 +1,11 @@
+---
+packages:
+  et:
+    type: patch
+---
+
+## Match SSH login greeting spacing
+
+Preserve the MOTD's original trailing blank lines without inserting an extra
+separator before the previous-login details. Internal SSH control-master
+checks no longer print status messages during ET startup.

--- a/crates/et-bin/src/ssh_process.rs
+++ b/crates/et-bin/src/ssh_process.rs
@@ -424,11 +424,23 @@ impl SshRunner for SystemSsh {
             return Err(ClientError::SshTimeout(invocation.operation));
         }
         let mut command = Command::new(&invocation.program);
+        let checks_control_master = invocation
+            .args
+            .first()
+            .is_some_and(|argument| argument == "-O")
+            && invocation
+                .args
+                .get(1)
+                .is_some_and(|argument| argument == "check");
         command
             .args(&invocation.args)
             .stdin(Stdio::inherit())
             .stdout(Stdio::piped())
-            .stderr(Stdio::inherit());
+            .stderr(if checks_control_master {
+                Stdio::null()
+            } else {
+                Stdio::inherit()
+            });
         // ssh stays in our process group so it can prompt on the controlling
         // terminal (password, passphrase, host-key confirmation), matching
         // upstream `SubprocessToStringInteractive`. Moving it to its own group

--- a/crates/et-bin/src/terminal_motd.rs
+++ b/crates/et-bin/src/terminal_motd.rs
@@ -51,9 +51,6 @@ pub fn load_startup_prefix() -> Option<Vec<u8>> {
     )))]
     let last_login: Option<Vec<u8>> = None;
     if let Some(last_login) = last_login {
-        if !output.is_empty() {
-            output.extend_from_slice(b"\r\n");
-        }
         output.extend_from_slice(&last_login);
     }
     (!output.is_empty()).then_some(output)
@@ -216,11 +213,8 @@ fn append_terminal_bytes(output: &mut Vec<u8>, bytes: &[u8]) {
     }
 }
 
-/// Remove blank lines only after every MOTD source has been assembled.
-fn finish_output(mut output: Vec<u8>) -> Option<Vec<u8>> {
-    while output.ends_with(b"\r\n\r\n") {
-        output.truncate(output.len() - 2);
-    }
+/// Preserve source blank lines, matching the greeting displayed by SSH.
+fn finish_output(output: Vec<u8>) -> Option<Vec<u8>> {
     (!output.is_empty()).then_some(output)
 }
 

--- a/crates/et-bin/src/terminal_motd_tests.rs
+++ b/crates/et-bin/src/terminal_motd_tests.rs
@@ -140,7 +140,7 @@ fn load_shows_dynamic_message_before_static_defaults() {
 }
 
 #[test]
-fn load_preserves_source_spacing_and_trims_only_final_blank_lines() {
+fn load_preserves_source_spacing_including_final_blank_lines() {
     let sandbox = Sandbox::new("source-spacing");
     let dynamic = sandbox.file("motd.dynamic", b"dynamic\n\n");
     let static_message = sandbox.file("motd", b"static\n\n\n");
@@ -153,7 +153,7 @@ fn load_preserves_source_spacing_and_trims_only_final_blank_lines() {
             None,
         )
         .unwrap(),
-        b"dynamic\r\n\r\nstatic\r\n"
+        b"dynamic\r\n\r\nstatic\r\n\r\n\r\n"
     );
 }
 

--- a/crates/et-bin/tests/client_bootstrap.rs
+++ b/crates/et-bin/tests/client_bootstrap.rs
@@ -89,6 +89,7 @@ if [ -n "$ET_FAKE_CLIENT_PIDS" ]; then
   echo "$PPID" >> "$ET_FAKE_CLIENT_PIDS"
 fi
 if [ "$1" = "-O" ] && [ "$2" = "check" ]; then
+  printf "%s" "$ET_FAKE_MASTER_STDERR" >&2
   if [ -n "$control_path" ]; then
     [ -e "$control_path" ] && exit 0
     exit 255
@@ -587,6 +588,26 @@ fn bootstrap_ssh_invocations_share_a_private_session_control_path() {
     assert!(
         path.exists(),
         "ControlPersist socket did not survive the session"
+    );
+}
+
+#[test]
+fn control_master_status_is_not_forwarded_to_client_stderr() {
+    let (port, server) = initial_payload_server();
+    let fake = FakeSsh::new();
+    let output = fake
+        .command(RESOLVED_CONFIG, VALID_MARKER, 0, "")
+        .env("ET_FAKE_MASTER_STDERR", "Master running (pid=1234)\n")
+        .args(["-N", &format!("server-alias:{port}")])
+        .output()
+        .unwrap();
+    server.join().unwrap();
+
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert!(
+        !stderr(&output).contains("Master running"),
+        "control-master status leaked to the user: {}",
+        stderr(&output),
     );
 }
 

--- a/crates/et-bin/tests/terminal_runtime.rs
+++ b/crates/et-bin/tests/terminal_runtime.rs
@@ -57,6 +57,7 @@ const PROMPT_MARKER: &[u8] = b"ET-PROMPT> ";
 fn assert_motd_prompt_spacing(
     fixture_name: &str,
     motd_contents: &[u8],
+    expected_spacing: &[u8],
     shell_factory: fn(&Fixture) -> std::path::PathBuf,
 ) {
     let fixture = Fixture::new(fixture_name);
@@ -88,8 +89,8 @@ fn assert_motd_prompt_spacing(
     let prompt_at = find(&output, PROMPT_MARKER).unwrap();
     assert_eq!(
         &output[motd_at + MOTD_MARKER.len()..prompt_at],
-        b"\r\n",
-        "expected prompt directly below MOTD; got {:?}",
+        expected_spacing,
+        "expected original MOTD spacing before prompt; got {:?}",
         String::from_utf8_lossy(&output),
     );
 
@@ -652,6 +653,7 @@ fn real_terminal_places_prompt_on_line_after_motd() {
     assert_motd_prompt_spacing(
         "motd-prompt-spacing",
         b"ET-MOTD-MARKER\n",
+        b"\r\n",
         Fixture::prompt_probe_shell,
     );
 }
@@ -661,15 +663,17 @@ fn real_terminal_does_not_stack_motd_newline_with_shell_startup_newline() {
     assert_motd_prompt_spacing(
         "motd-leading-shell-newline",
         b"ET-MOTD-MARKER\n",
+        b"\r\n",
         Fixture::leading_newline_prompt_shell,
     );
 }
 
 #[test]
-fn real_terminal_removes_trailing_blank_lines_from_motd() {
+fn real_terminal_preserves_trailing_blank_lines_from_motd() {
     assert_motd_prompt_spacing(
         "motd-trailing-blank-lines",
         b"ET-MOTD-MARKER\n\n\n",
+        b"\r\n\r\n\r\n",
         Fixture::prompt_probe_shell,
     );
 }
@@ -716,8 +720,8 @@ fn real_terminal_emits_last_login_between_motd_and_prompt() {
     let prompt_at = find(&output, PROMPT_MARKER).unwrap();
     assert_eq!(
         &output[motd_at + MOTD_MARKER.len()..prompt_at],
-        b"\r\n\r\nLast login: Thu Sep  3 22:41:07 2026 from 127.0.0.1\r\n",
-        "expected SSH-compatible MOTD, blank line, last-login, and prompt order; got {:?}",
+        b"\r\n\r\n\r\nLast login: Thu Sep  3 22:41:07 2026 from 127.0.0.1\r\n",
+        "expected SSH-compatible MOTD, last-login, and prompt order; got {:?}",
         String::from_utf8_lossy(&output),
     );
 


### PR DESCRIPTION
## Summary

- Preserve the MOTD's original trailing blank lines and remove the artificial
  separator before `Last login`.
- Suppress stderr only for internal `ssh -O check` calls, keeping normal SSH
  diagnostics visible.
- Add a Tegami patch changelog for the next release, `et@0.0.24`.

## Validation

- Regression RED: the real terminal emitted one CRLF where the source MOTD
  required three. The updated source-spacing assertion passes after the fix.
- `cargo test -p et --bin et --test terminal_runtime --test client_bootstrap -- --test-threads=1`:
  221 passed.
- `cargo fmt --all --check`, workspace Clippy with `-D warnings`, and
  `cargo build --release`: passed.
- Live SSH and candidate ET logins on OCI 1 -> 2 and OCI 2 -> 1 used real PTYs.
  All four sessions reached the shell prompt and exited 0. Both MOTD prefixes
  matched byte-for-byte, including the final three CRLFs. No control-master
  status or control-socket diagnostics appeared.
- The complete greeting is display-equivalent, not byte-identical: login
  timestamps differ naturally, and SSH emits CRCRLF after `Last login` while
  ET emits CRLF. The redundant CR does not alter terminal rows or columns.
  No blank lines were removed by the comparison.

The initial full-workspace run hit a timeout in the unchanged
`et-net::forward::tests::shutdown_completes_with_command_and_outbound_queues_saturated`
at `crates/et-net/src/forward.rs:1157`. A subsequent complete run of `et-net`
and `et-server` passed. This intermittent failure was not hidden or weakened.

Validated candidate SHA-256:
`93bd9aec59afe98c06982bebdc52df295646f45649280e739c7875f7bb6bcf1f`.
Temporary OCI validation servers were removed; installed services were not
replaced.

## Release preparation

Current release: `et@0.0.23`. This PR adds a patch changelog; after merge, the
release workflow will open the `Version Packages` PR for `0.0.24`. Merging
that version PR creates the tag and GitHub release and starts binary builds.
This PR does not publish or deploy a release.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes ET's login greeting match real SSH output by preserving the MOTD's original trailing blank lines and removing the artificial separator before `Last login`. Internal SSH control-master status messages no longer appear on the user's stderr.

- Stderr suppression is scoped to `ssh -O check` calls only; normal SSH diagnostics stay visible.
- Adds a patch changelog for the upcoming `et@0.0.24` release.

<sup>Written for commit 6801fdd0cacf2b0e517f2edc9ca2b41e5bb17e7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

