### PR TITLE
test(windows): exercise native server runtime in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,11 @@ jobs:
           --test terminal_tty_qa
           -- --test-threads=1
 
-  # Windows build is release-critical; the test harnesses are POSIX-only,
-  # so compile the shipped binary crate (like the release pipeline) and
-  # grow into `cargo test` later.
+  # Real foreground server, native ConPTY output, same-session recovery and
+  # process-tree cleanup. Keep the existing check name for branch protection.
   build-windows:
     runs-on: windows-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -102,7 +102,36 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - run: cargo build -p et
+      - name: Build relocatable native runtime QA artifacts
+        shell: pwsh
+        run: |
+          cargo build --locked -p et --bin et
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $messages = cargo test --locked -p et --test windows_runtime --no-run --message-format=json
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $tests = @($messages | ForEach-Object { $_ | ConvertFrom-Json } | Where-Object {
+            $_.reason -eq 'compiler-artifact' -and $_.target.name -eq 'windows_runtime' -and $_.executable
+          })
+          if ($tests.Count -ne 1) { throw 'Expected exactly one Windows runtime test executable' }
+          New-Item -ItemType Directory windows-runtime-artifact | Out-Null
+          Copy-Item target/debug/et.exe windows-runtime-artifact/et.exe
+          Copy-Item $tests[0].executable windows-runtime-artifact/windows_runtime.exe
+          Copy-Item crates/et-bin/tests/windows_runtime_support/Run-WindowsRuntime.ps1 windows-runtime-artifact/
+
+      - name: Exercise native server and ConPTY runtime
+        shell: pwsh
+        run: |
+          cargo test -p et --test windows_runtime -- --test-threads=1 --nocapture 2>&1 | Tee-Object windows-runtime-artifact/native-runtime.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Upload native QA executables and transcript
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-runtime-${{ github.sha }}
+          path: windows-runtime-artifact/
+          if-no-files-found: error
+          retention-days: 14
 
   # The release matrix builds jemalloc on native ARM against musl. Ubuntu's
   # aarch64 musl GCC needs outlined atomics disabled so libgcc does not retain

--- a/crates/et-bin/tests/windows_runtime.rs
+++ b/crates/et-bin/tests/windows_runtime.rs
@@ -1,0 +1,53 @@
+//! Native Windows server/ConPTY coverage. No SSH daemon or installed service is used.
+#![cfg(windows)]
+#![forbid(unsafe_code)]
+
+mod windows_runtime_support;
+
+use std::net::Shutdown;
+
+use et_core::proto::ConnectStatus;
+use windows_runtime_support::{ProcessExitObserver, Shell, Stack};
+
+#[test]
+fn conpty_shell_state_survives_same_session_recovery_and_exit_reaps_descendants() {
+    // Given: the shipped server and terminal host a real native shell and child.
+    let mut stack = Stack::start();
+    let mut client = stack.connect();
+    let shell = Shell::start(&mut client);
+    let mut exits = ProcessExitObserver::subscribe(&shell);
+
+    // When: the transport disappears, then the same credentials return.
+    client
+        .try_clone_stream()
+        .unwrap()
+        .shutdown(Shutdown::Both)
+        .unwrap();
+    let returning = stack.handshake(ConnectStatus::ReturningClient);
+    client.recover(returning).unwrap();
+
+    // Then: a fresh command proves preserved shell state and both process IDs;
+    // a successful handshake alone (or replay of the old marker) cannot pass.
+    shell.assert_recovered(&mut client);
+    Shell::send(&mut client, "exit\r\n");
+    stack.wait_terminal(true);
+    exits.wait();
+    stack.finish();
+}
+
+#[test]
+fn losing_the_router_reaps_the_native_shell_and_its_descendant() {
+    // Given: exit observers hold process handles before the router is closed.
+    let mut stack = Stack::start();
+    let mut client = stack.connect();
+    let shell = Shell::start(&mut client);
+    let mut exits = ProcessExitObserver::subscribe(&shell);
+
+    // When: only this test's foreground server is terminated.
+    stack.stop_server();
+
+    // Then: terminal failure cleanup, not the fixture's fallback, reaps the tree.
+    stack.wait_terminal(false);
+    exits.wait();
+    stack.finish();
+}

--- a/crates/et-bin/tests/windows_runtime_support/Run-WindowsRuntime.ps1
+++ b/crates/et-bin/tests/windows_runtime_support/Run-WindowsRuntime.ps1
@@ -7,6 +7,6 @@ $testExecutable = Join-Path $PSScriptRoot 'windows_runtime.exe'
 if (!(Test-Path $env:ET_WINDOWS_RUNTIME_BINARY) -or !(Test-Path $testExecutable)) {
     throw 'Extract et.exe and windows_runtime.exe beside this script'
 }
-$testArguments = if ($args.Count -eq 0) { @('--test-threads=1', '--nocapture') } else { $args }
+[string[]]$testArguments = if ($args.Count -eq 0) { @('--test-threads=1', '--nocapture') } else { $args }
 & $testExecutable @testArguments
 exit $LASTEXITCODE

--- a/crates/et-bin/tests/windows_runtime_support/Run-WindowsRuntime.ps1
+++ b/crates/et-bin/tests/windows_runtime_support/Run-WindowsRuntime.ps1
@@ -1,0 +1,12 @@
+# Run the CI artifact on a native Windows host without Cargo or protoc.
+# Example: powershell -NoProfile -File .\Run-WindowsRuntime.ps1
+# Only ephemeral loopback endpoints and test-owned processes are used.
+$ErrorActionPreference = 'Stop'
+$env:ET_WINDOWS_RUNTIME_BINARY = Join-Path $PSScriptRoot 'et.exe'
+$testExecutable = Join-Path $PSScriptRoot 'windows_runtime.exe'
+if (!(Test-Path $env:ET_WINDOWS_RUNTIME_BINARY) -or !(Test-Path $testExecutable)) {
+    throw 'Extract et.exe and windows_runtime.exe beside this script'
+}
+$testArguments = if ($args.Count -eq 0) { @('--test-threads=1', '--nocapture') } else { $args }
+& $testExecutable @testArguments
+exit $LASTEXITCODE

--- a/crates/et-bin/tests/windows_runtime_support/fallback_probe.ps1
+++ b/crates/et-bin/tests/windows_runtime_support/fallback_probe.ps1
@@ -1,0 +1,38 @@
+$script:observedTargets = @()
+$script:cleanupCalls = 0
+function Complete-ObservedProcesses {
+    param($Targets, $Mode, $BeforeKill)
+    # Fail the body while both real, ready targets still need final cleanup.
+    $script:observedTargets = $Targets
+    throw 'injected probe body failure'
+}
+function Stop-ObservedProcess {
+    param([Diagnostics.Process]$Process)
+    $Process.Kill()
+    if (!$Process.WaitForExit(10000)) { throw 'injected target exit failed' }
+    $script:cleanupCalls++
+    if ($script:cleanupCalls -eq 1) {
+        throw [ComponentModel.Win32Exception]::new(5)
+    }
+}
+$failure = $null
+try {
+    try { Test-ProcessCleanup -Scenario 'error' } catch { $failure = $_ }
+    if ($script:observedTargets.Count -ne 2) { throw 'probe did not create both targets' }
+    if ($script:cleanupCalls -ne 2) { throw 'probe fallback abandoned a remaining target' }
+    if ($null -eq $failure) { throw 'probe fallback concealed its failure' }
+    Write-Output 'FALLBACK_PROBE_PASS'
+} finally {
+    foreach ($target in $script:observedTargets) {
+        try {
+            if (!$target.HasExited) {
+                $target.Kill()
+                if (!$target.WaitForExit(10000)) { throw 'probe external cleanup failed' }
+            }
+        } catch [InvalidOperationException] {
+            # The real probe has already disposed a successfully cleaned handle.
+        }
+    }
+}
+# Expected caught exceptions must not become PowerShell's implicit exit status.
+exit 0

--- a/crates/et-bin/tests/windows_runtime_support/mod.rs
+++ b/crates/et-bin/tests/windows_runtime_support/mod.rs
@@ -34,24 +34,19 @@ pub struct Stack {
 
 impl Stack {
     pub fn start() -> Self {
+        Self::start_with_setup(|_| {})
+    }
+
+    fn start_with_setup(before_config: impl FnOnce(&std::path::Path)) -> Self {
         let (id, key) = gen_id_passkey();
         let directory = std::env::temp_dir().join(format!("et-win-{}-{id}", std::process::id()));
-        fs::create_dir(&directory).unwrap();
         let router = directory.join("router");
         // The CLI deliberately rejects port zero. Reserve an ephemeral port and
         // fail on bind collision rather than retrying or using a fleet endpoint.
         let reserved = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
         let address = reserved.local_addr().unwrap();
         let config = directory.join("et.cfg");
-        fs::write(
-            &config,
-            format!(
-                "[Networking]\nport={}\nbind_ip=127.0.0.1\n[Debug]\nserverfifo={}\n",
-                address.port(),
-                router.display()
-            ),
-        )
-        .unwrap();
+        fs::create_dir(&directory).unwrap();
         let mut stack = Self {
             directory,
             address,
@@ -61,6 +56,16 @@ impl Stack {
             terminal: None,
             cleaned: false,
         };
+        before_config(&stack.directory);
+        fs::write(
+            &config,
+            format!(
+                "[Networking]\nport={}\nbind_ip=127.0.0.1\n[Debug]\nserverfifo={}\n",
+                address.port(),
+                router.display()
+            ),
+        )
+        .unwrap();
         drop(reserved);
         let mut command = binary();
         command
@@ -171,6 +176,9 @@ impl Stack {
         println!("FIXTURE_REMOVED {}", self.directory.display());
     }
 }
+
+#[path = "setup_tests.rs"]
+mod setup_tests;
 
 impl Drop for Stack {
     fn drop(&mut self) {

--- a/crates/et-bin/tests/windows_runtime_support/mod.rs
+++ b/crates/et-bin/tests/windows_runtime_support/mod.rs
@@ -1,0 +1,205 @@
+mod process;
+mod shell;
+
+pub use process::ProcessExitObserver;
+pub use shell::Shell;
+
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use et_core::keys::{gen_id_passkey, passkey_to_key};
+use et_core::proto::{ConnectResponse, ConnectStatus, InitialPayload, InitialResponse};
+use et_net::connection::Connection;
+use et_net::framing_io::{read_proto_limited, write_proto};
+use et_net::handshake::client_request;
+use process::OwnedChild;
+use prost::Message;
+
+pub const TIMEOUT: Duration = Duration::from_secs(45);
+
+pub struct Stack {
+    directory: PathBuf,
+    address: SocketAddr,
+    id: String,
+    key: String,
+    server: Option<OwnedChild>,
+    terminal: Option<OwnedChild>,
+    cleaned: bool,
+}
+
+impl Stack {
+    pub fn start() -> Self {
+        let (id, key) = gen_id_passkey();
+        let directory = std::env::temp_dir().join(format!("et-win-{}-{id}", std::process::id()));
+        fs::create_dir(&directory).unwrap();
+        let router = directory.join("router");
+        // The CLI deliberately rejects port zero. Reserve an ephemeral port and
+        // fail on bind collision rather than retrying or using a fleet endpoint.
+        let reserved = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let address = reserved.local_addr().unwrap();
+        let config = directory.join("et.cfg");
+        fs::write(
+            &config,
+            format!(
+                "[Networking]\nport={}\nbind_ip=127.0.0.1\n[Debug]\nserverfifo={}\n",
+                address.port(),
+                router.display()
+            ),
+        )
+        .unwrap();
+        let mut stack = Self {
+            directory,
+            address,
+            id,
+            key,
+            server: None,
+            terminal: None,
+            cleaned: false,
+        };
+        drop(reserved);
+        let mut command = binary();
+        command
+            .args(["server", "--cfgfile"])
+            .arg(config)
+            .arg("--logdir")
+            .arg(&stack.directory)
+            .stdout(Stdio::piped());
+        stack.server = Some(OwnedChild::spawn(&mut command));
+        let stdout = stack.server.as_mut().unwrap().0.stdout.take().unwrap();
+        let ready = observe(move || {
+            let mut line = String::new();
+            BufReader::new(stdout).read_line(&mut line).unwrap();
+            line
+        });
+        assert_eq!(
+            ready,
+            format!("ETSERVER_READY tcp={address} router={}\n", router.display())
+        );
+        println!("{ready}");
+        assert!(et_net::local::supports_registration_ack(&router));
+        let (local_address, _) = et_net::local::read_endpoint(&router).unwrap();
+        assert!(local_address.ip().is_loopback());
+
+        let mut command = binary();
+        command
+            .args([
+                "terminal",
+                "--session-child",
+                "--ready-socket",
+                "inherited",
+                "--serverfifo",
+            ])
+            .arg(router)
+            .arg("--logdir")
+            .arg(&stack.directory)
+            .env("ET_SHELL", process::powershell())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped());
+        stack.terminal = Some(OwnedChild::spawn(&mut command));
+        let terminal = &mut stack.terminal.as_mut().unwrap().0;
+        let mut stdout = terminal.stdout.take().unwrap();
+        let stdin = terminal.stdin.take().unwrap();
+        // Subscribe before writing credentials; the exact registered frame is
+        // emitted only after the server commits the terminal registration.
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let worker = std::thread::spawn(move || {
+            let mut status = [0u8; 7];
+            let result = stdout.read_exact(&mut status).map(|()| status);
+            sender.send(result).unwrap();
+        });
+        writeln!(&stdin, "{}/{}_xterm-256color", stack.id, stack.key).unwrap();
+        drop(stdin);
+        assert_eq!(
+            receiver.recv_timeout(TIMEOUT).unwrap().unwrap(),
+            *b"ETS1\x01\0\0"
+        );
+        worker.join().unwrap();
+        println!("REGISTERED terminal_pid={}", terminal.id());
+        stack
+    }
+
+    pub fn handshake(&self, expected: ConnectStatus) -> TcpStream {
+        let mut stream = TcpStream::connect_timeout(&self.address, TIMEOUT).unwrap();
+        stream.set_read_timeout(Some(TIMEOUT)).unwrap();
+        stream.set_write_timeout(Some(TIMEOUT)).unwrap();
+        write_proto(&mut stream, &client_request(&self.id)).unwrap();
+        let response: ConnectResponse = read_proto_limited(&mut stream, 64 * 1024).unwrap();
+        assert_eq!(response.status, Some(expected as i32), "{response:?}");
+        println!("HANDSHAKE {expected:?}");
+        stream
+    }
+
+    pub fn connect(&self) -> Connection {
+        let stream = self.handshake(ConnectStatus::NewClient);
+        let mut client = Connection::new_client(stream, &passkey_to_key(&self.key).unwrap());
+        client
+            .write_packet(253, &InitialPayload::default().encode_to_vec())
+            .unwrap();
+        let packet = client
+            .read_packet_until(std::time::Instant::now() + TIMEOUT)
+            .unwrap();
+        assert_eq!(packet.header(), 252);
+        let response = InitialResponse::decode(packet.payload()).unwrap();
+        assert_eq!(response.error, None, "{response:?}");
+        client
+    }
+
+    pub fn wait_terminal(&mut self, success: bool) {
+        let status = self.terminal.as_mut().unwrap().wait();
+        assert_eq!(status.success(), success, "terminal exit: {status}");
+        println!("TERMINAL_REAPED {status}");
+    }
+
+    pub fn stop_server(&mut self) {
+        let mut server = self.server.take().unwrap();
+        server.0.kill().unwrap();
+        println!("SERVER_REAPED {}", server.wait());
+    }
+
+    pub fn finish(mut self) {
+        if self.server.is_some() {
+            self.stop_server();
+        }
+        drop(self.terminal.take());
+        fs::remove_dir_all(&self.directory).expect("fixture directory cleanup failed");
+        self.cleaned = true;
+        println!("FIXTURE_REMOVED {}", self.directory.display());
+    }
+}
+
+impl Drop for Stack {
+    fn drop(&mut self) {
+        if self.cleaned {
+            return;
+        }
+        drop(self.server.take());
+        drop(self.terminal.take());
+        match fs::remove_dir_all(&self.directory) {
+            Ok(()) => println!("FIXTURE_REMOVED {}", self.directory.display()),
+            Err(error) => eprintln!("fixture cleanup failed: {error}"),
+        }
+    }
+}
+
+fn binary() -> Command {
+    // CI's downloadable test executable can run on a toolchain-free host.
+    Command::new(
+        std::env::var_os("ET_WINDOWS_RUNTIME_BINARY")
+            .unwrap_or_else(|| env!("CARGO_BIN_EXE_et").into()),
+    )
+}
+
+fn observe<T: Send + 'static>(read: impl FnOnce() -> T + Send + 'static) -> T {
+    let (sender, receiver) = mpsc::sync_channel(1);
+    let worker = std::thread::spawn(move || sender.send(read()).is_ok());
+    let result = receiver
+        .recv_timeout(TIMEOUT)
+        .expect("process readiness event timed out");
+    assert!(worker.join().unwrap());
+    result
+}

--- a/crates/et-bin/tests/windows_runtime_support/process.rs
+++ b/crates/et-bin/tests/windows_runtime_support/process.rs
@@ -1,0 +1,118 @@
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Child, Command, ExitStatus, Stdio};
+
+use wait_timeout::ChildExt;
+
+use super::{observe, Shell, TIMEOUT};
+
+pub fn powershell() -> PathBuf {
+    PathBuf::from(std::env::var_os("SystemRoot").unwrap())
+        .join("System32/WindowsPowerShell/v1.0/powershell.exe")
+}
+
+pub struct OwnedChild(pub Child);
+
+impl OwnedChild {
+    pub fn spawn(command: &mut Command) -> Self {
+        Self(command.spawn().unwrap())
+    }
+
+    pub fn wait(&mut self) -> ExitStatus {
+        self.0
+            .wait_timeout(TIMEOUT)
+            .unwrap()
+            .expect("owned process exit timed out")
+    }
+}
+
+impl Drop for OwnedChild {
+    fn drop(&mut self) {
+        match self.0.try_wait() {
+            Ok(Some(_)) => return,
+            Ok(None) => {}
+            Err(error) => eprintln!("process inspection failed: {error}"),
+        }
+        // Failure-only cleanup targets the exact test-owned root, never an
+        // image name, installed service, or machine-wide process list.
+        match Command::new("taskkill.exe")
+            .args(["/F", "/T", "/PID", &self.0.id().to_string()])
+            .output()
+        {
+            Ok(output) if output.status.success() => {}
+            result => eprintln!("fallback tree cleanup: {result:?}"),
+        }
+        if let Err(error) = self.0.wait() {
+            eprintln!("process reaping failed: {error}");
+        }
+    }
+}
+
+pub struct ProcessExitObserver(OwnedChild);
+
+impl ProcessExitObserver {
+    pub fn subscribe(shell: &Shell) -> Self {
+        // Opening both handles before READY prevents PID reuse races. Native
+        // WaitForExit subscribes to process completion without process polling.
+        // The observer also owns failure cleanup if a mutant leaves children.
+        let script = format!(
+            "$ErrorActionPreference='Stop'; \
+             $targets=@({},{}) | ForEach-Object {{ \
+               $p=[Diagnostics.Process]::GetProcessById($_); $null=$p.Handle; $p \
+             }}; \
+             [Console]::WriteLine('READY'); \
+             $mode=[Console]::ReadLine(); \
+             $failed=$false; \
+             foreach($p in $targets) {{ \
+               if ($mode -ne 'WAIT' -and !$p.HasExited) {{ $p.Kill() }}; \
+               if (!$p.WaitForExit(10000)) {{ \
+                 $p.Kill(); $failed=$true; \
+                 if (!$p.WaitForExit(10000)) {{ throw 'fallback process cleanup timed out' }} \
+               }} \
+             }}; \
+             if ($failed) {{ throw 'native process cleanup timed out' }}",
+            shell.pid, shell.descendant
+        );
+        let mut command = Command::new(powershell());
+        command
+            .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped());
+        let mut child = OwnedChild::spawn(&mut command);
+        let stdout = child.0.stdout.take().unwrap();
+        assert_eq!(
+            observe(move || {
+                let mut line = String::new();
+                BufReader::new(stdout).read_line(&mut line).unwrap();
+                line
+            })
+            .trim(),
+            "READY"
+        );
+        println!(
+            "PROCESS_EXIT_SUBSCRIBED shell={} descendant={}",
+            shell.pid, shell.descendant
+        );
+        Self(child)
+    }
+
+    pub fn wait(&mut self) {
+        writeln!(self.0 .0.stdin.take().unwrap(), "WAIT").unwrap();
+        assert!(self.0.wait().success(), "native shell/descendant leaked");
+        println!("SHELL_AND_DESCENDANT_EXITED");
+    }
+}
+
+impl Drop for ProcessExitObserver {
+    fn drop(&mut self) {
+        if let Some(stdin) = self.0 .0.stdin.take() {
+            // EOF requests cleanup through the already-open process handles,
+            // even if the terminal exited and orphaned a descendant on panic.
+            drop(stdin);
+            match self.0 .0.wait_timeout(TIMEOUT) {
+                Ok(Some(status)) if status.success() => {}
+                result => eprintln!("process observer fallback failed: {result:?}"),
+            }
+        }
+    }
+}

--- a/crates/et-bin/tests/windows_runtime_support/process.rs
+++ b/crates/et-bin/tests/windows_runtime_support/process.rs
@@ -6,6 +6,8 @@ use wait_timeout::ChildExt;
 
 use super::{observe, Shell, TIMEOUT};
 
+const PROCESS_CLEANUP: &str = include_str!("process_cleanup.ps1");
+
 pub fn powershell() -> PathBuf {
     PathBuf::from(std::env::var_os("SystemRoot").unwrap())
         .join("System32/WindowsPowerShell/v1.0/powershell.exe")
@@ -56,21 +58,13 @@ impl ProcessExitObserver {
         // WaitForExit subscribes to process completion without process polling.
         // The observer also owns failure cleanup if a mutant leaves children.
         let script = format!(
-            "$ErrorActionPreference='Stop'; \
+            "{PROCESS_CLEANUP}\n$ErrorActionPreference='Stop'; \
              $targets=@({},{}) | ForEach-Object {{ \
                $p=[Diagnostics.Process]::GetProcessById($_); $null=$p.Handle; $p \
              }}; \
              [Console]::WriteLine('READY'); \
              $mode=[Console]::ReadLine(); \
-             $failed=$false; \
-             foreach($p in $targets) {{ \
-               if ($mode -ne 'WAIT' -and !$p.HasExited) {{ $p.Kill() }}; \
-               if (!$p.WaitForExit(10000)) {{ \
-                 $p.Kill(); $failed=$true; \
-                 if (!$p.WaitForExit(10000)) {{ throw 'fallback process cleanup timed out' }} \
-               }} \
-             }}; \
-             if ($failed) {{ throw 'native process cleanup timed out' }}",
+             Complete-ObservedProcesses -Targets $targets -Mode $mode",
             shell.pid, shell.descendant
         );
         let mut command = Command::new(powershell());
@@ -116,3 +110,6 @@ impl Drop for ProcessExitObserver {
         }
     }
 }
+
+#[path = "process_tests.rs"]
+mod tests;

--- a/crates/et-bin/tests/windows_runtime_support/process_cleanup.ps1
+++ b/crates/et-bin/tests/windows_runtime_support/process_cleanup.ps1
@@ -1,0 +1,41 @@
+function Stop-ObservedProcess {
+    param([Diagnostics.Process]$Process)
+    try {
+        $Process.Kill()
+    } catch [InvalidOperationException], [ComponentModel.Win32Exception] {
+        # Kill may race another owner completing exit. Only confirmed process
+        # completion makes that error benign; real termination errors escape.
+        if (!$Process.HasExited) { throw }
+    }
+}
+
+function Complete-ObservedProcesses {
+    param(
+        [Diagnostics.Process[]]$Targets,
+        [string]$Mode,
+        [scriptblock]$BeforeKill = {}
+    )
+    $failures = [Collections.Generic.List[string]]::new()
+    foreach ($process in $Targets) {
+        $processId = $process.Id
+        try {
+            if ($Mode -ne 'WAIT' -and !$process.HasExited) {
+                & $BeforeKill $process
+                Stop-ObservedProcess $process
+            }
+            if (!$process.WaitForExit(10000)) {
+                # A watchdog failure stays a failure even if fallback succeeds.
+                $failures.Add("process $processId cleanup timed out")
+                & $BeforeKill $process
+                Stop-ObservedProcess $process
+                if (!$process.WaitForExit(10000)) {
+                    $failures.Add("process $processId fallback cleanup timed out")
+                }
+            }
+        } catch {
+            # One target's error must not abandon the remaining owned handles.
+            $failures.Add("process ${processId}: $($_.Exception.Message)")
+        }
+    }
+    if ($failures.Count -ne 0) { throw ($failures -join '; ') }
+}

--- a/crates/et-bin/tests/windows_runtime_support/process_cleanup_probe.ps1
+++ b/crates/et-bin/tests/windows_runtime_support/process_cleanup_probe.ps1
@@ -54,10 +54,17 @@ function Test-ProcessCleanup {
         }
         Write-Output ('CLEANUP_PROBE_PASS scenario=' + $Scenario)
     } finally {
+        $cleanupFailures = [Collections.Generic.List[string]]::new()
         foreach ($process in $targets) {
-            if (!$process.HasExited) { Stop-ObservedProcess $process }
-            if (!$process.WaitForExit(10000)) { throw 'Probe fallback cleanup failed' }
-            $process.Dispose()
+            try {
+                if (!$process.HasExited) { Stop-ObservedProcess $process }
+                if (!$process.WaitForExit(10000)) { throw 'Probe fallback cleanup failed' }
+            } catch {
+                $cleanupFailures.Add($_.Exception.Message)
+            } finally {
+                $process.Dispose()
+            }
         }
+        if ($cleanupFailures.Count -ne 0) { throw ($cleanupFailures -join '; ') }
     }
 }

--- a/crates/et-bin/tests/windows_runtime_support/process_cleanup_probe.ps1
+++ b/crates/et-bin/tests/windows_runtime_support/process_cleanup_probe.ps1
@@ -1,0 +1,63 @@
+function Test-ProcessCleanup {
+    param([ValidateSet('race', 'error')][string]$Scenario)
+    $targets = @()
+    try {
+        # Given: both real targets signal readiness, then block on a kernel event.
+        foreach ($index in 0..1) {
+            $process = [Diagnostics.Process]::new()
+            $process.StartInfo.FileName = Join-Path $PSHOME 'powershell.exe'
+            $process.StartInfo.Arguments = '-NoProfile -NonInteractive -Command "[Console]::WriteLine(''READY''); [void]([Threading.ManualResetEvent]::new($false)).WaitOne()"'
+            $process.StartInfo.UseShellExecute = $false
+            $process.StartInfo.CreateNoWindow = $true
+            $process.StartInfo.RedirectStandardOutput = $true
+            if (!$process.Start()) { $process.Dispose(); throw 'Could not start native target' }
+            $targets += $process
+            $null = $process.Handle
+            $ready = $process.StandardOutput.ReadLineAsync()
+            if (!$ready.Wait(10000) -or $ready.Result -ne 'READY') {
+                throw 'Native target readiness event failed'
+            }
+        }
+        $firstId = $targets[0].Id
+        $beforeKill = {
+            param([Diagnostics.Process]$Process)
+            if ($Process.Id -eq $firstId) {
+                switch ($Scenario) {
+                    'race' {
+                        # Exact competing-exit barrier between the state check
+                        # and Kill: no timing sleeps and no fake process object.
+                        $Process.Kill()
+                        if (!$Process.WaitForExit(10000)) { throw 'Competing exit barrier failed' }
+                    }
+                    'error' { throw [ComponentModel.Win32Exception]::new(5) }
+                }
+            }
+        }.GetNewClosure()
+        # When: cleanup sees either a completed competing exit or a real error
+        # category injected only at the narrow pre-kill seam.
+        $failure = $null
+        try {
+            Complete-ObservedProcesses -Targets $targets -Mode 'CLEANUP' -BeforeKill $beforeKill
+        } catch { $failure = $_ }
+
+        # Then: later targets always retire, while genuine errors remain visible.
+        if (!$targets[1].HasExited) { throw 'Cleanup abandoned the second target' }
+        switch ($Scenario) {
+            'race' {
+                if ($null -ne $failure) { throw $failure }
+                if (!$targets[0].HasExited) { throw 'Competing exit was not observed' }
+            }
+            'error' {
+                if ($null -eq $failure) { throw 'Cleanup concealed a termination error' }
+                if ($targets[0].HasExited) { throw 'Error probe did not preserve its live target' }
+            }
+        }
+        Write-Output ('CLEANUP_PROBE_PASS scenario=' + $Scenario)
+    } finally {
+        foreach ($process in $targets) {
+            if (!$process.HasExited) { Stop-ObservedProcess $process }
+            if (!$process.WaitForExit(10000)) { throw 'Probe fallback cleanup failed' }
+            $process.Dispose()
+        }
+    }
+}

--- a/crates/et-bin/tests/windows_runtime_support/process_tests.rs
+++ b/crates/et-bin/tests/windows_runtime_support/process_tests.rs
@@ -1,0 +1,29 @@
+use std::process::{Command, Stdio};
+
+use super::{powershell, OwnedChild, PROCESS_CLEANUP};
+
+#[test]
+fn cleanup_continues_when_a_target_exits_between_has_exited_and_kill() {
+    run_cleanup_probe("race");
+}
+
+#[test]
+fn cleanup_reports_target_errors_after_processing_remaining_targets() {
+    run_cleanup_probe("error");
+}
+
+fn run_cleanup_probe(scenario: &str) {
+    let script = format!(
+        "$ErrorActionPreference='Stop';\n{PROCESS_CLEANUP}\n{}\nTest-ProcessCleanup -Scenario '{scenario}'",
+        include_str!("process_cleanup_probe.ps1")
+    );
+    let mut command = Command::new(powershell());
+    command
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .stdin(Stdio::null());
+    let mut child = OwnedChild::spawn(&mut command);
+    assert!(
+        child.wait().success(),
+        "native cleanup probe failed: {scenario}"
+    );
+}

--- a/crates/et-bin/tests/windows_runtime_support/process_tests.rs
+++ b/crates/et-bin/tests/windows_runtime_support/process_tests.rs
@@ -27,3 +27,21 @@ fn run_cleanup_probe(scenario: &str) {
         "native cleanup probe failed: {scenario}"
     );
 }
+
+#[test]
+fn probe_fallback_processes_remaining_targets_after_a_cleanup_error() {
+    let script = format!(
+        "$ErrorActionPreference='Stop';\n{PROCESS_CLEANUP}\n{}\n{}",
+        include_str!("process_cleanup_probe.ps1"),
+        include_str!("fallback_probe.ps1")
+    );
+    let mut command = Command::new(powershell());
+    command
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .stdin(Stdio::null());
+    let mut child = OwnedChild::spawn(&mut command);
+    assert!(
+        child.wait().success(),
+        "native probe fallback abandoned a target"
+    );
+}

--- a/crates/et-bin/tests/windows_runtime_support/setup_tests.rs
+++ b/crates/et-bin/tests/windows_runtime_support/setup_tests.rs
@@ -1,0 +1,22 @@
+use super::Stack;
+
+#[test]
+fn setup_failure_removes_the_acquired_directory() {
+    // Given a setup hook reached after the fixture directory is created.
+    let mut directory = None;
+    // When setup fails before the server is spawned.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        Stack::start_with_setup(|path| {
+            directory = Some(path.to_path_buf());
+            panic!("injected configuration setup failure");
+        });
+    }));
+    let directory = directory.expect("setup hook did not run");
+    let leaked = directory.exists();
+    if leaked {
+        std::fs::remove_dir_all(&directory).unwrap();
+    }
+    // Then the fixture, not this probe's fallback, owns failure cleanup.
+    assert!(result.is_err());
+    assert!(!leaked, "setup failure leaked {}", directory.display());
+}

--- a/crates/et-bin/tests/windows_runtime_support/shell.rs
+++ b/crates/et-bin/tests/windows_runtime_support/shell.rs
@@ -1,0 +1,103 @@
+use et_core::proto::{TerminalBuffer, TerminalPacketType};
+use et_net::connection::Connection;
+use prost::Message;
+
+use super::TIMEOUT;
+
+pub struct Shell {
+    pub pid: u32,
+    pub descendant: u32,
+    state: String,
+}
+
+impl Shell {
+    pub fn start(client: &mut Connection) -> Self {
+        // portable-pty uses PSEUDOCONSOLE_INHERIT_CURSOR. Act as the terminal
+        // emulator: answer its exact DSR event before submitting shell input.
+        assert_eq!(read_marker(client, "\x1b[", 'n'), "6");
+        Self::send(client, "\x1b[1;1R");
+        // Sentinels are assembled by the shell: input echo cannot satisfy them.
+        // The descendant blocks on a kernel event, not a correctness sleep.
+        Self::send(client, concat!(
+            "$etState=[guid]::NewGuid().ToString('N'); ",
+            "$etChild=Start-Process -FilePath ($PSHOME+'\\powershell.exe') ",
+            "-ArgumentList '-NoProfile -Command \"([Threading.ManualResetEvent]::new($false)).WaitOne()\"' ",
+            "-WindowStyle Hidden -PassThru; ",
+            "[Console]::WriteLine(('ET'+'-INITIAL:')+$PID+':'+$etChild.Id+':'+$etState+';')\r\n"
+        ));
+        let value = read_marker(client, "ET-INITIAL:", ';');
+        let fields: Vec<_> = value.split(':').collect();
+        assert_eq!(fields.len(), 3, "invalid shell identity: {value}");
+        let shell = Self {
+            pid: fields[0].parse().unwrap(),
+            descendant: fields[1].parse().unwrap(),
+            state: fields[2].to_owned(),
+        };
+        assert_ne!(shell.pid, shell.descendant);
+        assert_eq!(shell.state.len(), 32);
+        assert!(shell.state.bytes().all(|byte| byte.is_ascii_hexdigit()));
+        println!("CONPTY_INITIAL {value}");
+        shell
+    }
+
+    pub fn assert_recovered(&self, client: &mut Connection) {
+        Self::send(
+            client,
+            "[Console]::WriteLine(('ET'+'-RECOVERED:')+$PID+':'+$etChild.Id+':'+$etState+';')\r\n",
+        );
+        let value = read_marker(client, "ET-RECOVERED:", ';');
+        assert_eq!(
+            value,
+            format!("{}:{}:{}", self.pid, self.descendant, self.state)
+        );
+        println!("CONPTY_RECOVERED {value}");
+    }
+
+    pub fn send(client: &mut Connection, command: &str) {
+        client.set_io_timeout(Some(TIMEOUT)).unwrap();
+        client
+            .write_packet(
+                TerminalPacketType::TerminalBuffer as u8,
+                &TerminalBuffer {
+                    buffer: Some(command.as_bytes().to_vec()),
+                }
+                .encode_to_vec(),
+            )
+            .unwrap();
+    }
+}
+
+fn read_marker(client: &mut Connection, marker: &str, delimiter: char) -> String {
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    let mut output = Vec::new();
+    loop {
+        let packet = client.read_packet_until(deadline).unwrap_or_else(|error| {
+            panic!(
+                "missing {marker}: {error}; ConPTY output={:?}",
+                String::from_utf8_lossy(&output)
+            )
+        });
+        match packet.header() {
+            header if header == TerminalPacketType::TerminalBuffer as u8 => {
+                output.extend(
+                    TerminalBuffer::decode(packet.payload())
+                        .unwrap()
+                        .buffer
+                        .unwrap(),
+                );
+            }
+            header if header == TerminalPacketType::KeepAlive as u8 => {}
+            header => panic!("unexpected server packet {header}"),
+        }
+        assert!(
+            output.len() <= 1024 * 1024,
+            "shell output exceeded test bound"
+        );
+        let text = String::from_utf8_lossy(&output);
+        if let Some((_, tail)) = text.split_once(marker) {
+            if let Some((value, _)) = tail.split_once(delimiter) {
+                return value.to_owned();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Run real native server, ConPTY shell, same-session recovery, and process cleanup tests on Windows CI.
- Upload relocatable executables and native transcript for independent QA.

## Verification
- Windows 10 native execution: 2 tests pass; GNU cross-build used for local artifacts.
- Production descendant-cleanup mutation: both unchanged tests fail on the leak assertion; restored runtime passes.
- Formatting and targeted Windows clippy pass.
- Hosted MSVC/Cargo CI, additional output/recovery mutation evidence, and independent review are pending. Do not merge before all required checks and review pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the Windows CI compile-only check with real native runtime tests: the shipped server now runs a native ConPTY shell under Windows, and tests verify shell state survives same-session recovery and that losing the server reaps the shell and its descendants.

- Preserves the `build-windows` job name so branch protection stays intact.
- Uploads relocatable executables and a transcript; `Run-WindowsRuntime.ps1` runs them on a Windows host without Cargo or protoc.
- Adds probes verifying cleanup survives exit races, surfaces real termination errors while still retiring remaining targets, and that fixtures own directory cleanup when setup fails early.

<sup>Written for commit e1e376cd579dca8857f28ca03fb97aa24b4738f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

