### PR TITLE
feat(htm): support native Windows multiplexer sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,10 @@ jobs:
           --test terminal_tty_qa
           -- --test-threads=1
 
-  # Windows build is release-critical; the test harnesses are POSIX-only,
-  # so compile the shipped binary crate (like the release pipeline) and
-  # grow into `cargo test` later.
+  # Compile the shipped binary and exercise native HTM IPC and ConPTY roles.
   build-windows:
     runs-on: windows-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -103,6 +102,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - run: cargo build -p et
+
+      - name: Exercise native HTM transport and panes
+        run: cargo test -p et-htm -- --test-threads=1 --nocapture
+
+      - name: Exercise HTM role startup, resize and reattach
+        run: cargo test -p et --test htm_runtime -- --test-threads=1 --nocapture
 
   # The release matrix builds jemalloc on native ARM against musl. Ubuntu's
   # aarch64 musl GCC needs outlined atomics disabled so libgcc does not retain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
  "portable-pty",
  "prost",
  "rustix",
+ "serde_json",
  "signal-hook",
  "socket2",
  "sysinfo",
@@ -456,6 +457,8 @@ name = "et-htm"
 version = "0.0.24"
 dependencies = [
  "base64",
+ "et-net",
+ "filedescriptor",
  "portable-pty",
  "rustix",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ terminal types are forwarded unchanged.
   below that user's `LOCALAPPDATA` tree, without junctions or parent traversal.
   Do not grant other users access to this directory or its token files.
   `htm -x` shuts down only the selected authenticated daemon, not named fleet processes.
+- HTM first requests Windows job breakaway. If the host denies it, HTM reports the
+  restriction and starts a detached, handle-isolated daemon within the host job.
+  It survives the launching `htm` client, but **not termination of that host job**.
+  The stricter `etserver`/`etterminal` SSH-bootstrap breakaway policy is unchanged.
 - Unix-socket tunnels remain POSIX-only.
 - Inbound connections need a firewall rule; the server does not modify firewall state itself.
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ subcommand:
 | `et`            | `et <host>` / `et client <host>` | yes     |
 | `etserver`      | `etserver` / `et server`         | yes     |
 | `etterminal`    | `etterminal` / `et terminal`     | yes     |
-| `htm`           | `htm` / `et htm`                 | no      |
-| `htmd`          | `htmd` / `et htmd`               | no      |
+| `htm`           | `htm` / `et htm`                 | yes     |
+| `htmd`          | `htmd` / `et htmd`               | yes     |
 
 ```sh
 ln -s et etserver && ln -s et etterminal && ln -s et htm && ln -s et htmd
@@ -164,7 +164,16 @@ terminal types are forwarded unchanged.
 
 - The router is a loopback TCP listener; its address and a CSPRNG token live in the `--serverfifo`
   endpoint file under `%LOCALAPPDATA%\etserver`, which takes the place of Unix socket permissions.
-- Unix-socket tunnels and the `htm` multiplexer stay POSIX-only, like upstream.
+- HTM runs native ConPTY panes on Windows 10 1809+; use `et.exe htm` from an
+  HTM-capable terminal emulator. It is a protocol relay, not a standalone pane UI.
+  The pane shell is `SHELL`, then `COMSPEC`, then `cmd.exe`; its home is `USERPROFILE`.
+- HTM IPC uses an authenticated loopback endpoint at `%LOCALAPPDATA%\et-htm\htm.ipc`.
+  The endpoint inherits the user-private application directory ACL, like the router.
+  `--socket` on both HTM roles selects an isolated endpoint; on Windows it must remain
+  below that user's `LOCALAPPDATA` tree, without junctions or parent traversal.
+  Do not grant other users access to this directory or its token files.
+  `htm -x` shuts down only the selected authenticated daemon, not named fleet processes.
+- Unix-socket tunnels remain POSIX-only.
 - Inbound connections need a firewall rule; the server does not modify firewall state itself.
 
 ## Tests

--- a/crates/et-bin/Cargo.toml
+++ b/crates/et-bin/Cargo.toml
@@ -27,6 +27,7 @@ et-cli = { path = "../et-cli" }
 et-core = { path = "../et-core" }
 et-net = { path = "../et-net" }
 et-server = { path = "../et-server" }
+et-htm = { path = "../et-htm" }
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.29.0"
 # ConPTY on Windows, forkpty on Unix.
@@ -35,9 +36,7 @@ prost = "0.13"
 sysinfo = { version = "0.37.2", default-features = false, features = ["system"] }
 wait-timeout = "0.2.1"
 
-# The headless multiplexer follows upstream and stays POSIX-only.
 [target.'cfg(unix)'.dependencies]
-et-htm = { path = "../et-htm" }
 nix = { version = "0.31.3", default-features = false, features = ["signal"] }
 rustix = { version = "1.1.4", features = ["event", "fs", "process", "time"] }
 signal-hook = "0.3.18"
@@ -55,6 +54,7 @@ tikv-jemallocator = "0.7.0"
 jiff = { version = "0.2.35", default-features = false, features = ["tz-system", "tzdb-zoneinfo"] }
 
 [dev-dependencies]
+serde_json = "1"
 socket2 = "0.6.1"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]

--- a/crates/et-bin/src/htm.rs
+++ b/crates/et-bin/src/htm.rs
@@ -1,92 +1,127 @@
-//! `htm` and `htmd` role entry points, mirroring upstream `HtmClientMain.cpp`
-//! and `HtmServerMain.cpp`.
+//! `htm` and `htmd` role entry points, mirroring upstream HTM mains.
 
 use std::ffi::OsString;
 use std::io::Write;
+use std::path::PathBuf;
 
 use clap::error::ErrorKind;
 use clap::Parser;
 use et_htm::server::{pipe_name, HtmServer};
 
 #[derive(Debug, Parser)]
-#[command(
-    name = "htm",
-    version = et_cli::VERSION,
-    long_version = et_cli::LONG_VERSION,
-    about = "Headless terminal multiplexer"
-)]
+#[command(name = "htm", version = et_cli::VERSION, long_version = et_cli::LONG_VERSION,
+    about = "Headless terminal multiplexer")]
 struct HtmArgs {
     #[arg(
         short = 'x',
         long = "kill-other-sessions",
-        help = "kill all old sessions belonging to the user"
+        help = "stop the user's daemon before starting a new session"
     )]
     kill_other_sessions: bool,
-    /// Internal marker: this process is the re-executed daemon.
+    /// Select an isolated IPC endpoint (Windows: beneath LOCALAPPDATA).
+    #[arg(long)]
+    socket: Option<PathBuf>,
     #[arg(long = "daemon-child", hide = true)]
     daemon_child: bool,
 }
 
 #[derive(Debug, Parser)]
-#[command(
-    name = "htmd",
-    version = et_cli::VERSION,
-    long_version = et_cli::LONG_VERSION,
-    about = "Headless terminal multiplexer daemon"
-)]
-struct HtmdArgs {}
+#[command(name = "htmd", version = et_cli::VERSION, long_version = et_cli::LONG_VERSION,
+    about = "Headless terminal multiplexer daemon")]
+struct HtmdArgs {
+    /// Select an isolated IPC endpoint (Windows: beneath LOCALAPPDATA).
+    #[arg(long)]
+    socket: Option<PathBuf>,
+    /// Emit HTMD_READY on stdout after the IPC endpoint and initial PTY exist.
+    #[arg(long)]
+    ready_stdout: bool,
+    #[arg(long, hide = true)]
+    daemon_child: bool,
+}
 
-/// `htmd`: run the multiplexer daemon in the foreground.
 pub fn run_daemon(args: &[OsString]) -> Result<i32, clap::Error> {
-    HtmdArgs::try_parse_from(
-        ["htmd"]
-            .iter()
-            .map(|value| OsString::from(*value))
-            .chain(args.iter().cloned()),
+    let parsed = HtmdArgs::try_parse_from(
+        std::iter::once(OsString::from("htmd")).chain(args.iter().cloned()),
     )?;
-    let path = pipe_name();
+    #[cfg(unix)]
+    if parsed.daemon_child {
+        crate::detach::close_inherited_descriptors()
+            .map_err(|error| clap_io("closing inherited descriptors", error))?;
+        rustix::process::setsid().map_err(|error| clap_io("detaching htmd", error))?;
+    }
+    let path = parsed
+        .socket
+        .map(Ok)
+        .unwrap_or_else(pipe_name)
+        .map_err(|error| clap_io("selecting HTM endpoint", error))?;
     let mut server = HtmServer::bind(&path)
         .map_err(|error| clap_io("could not bind the htm IPC socket", error))?;
+    if parsed.ready_stdout {
+        let mut stdout = std::io::stdout().lock();
+        stdout
+            .write_all(b"HTMD_READY\n")
+            .and_then(|()| stdout.flush())
+            .map_err(|error| clap_io("reporting htmd readiness", error))?;
+    }
     server
         .run()
         .map_err(|error| clap_io("htmd stopped with an error", error))?;
     Ok(0)
 }
 
-/// `htm`: start the daemon if needed, then relay stdin/stdout to it in raw
-/// terminal mode.
 pub fn run_client(args: &[OsString]) -> Result<i32, clap::Error> {
     let parsed = HtmArgs::try_parse_from(
-        ["htm"]
-            .iter()
-            .map(|value| OsString::from(*value))
-            .chain(args.iter().cloned()),
+        std::iter::once(OsString::from("htm")).chain(args.iter().cloned()),
     )?;
-    let path = pipe_name();
+    let path = parsed
+        .socket
+        .map(Ok)
+        .unwrap_or_else(pipe_name)
+        .map_err(|error| clap_io("selecting HTM endpoint", error))?;
     if parsed.kill_other_sessions {
-        stop_daemon(&path);
+        crate::htm_daemon::stop(&path).map_err(|error| clap_io("stopping htmd", error))?;
     }
-    if std::os::unix::net::UnixStream::connect(&path).is_err() {
-        spawn_daemon().map_err(|error| clap_io("could not start htmd", error))?;
-        std::thread::sleep(std::time::Duration::from_millis(50));
-    }
-    let mut stream = et_htm::client::connect(&path)
-        .map_err(|error| clap_io("could not connect to htmd", error))?;
-
-    // Raw mode for the duration of the session; the terminal is restored on
-    // every exit path, including the HTM-mode-off escape upstream sends.
+    // Keep the first successful connection: a connect-and-drop probe creates a
+    // phantom UI and can race the daemon's recovery writes.
+    let mut stream = match et_htm::transport::connect(&path) {
+        Ok(stream) => stream,
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
+            ) =>
+        {
+            crate::htm_daemon::spawn(&path)
+                .map_err(|error| clap_io("could not start htmd", error))?;
+            et_htm::transport::connect(&path)
+                .map_err(|error| clap_io("could not connect to htmd", error))?
+        }
+        Err(error) => return Err(clap_io("could not connect to htmd", error)),
+    };
     let raw = RawTerminal::enter();
-    let mut stdin = et_htm::client::Stdin(std::io::stdin());
     let mut stdout = std::io::stdout();
-    let result = et_htm::client::run(&mut stream, &mut stdin, &mut stdout);
-    let _ = stdout.write_all(et_htm::codes::LEAVE_HTM_MODE);
-    let _ = stdout.flush();
+    #[cfg(unix)]
+    let result = et_htm::client::run(
+        &mut stream,
+        &mut et_htm::client::Stdin(std::io::stdin()),
+        &mut stdout,
+    );
+    #[cfg(windows)]
+    let result = et_htm::client::run(
+        &mut stream,
+        et_htm::client::Stdin(std::io::stdin()),
+        &mut stdout,
+    );
+    let leave = stdout
+        .write_all(et_htm::codes::LEAVE_HTM_MODE)
+        .and_then(|()| stdout.flush());
     drop(raw);
-    result.map_err(|error| clap_io("htm session ended with an error", error))?;
+    result
+        .and(leave)
+        .map_err(|error| clap_io("htm session ended with an error", error))?;
     Ok(0)
 }
 
-/// Raw terminal mode for the HTM relay, restored on drop.
 struct RawTerminal {
     enabled: bool,
 }
@@ -104,50 +139,11 @@ impl RawTerminal {
 impl Drop for RawTerminal {
     fn drop(&mut self) {
         if self.enabled {
-            let _ = crossterm::terminal::disable_raw_mode();
-        }
-    }
-}
-
-/// Re-exec this binary as a detached `htmd`, like upstream's daemon fork.
-fn spawn_daemon() -> std::io::Result<()> {
-    let executable = std::env::current_exe()?;
-    std::process::Command::new(executable)
-        .arg("htmd")
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .current_dir("/")
-        .spawn()
-        .map(|_| ())
-}
-
-/// Remove a running daemon, matching upstream's `pkill -x -U <uid> htmd`.
-fn stop_daemon(path: &std::path::Path) {
-    use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System};
-    let mut system = System::new();
-    system.refresh_processes_specifics(ProcessesToUpdate::All, true, ProcessRefreshKind::nothing());
-    let me = rustix::process::getuid().as_raw();
-    for (pid, process) in system.processes() {
-        let is_htmd = process
-            .name()
-            .to_str()
-            .is_some_and(|name| name == "htmd" || name == "et")
-            && process
-                .cmd()
-                .iter()
-                .any(|argument| argument.to_str() == Some("htmd"));
-        let same_user = process.user_id().map(|uid| **uid) == Some(me);
-        if is_htmd && same_user && pid.as_u32() != std::process::id() {
-            if let Ok(raw) = i32::try_from(pid.as_u32()) {
-                let _ = nix::sys::signal::kill(
-                    nix::unistd::Pid::from_raw(raw),
-                    nix::sys::signal::Signal::SIGKILL,
-                );
+            if let Err(error) = crossterm::terminal::disable_raw_mode() {
+                eprintln!("htm: restoring terminal mode: {error}");
             }
         }
     }
-    let _ = std::fs::remove_file(path);
 }
 
 fn clap_io(message: &str, error: impl std::fmt::Display) -> clap::Error {

--- a/crates/et-bin/src/htm_daemon.rs
+++ b/crates/et-bin/src/htm_daemon.rs
@@ -33,7 +33,28 @@ pub fn spawn(path: &Path) -> io::Result<()> {
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
     crate::detach::configure(&mut command);
-    let mut child = crate::detach::spawn(&mut command)?;
+    let child = crate::detach::spawn(&mut command);
+    #[cfg(windows)]
+    let child = match child {
+        Err(error) if error.raw_os_error() == Some(5) => {
+            use windows_spawn::{CreationFlags, DropPolicy, SpawnOptions};
+            // ERROR_ACCESS_DENIED can mean that a supervising job forbids
+            // breakaway. HTM needs to outlive its UI, not override that host's
+            // job lifetime. Keep the allowlisted spawn and console detachment;
+            // never relax the shared SSH-bootstrap detach::spawn contract.
+            let child = command.spawn_with(
+                SpawnOptions::new()
+                    .creation_flags(
+                        CreationFlags::DETACHED_PROCESS | CreationFlags::NEW_PROCESS_GROUP,
+                    )
+                    .drop_policy(DropPolicy::Detach),
+            )?;
+            eprintln!("htm: independent daemon startup was denied; htmd remains supervised by the host job and cannot survive that job's termination");
+            Ok(child)
+        }
+        result => result,
+    };
+    let mut child = child?;
     let mut output = child
         .stdout
         .take()

--- a/crates/et-bin/src/htm_daemon.rs
+++ b/crates/et-bin/src/htm_daemon.rs
@@ -1,0 +1,94 @@
+//! HTM daemon startup and shutdown through owned process/IPC capabilities.
+//! Never enumerate or kill unrelated processes named et.exe or htmd.exe.
+
+use std::io::{self, Read};
+use std::path::Path;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use crate::detach::{Child, Stdio};
+
+struct Startup(Option<Child>);
+
+impl Drop for Startup {
+    fn drop(&mut self) {
+        if let Some(child) = self.0.as_mut() {
+            if let Err(error) = child.kill() {
+                eprintln!("htm: stopping failed daemon startup: {error}");
+            }
+            if let Err(error) = child.wait() {
+                eprintln!("htm: reaping failed daemon startup: {error}");
+            }
+        }
+    }
+}
+
+pub fn spawn(path: &Path) -> io::Result<()> {
+    let executable = std::env::current_exe()?;
+    let mut command = crate::detach::direct_command(executable.as_os_str());
+    command
+        .args(["htmd", "--daemon-child", "--ready-stdout", "--socket"])
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    crate::detach::configure(&mut command);
+    let mut child = crate::detach::spawn(&mut command)?;
+    let mut output = child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::other("missing htmd readiness pipe"))?;
+    let mut startup = Startup(Some(child));
+    let (send, receive) = mpsc::sync_channel(1);
+    let worker = std::thread::Builder::new()
+        .name("htmd-startup".to_owned())
+        .spawn(move || {
+            let mut ready = [0; 11];
+            let result = output.read_exact(&mut ready).and_then(|()| {
+                if &ready == b"HTMD_READY\n" {
+                    Ok(())
+                } else {
+                    Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "invalid htmd readiness marker",
+                    ))
+                }
+            });
+            // The receiver may have timed out and killed this owned child.
+            let _ = send.send(result);
+        })?;
+    let result = receive
+        .recv_timeout(Duration::from_secs(30))
+        .map_err(|error| io::Error::new(io::ErrorKind::TimedOut, error))
+        .and_then(|result| result);
+    if result.is_ok() {
+        startup.0.take();
+    }
+    // Failure closes the child's writer before joining the status reader.
+    drop(startup);
+    worker
+        .join()
+        .map_err(|_| io::Error::other("htmd readiness worker panicked"))?;
+    result
+}
+
+pub fn stop(path: &Path) -> io::Result<()> {
+    let mut stream = match et_htm::transport::connect(path) {
+        Ok(stream) => stream,
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::NotFound | io::ErrorKind::ConnectionRefused
+            ) =>
+        {
+            return Ok(())
+        }
+        Err(error) => return Err(error),
+    };
+    stream.set_read_timeout(Some(Duration::from_secs(15)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+    et_htm::framing::write_debug_keys(&mut stream, b"x")?;
+    // EOF acknowledges shutdown only after the daemon retires its endpoint.
+    io::copy(&mut stream, &mut io::sink())?;
+    Ok(())
+}

--- a/crates/et-bin/src/main.rs
+++ b/crates/et-bin/src/main.rs
@@ -53,6 +53,8 @@ fn main() {
 }
 
 fn dispatch(prog: &str, args: &[OsString]) -> Result<i32, clap::Error> {
+    #[cfg(windows)]
+    let prog = prog.strip_suffix(".exe").unwrap_or(prog);
     match prog {
         "etserver" => return role("etserver", args),
         "etterminal" => return role("etterminal", args),
@@ -77,17 +79,8 @@ fn role(name: &str, args: &[OsString]) -> Result<i32, clap::Error> {
     match name {
         "etserver" => crate::server::run(args),
         "etterminal" => crate::terminal::run(args),
-        #[cfg(unix)]
         "htm" => crate::htm::run_client(args),
-        #[cfg(unix)]
         "htmd" => crate::htm::run_daemon(args),
-        // Upstream's htm/htmd are POSIX-only, and their multiplexer state model
-        // has no Windows counterpart yet.
-        #[cfg(windows)]
-        "htm" | "htmd" => Err(clap::Error::raw(
-            clap::error::ErrorKind::InvalidSubcommand,
-            format!("{name} is not available on Windows yet\n"),
-        )),
         _ => crate::client::run(args),
     }
 }
@@ -130,7 +123,6 @@ mod terminal_motd;
 mod terminal_protocol;
 mod terminal_pty;
 
-// The headless multiplexer still needs the Unix-only pieces of upstream's htm.
-#[cfg(unix)]
 mod htm;
+mod htm_daemon;
 mod terminal_jump;

--- a/crates/et-bin/src/ssh_process.rs
+++ b/crates/et-bin/src/ssh_process.rs
@@ -329,7 +329,10 @@ fn control_directory_root(temp: &Path) -> PathBuf {
     let suffix = format!("et-ssh-{}", rustix::process::getuid().as_raw());
     #[cfg(not(unix))]
     let suffix = "et-ssh";
+    #[cfg(unix)]
     let path = temp.join(&suffix);
+    #[cfg(not(unix))]
+    let path = temp.join(suffix);
     #[cfg(unix)]
     if control_path_len(&path.join("0".repeat(32))) > MAX_CONTROL_PATH_BYTES {
         return PathBuf::from("/tmp").join(suffix);

--- a/crates/et-bin/tests/htm_runtime.rs
+++ b/crates/et-bin/tests/htm_runtime.rs
@@ -1,6 +1,8 @@
 //! Real HTM process/PTY contract, shared by Unix and native Windows QA.
 #![forbid(unsafe_code)]
 
+#[path = "htm_support/attached.rs"]
+mod attached;
 mod htm_support;
 
 use et_htm::{codes, framing};

--- a/crates/et-bin/tests/htm_runtime.rs
+++ b/crates/et-bin/tests/htm_runtime.rs
@@ -1,0 +1,115 @@
+//! Real HTM process/PTY contract, shared by Unix and native Windows QA.
+#![forbid(unsafe_code)]
+
+mod htm_support;
+
+use et_htm::{codes, framing};
+use htm_support::{Daemon, Relay};
+
+#[test]
+fn panes_resize_and_reattach_through_real_roles() {
+    // Given an isolated foreground daemon and the actual stdin/stdout relay.
+    let mut daemon = Daemon::start();
+    let mut relay = Relay::start(&daemon.path);
+    let initial = relay.state();
+    let original = initial["panes"].as_object().unwrap().keys().next().unwrap();
+    let pane = "11111111-1111-4111-8111-111111111111";
+    let tab = "22222222-2222-4222-8222-222222222222";
+
+    // When a new pane receives commands and a resize through HTM framing.
+    framing::write_new_tab(&mut relay.input, tab, pane).unwrap();
+    #[cfg(windows)]
+    {
+        // portable-pty requests an inherited cursor position. Act as the HTM
+        // terminal emulator only after receiving that exact ConPTY query.
+        relay.output_contains(pane, b"\x1b[6n");
+        framing::write_insert_keys(&mut relay.input, pane, b"\x1b[1;1R").unwrap();
+    }
+    println!("HTM_PANE_CREATED id={pane}");
+    #[cfg(unix)]
+    let command = b"HTM_QA=73; printf 'HTM_%s=%s\\n' VALUE \"$HTM_QA\"\n";
+    #[cfg(windows)]
+    let command = b"set HTM_QA=73\r\necho HTM_VALUE=%HTM_QA%\r\n";
+    framing::write_insert_keys(&mut relay.input, pane, command).unwrap();
+    relay.output_contains(pane, b"HTM_VALUE=73");
+    println!("HTM_SHELL_VALUE=73");
+    framing::write_resize_pane(&mut relay.input, pane, 113, 37).unwrap();
+    #[cfg(unix)]
+    let geometry = b"printf 'HTM_SIZE='; stty size\n";
+    #[cfg(windows)]
+    let geometry = b"powershell.exe -NoProfile -Command \"Write-Output ('HTM_SIZE=' + [Console]::WindowHeight + ' ' + [Console]::WindowWidth)\"\r\n";
+    framing::write_insert_keys(&mut relay.input, pane, geometry).unwrap();
+    relay.output_contains(pane, b"HTM_SIZE=37 113");
+    println!("HTM_SHELL_GEOMETRY=37x113");
+    framing::write_debug_keys(&mut relay.input, &[27]).unwrap();
+    relay.finish();
+
+    // Then reattach preserves pane identity, replay, and the living shell state.
+    let mut relay = Relay::start(&daemon.path);
+    let restored = relay.state();
+    assert_eq!(restored["panes"].as_object().unwrap().len(), 2);
+    assert!(restored["panes"][original].is_object());
+    assert_eq!(restored["tabs"][tab]["paneOrSplit"], pane);
+    relay.output_contains(pane, b"HTM_VALUE=73");
+    #[cfg(unix)]
+    let retained = b"printf 'HTM_%s=%s\\n' RETAINED \"$HTM_QA\"\n";
+    #[cfg(windows)]
+    let retained = b"echo HTM_RETAINED=%HTM_QA%\r\n";
+    framing::write_insert_keys(&mut relay.input, pane, retained).unwrap();
+    relay.output_contains(pane, b"HTM_RETAINED=73");
+    framing::write_client_close_pane(&mut relay.input, pane).unwrap();
+    framing::write_debug_keys(&mut relay.input, b"x").unwrap();
+    relay.finish();
+    daemon.finish();
+    println!(
+        "HTM_QA_PASS pane-create input/output resize=113x37 replay shell-retained shutdown cleanup"
+    );
+}
+
+#[test]
+fn session_end_detaches_without_a_length_field() {
+    use std::io::Write;
+    // Given a running daemon and an initialized client.
+    let mut daemon = Daemon::start();
+    let mut relay = Relay::start(&daemon.path);
+    let initial = relay.state();
+    // When the client sends the upstream one-byte detach message.
+    relay.input.write_all(&[codes::SESSION_END]).unwrap();
+    relay.finish();
+    // Then a fresh client reattaches to exactly the same pane.
+    let mut relay = Relay::start(&daemon.path);
+    assert_eq!(relay.state()["panes"], initial["panes"]);
+    framing::write_debug_keys(&mut relay.input, b"x").unwrap();
+    relay.finish();
+    daemon.finish();
+}
+
+#[test]
+fn auto_start_and_kill_other_sessions_replace_only_the_selected_daemon() {
+    // Given an unrelated daemon and a never-bound isolated endpoint.
+    let mut other = Daemon::start();
+    let mut other_relay = Relay::start(&other.path);
+    let other_state = other_relay.state();
+    framing::write_debug_keys(&mut other_relay.input, &[27]).unwrap();
+    other_relay.finish();
+    let endpoint = htm_support::Endpoint::new();
+
+    // When htm auto-starts its daemon, detaches, and then restarts it with -x.
+    let mut first = Relay::start(&endpoint.path);
+    let before = first.state();
+    framing::write_debug_keys(&mut first.input, &[27]).unwrap();
+    first.finish();
+    let mut replacement = Relay::restart(&endpoint.path);
+    let after = replacement.state();
+
+    // Then the selected daemon has fresh panes, while the other daemon survived.
+    assert_ne!(after["panes"], before["panes"]);
+    let mut other_relay = Relay::start(&other.path);
+    assert_eq!(other_relay.state()["panes"], other_state["panes"]);
+    framing::write_debug_keys(&mut replacement.input, b"x").unwrap();
+    replacement.finish();
+    framing::write_debug_keys(&mut other_relay.input, b"x").unwrap();
+    other_relay.finish();
+    other.finish();
+    println!("HTM_AUTOSTART_PASS ready detach -x replacement unrelated-daemon-survived shutdown");
+}

--- a/crates/et-bin/tests/htm_runtime.rs
+++ b/crates/et-bin/tests/htm_runtime.rs
@@ -99,6 +99,11 @@ fn auto_start_and_kill_other_sessions_replace_only_the_selected_daemon() {
     let before = first.state();
     framing::write_debug_keys(&mut first.input, &[27]).unwrap();
     first.finish();
+    // The auto-started daemon must outlive the htm process that launched it.
+    let mut reattached = Relay::start(&endpoint.path);
+    assert_eq!(reattached.state()["panes"], before["panes"]);
+    framing::write_debug_keys(&mut reattached.input, &[27]).unwrap();
+    reattached.finish();
     let mut replacement = Relay::restart(&endpoint.path);
     let after = replacement.state();
 
@@ -112,4 +117,54 @@ fn auto_start_and_kill_other_sessions_replace_only_the_selected_daemon() {
     other_relay.finish();
     other.finish();
     println!("HTM_AUTOSTART_PASS ready detach -x replacement unrelated-daemon-survived shutdown");
+}
+
+#[cfg(windows)]
+#[test]
+fn autostart_survives_client_exit_inside_a_nonbreakaway_host_job() {
+    use std::sync::mpsc;
+    use std::time::Duration;
+    use windows_spawn::{Command, DropPolicy, Job, SpawnOptions, Stdio};
+
+    // Given a real supervisor job that does not permit child breakaway.
+    // Kill-on-close preserves the host's authority to end this entire tree.
+    let job = Job::create().unwrap();
+    job.set_kill_on_close(true).unwrap();
+    let mut command = Command::new(std::env::current_exe().unwrap());
+    command
+        .args([
+            "auto_start_and_kill_other_sessions_replace_only_the_selected_daemon",
+            "--exact",
+            "--test-threads=1",
+            "--nocapture",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    // Assignment is atomic with process creation, not a race after spawning.
+    let child = command
+        .spawn_with(
+            SpawnOptions::new()
+                .job(&job)
+                .drop_policy(DropPolicy::Detach),
+        )
+        .unwrap();
+    let (sender, receiver) = mpsc::sync_channel(1);
+    let worker = std::thread::spawn(move || {
+        let _ = sender.send(child.wait_with_output());
+    });
+
+    // When the real role scenario starts, exits/reconnects, and replaces clients.
+    let result = receiver.recv_timeout(Duration::from_secs(45));
+    if result.is_err() {
+        job.terminate(1).unwrap();
+    }
+    worker.join().unwrap();
+    let output = result.expect("host-job role scenario completion").unwrap();
+    println!("{}", String::from_utf8_lossy(&output.stdout));
+    eprintln!("{}", String::from_utf8_lossy(&output.stderr));
+
+    // Then HTM survives client exit inside that still-living supervisor job.
+    // No assertion claims survival after the supervising job itself is killed.
+    assert!(output.status.success(), "host-job HTM role scenario failed");
 }

--- a/crates/et-bin/tests/htm_support/attached.rs
+++ b/crates/et-bin/tests/htm_support/attached.rs
@@ -1,0 +1,53 @@
+//! Real-role takeover while the previous UI is still attached.
+
+use super::htm_support::{Daemon, Relay};
+use et_htm::framing;
+
+#[test]
+fn kill_replaces_an_attached_session_without_stopping_an_unrelated_daemon() {
+    // Given two initialized UIs, neither detached before the replacement.
+    let selected = super::htm_support::Endpoint::new();
+    let mut old_ui = Relay::start(&selected.path);
+    let old_state = old_ui.state();
+    let mut other = Daemon::start();
+    let mut other_ui = Relay::start(&other.path);
+    let other_state = other_ui.state();
+
+    // When a new client requests -x against the occupied selected endpoint.
+    let mut replacement = Relay::restart(&selected.path);
+    let fresh_state = replacement.state();
+
+    // Then the old UI exits cleanly, and the replacement owns fresh pane state.
+    old_ui.finish();
+    assert_ne!(fresh_state["panes"], old_state["panes"]);
+    // The unrelated UI remains responsive and its daemon preserves pane state.
+    framing::write_debug_keys(&mut other_ui.input, &[27]).unwrap();
+    other_ui.finish();
+    let mut other_ui = Relay::start(&other.path);
+    assert_eq!(other_ui.state()["panes"], other_state["panes"]);
+    framing::write_debug_keys(&mut replacement.input, b"x").unwrap();
+    replacement.finish();
+    framing::write_debug_keys(&mut other_ui.input, b"x").unwrap();
+    other_ui.finish();
+    other.finish();
+    println!("HTM_ATTACHED_RESTART_PASS old-ui-closed fresh-daemon unrelated-daemon-survived");
+}
+
+#[test]
+fn new_ui_takes_over_an_attached_daemon_and_preserves_its_panes() {
+    // Given an initialized UI that remains open.
+    let mut daemon = Daemon::start();
+    let mut old_ui = Relay::start(&daemon.path);
+    let original = old_ui.state();
+
+    // When another UI attaches without requesting daemon shutdown.
+    let mut new_ui = Relay::start(&daemon.path);
+    let recovered = new_ui.state();
+
+    // Then only the old UI closes; the daemon and pane identities survive.
+    old_ui.finish();
+    assert_eq!(recovered["panes"], original["panes"]);
+    framing::write_debug_keys(&mut new_ui.input, b"x").unwrap();
+    new_ui.finish();
+    daemon.finish();
+}

--- a/crates/et-bin/tests/htm_support/mod.rs
+++ b/crates/et-bin/tests/htm_support/mod.rs
@@ -1,0 +1,236 @@
+use std::io::{BufRead, BufReader, Read};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::time::Duration;
+
+use et_htm::{codes, framing};
+
+const LIMIT: Duration = Duration::from_secs(30);
+
+// Native CI test artifacts can be copied with et.exe to an isolated QA host.
+fn executable() -> std::ffi::OsString {
+    std::env::var_os("ET_HTM_TEST_BINARY")
+        .unwrap_or_else(|| std::ffi::OsString::from(env!("CARGO_BIN_EXE_et")))
+}
+
+pub struct Daemon {
+    process: Child,
+    directory: PathBuf,
+    pub path: PathBuf,
+}
+
+impl Daemon {
+    pub fn start() -> Self {
+        #[cfg(unix)]
+        let base = std::env::temp_dir();
+        #[cfg(windows)]
+        let base = PathBuf::from(std::env::var_os("LOCALAPPDATA").unwrap());
+        let directory = base.join(format!(
+            "et-htm-qa-{}-{}",
+            std::process::id(),
+            et_core::keys::gen_id_passkey().0
+        ));
+        std::fs::create_dir(&directory).unwrap();
+        let path = directory.join("htm.ipc");
+        let mut command = Command::new(executable());
+        command
+            .args(["htmd", "--ready-stdout", "--socket"])
+            .arg(&path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+        #[cfg(unix)]
+        command.env("SHELL", "/bin/sh");
+        #[cfg(windows)]
+        command.env("SHELL", "cmd.exe").env("COMSPEC", "cmd.exe");
+        let mut process = command.spawn().unwrap();
+        let output = process.stdout.take().unwrap();
+        let daemon = Self {
+            process,
+            directory,
+            path,
+        };
+        let (send, receive) = mpsc::channel();
+        std::thread::spawn(move || {
+            let mut line = String::new();
+            BufReader::new(output).read_line(&mut line).unwrap();
+            send.send(line).unwrap();
+        });
+        assert_eq!(receive.recv_timeout(LIMIT).unwrap(), "HTMD_READY\n");
+        daemon
+    }
+
+    pub fn finish(&mut self) {
+        use wait_timeout::ChildExt;
+        assert!(self
+            .process
+            .wait_timeout(LIMIT)
+            .unwrap()
+            .expect("htmd exit")
+            .success());
+    }
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = self.process.kill();
+        let _ = self.process.wait();
+        std::fs::remove_dir_all(&self.directory).unwrap();
+    }
+}
+
+pub struct Relay {
+    process: Child,
+    pub input: ChildStdin,
+    messages: Receiver<(u8, Vec<u8>)>,
+}
+
+impl Relay {
+    pub fn start(path: &Path) -> Self {
+        Self::start_with(path, &[])
+    }
+
+    pub fn restart(path: &Path) -> Self {
+        Self::start_with(path, &["-x"])
+    }
+
+    fn start_with(path: &Path, args: &[&str]) -> Self {
+        let mut command = Command::new(executable());
+        #[cfg(unix)]
+        command.env("SHELL", "/bin/sh");
+        #[cfg(windows)]
+        command.env("SHELL", "cmd.exe").env("COMSPEC", "cmd.exe");
+        let mut process = command
+            .args(["htm", "--socket"])
+            .arg(path)
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .unwrap();
+        let input = process.stdin.take().unwrap();
+        let mut output = process.stdout.take().unwrap();
+        let (send, messages) = mpsc::channel();
+        std::thread::spawn(move || {
+            let mut enter = [0; 6];
+            output.read_exact(&mut enter).unwrap();
+            assert_eq!(&enter, codes::ENTER_HTM_MODE);
+            loop {
+                let mut header = [0];
+                if output.read_exact(&mut header).is_err() || header[0] == 27 {
+                    return;
+                }
+                if header[0] == codes::SESSION_END {
+                    continue;
+                }
+                let length = usize::try_from(framing::read_length(&mut output).unwrap()).unwrap();
+                let body = framing::read_exact_vec(&mut output, length).unwrap();
+                if send.send((header[0], body)).is_err() {
+                    return;
+                }
+            }
+        });
+        Self {
+            process,
+            input,
+            messages,
+        }
+    }
+
+    pub fn state(&self) -> serde_json::Value {
+        loop {
+            let (header, body) = self.messages.recv_timeout(LIMIT).expect("HTM state event");
+            if header == codes::INIT_STATE {
+                return serde_json::from_slice(&body).unwrap();
+            }
+        }
+    }
+
+    pub fn output_contains(&self, pane: &str, expected: &[u8]) {
+        let deadline = std::time::Instant::now() + LIMIT;
+        let mut output = Vec::new();
+        loop {
+            let (header, body) = self
+                .messages
+                .recv_timeout(deadline.saturating_duration_since(std::time::Instant::now()))
+                .expect("pane output event");
+            if header == codes::APPEND_TO_PANE && body.starts_with(pane.as_bytes()) {
+                output.extend(framing::decode(&body[codes::UUID_LENGTH..]).unwrap());
+                if output.windows(expected.len()).any(|part| part == expected) {
+                    return;
+                }
+            }
+        }
+    }
+
+    pub fn finish(&mut self) {
+        use wait_timeout::ChildExt;
+        assert!(self
+            .process
+            .wait_timeout(LIMIT)
+            .unwrap()
+            .expect("htm exit")
+            .success());
+    }
+}
+
+impl Drop for Relay {
+    fn drop(&mut self) {
+        let _ = self.process.kill();
+        let _ = self.process.wait();
+    }
+}
+
+/// Owns the namespace and shutdown capability of an automatically started daemon.
+/// Unlike foreground Daemon, the detached process is reaped by its OS parent.
+pub struct Endpoint {
+    pub path: PathBuf,
+    directory: PathBuf,
+}
+
+impl Endpoint {
+    pub fn new() -> Self {
+        #[cfg(unix)]
+        let base = std::env::temp_dir();
+        #[cfg(windows)]
+        let base = PathBuf::from(std::env::var_os("LOCALAPPDATA").unwrap());
+        let directory = base.join(format!(
+            "et-htm-auto-{}-{}",
+            std::process::id(),
+            et_core::keys::gen_id_passkey().0
+        ));
+        std::fs::create_dir(&directory).unwrap();
+        Self {
+            path: directory.join("htm.ipc"),
+            directory,
+        }
+    }
+}
+
+impl Drop for Endpoint {
+    fn drop(&mut self) {
+        let cleanup = (|| -> std::io::Result<()> {
+            match et_htm::transport::connect(&self.path) {
+                Ok(mut stream) => {
+                    stream.set_read_timeout(Some(LIMIT))?;
+                    stream.set_write_timeout(Some(LIMIT))?;
+                    framing::write_debug_keys(&mut stream, b"x")?;
+                    std::io::copy(&mut stream, &mut std::io::sink())?;
+                }
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
+                    ) => {}
+                Err(error) => return Err(error),
+            }
+            std::fs::remove_dir_all(&self.directory)
+        })();
+        if let Err(error) = cleanup {
+            eprintln!("HTM autostart cleanup failed: {error}");
+            assert!(std::thread::panicking(), "HTM autostart cleanup failed");
+        }
+    }
+}

--- a/crates/et-htm/Cargo.toml
+++ b/crates/et-htm/Cargo.toml
@@ -14,6 +14,12 @@ workspace = true
 [dependencies]
 base64 = "0.22"
 portable-pty = "0.9.0"
-rustix = { version = "1.1.4", features = ["event", "process"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
+
+[target.'cfg(unix)'.dependencies]
+rustix = { version = "1.1.4", features = ["event", "process"] }
+
+[target.'cfg(windows)'.dependencies]
+et-net = { path = "../et-net" }
+filedescriptor = "0.8.3"

--- a/crates/et-htm/src/client_windows.rs
+++ b/crates/et-htm/src/client_windows.rs
@@ -1,0 +1,78 @@
+//! Windows HTM is a byte relay, including when stdin/stdout are redirected by
+//! the HTM-capable terminal emulator. Console input cannot be polled with a
+//! Winsock socket, so one process-lifetime thread owns the blocking stdin read.
+//! The role's main thread returns on daemon EOF even if stdin remains open;
+//! process exit releases that reader, without waiting for another keystroke.
+
+use std::io::{self, Read, Write};
+use std::net::Shutdown;
+use std::path::Path;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use crate::transport::{self, Stream};
+
+pub struct Stdin(pub std::io::Stdin);
+
+impl Read for Stdin {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        self.0.lock().read(buffer)
+    }
+}
+
+pub fn connect(path: &Path) -> io::Result<Stream> {
+    let mut last_error = io::Error::from(io::ErrorKind::NotFound);
+    for attempt in 0..5 {
+        match transport::connect(path) {
+            Ok(stream) => return Ok(stream),
+            Err(error) => last_error = error,
+        }
+        if attempt < 4 {
+            std::thread::sleep(Duration::from_secs(1));
+        }
+    }
+    Err(last_error)
+}
+
+pub fn run(
+    stream: &mut Stream,
+    mut input: impl Read + Send + 'static,
+    output: &mut impl Write,
+) -> io::Result<()> {
+    let mut writer = stream.try_clone()?;
+    let (errors, input_error) = mpsc::channel();
+    std::thread::Builder::new()
+        .name("htm-stdin".to_owned())
+        .spawn(move || {
+            let error = match io::copy(&mut input, &mut writer) {
+                Ok(_) => io::Error::new(io::ErrorKind::UnexpectedEof, "stdin has closed abruptly"),
+                Err(error) => error,
+            };
+            if errors.send(error).is_ok() {
+                // Wake the output reader so an input error is reported promptly.
+                if let Err(error) = writer.shutdown(Shutdown::Both) {
+                    eprintln!("htm: closing input stream: {error}");
+                }
+            }
+        })?;
+    let result = (|| {
+        let mut buffer = [0; 16 * 1024];
+        loop {
+            match stream.read(&mut buffer) {
+                Ok(0) => return Ok(()),
+                Ok(count) => {
+                    // Do not guess frame boundaries from read() chunk sizes.
+                    // SESSION_END is relayed too; htmd follows it with EOF.
+                    output.write_all(&buffer[..count])?;
+                    output.flush()?;
+                }
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+                Err(error) => return Err(error),
+            }
+        }
+    })();
+    match input_error.try_recv() {
+        Ok(error) => Err(error),
+        Err(_) => result,
+    }
+}

--- a/crates/et-htm/src/lib.rs
+++ b/crates/et-htm/src/lib.rs
@@ -7,9 +7,15 @@
 //! - [`state`] is the tabs/splits/panes model with upstream's JSON shape.
 //! - [`server`] is `htmd` (multiplexer daemon), [`client`] is `htm` (relay).
 
+#[cfg(unix)]
+pub mod client;
+#[cfg(windows)]
+#[path = "client_windows.rs"]
 pub mod client;
 pub mod codes;
 pub mod framing;
 pub mod server;
 pub mod state;
 pub mod terminal_handler;
+
+pub mod transport;

--- a/crates/et-htm/src/server.rs
+++ b/crates/et-htm/src/server.rs
@@ -32,12 +32,15 @@ impl HtmServer {
 
     pub fn run(&mut self) -> io::Result<()> {
         while self.running {
+            // A new authenticated UI (including htm -x) must be serviced even
+            // while the previous UI remains attached. poll_accept closes the
+            // old endpoint only after accepting the replacement.
+            if let Err(error) = self.poll_accept() {
+                self.close_endpoint();
+                eprintln!("htmd: accepting UI client: {error}");
+            }
             if self.endpoint.is_none() {
                 std::thread::sleep(Duration::from_millis(200));
-                if let Err(error) = self.poll_accept() {
-                    self.close_endpoint();
-                    eprintln!("htmd: accepting UI client: {error}");
-                }
                 continue;
             }
             if let Err(error) = self.step() {

--- a/crates/et-htm/src/server.rs
+++ b/crates/et-htm/src/server.rs
@@ -2,52 +2,28 @@
 //! plus `IpcPairServer`.
 
 use std::io::{self, Read, Write};
-use std::os::unix::net::{UnixListener, UnixStream};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::Duration;
 
-use rustix::event::{poll, PollFd, PollFlags};
+pub use crate::transport::pipe_name;
+use crate::transport::{self, Listener, Stream};
 
 use crate::codes;
 use crate::framing;
 use crate::state::MultiplexerState;
 
-/// 10ms poll interval, matching upstream's select() timeout.
-const POLL_TIMEOUT: rustix::event::Timespec = rustix::event::Timespec {
-    tv_sec: 0,
-    tv_nsec: 10_000_000,
-};
-
-/// Default IPC socket path: `<tmp>/htm.<uid>.ipc`, like upstream
-/// `HtmServer::getPipeName`.
-pub fn pipe_name() -> PathBuf {
-    std::env::temp_dir().join(format!("htm.{}.ipc", rustix::process::getuid().as_raw()))
-}
-
 pub struct HtmServer {
-    listener: UnixListener,
-    path: PathBuf,
-    endpoint: Option<UnixStream>,
+    listener: Listener,
+    endpoint: Option<Stream>,
     state: MultiplexerState,
     running: bool,
 }
 
 impl HtmServer {
     pub fn bind(path: &Path) -> io::Result<Self> {
-        // A stale socket from a crashed daemon must not block startup.
-        if path.exists() && UnixStream::connect(path).is_err() {
-            let _ = std::fs::remove_file(path);
-        }
-        let listener = UnixListener::bind(path)?;
-        listener.set_nonblocking(true)?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
-        }
+        let listener = Listener::bind(path)?;
         Ok(Self {
             listener,
-            path: path.to_path_buf(),
             endpoint: None,
             state: MultiplexerState::new().map_err(io::Error::other)?,
             running: true,
@@ -58,7 +34,10 @@ impl HtmServer {
         while self.running {
             if self.endpoint.is_none() {
                 std::thread::sleep(Duration::from_millis(200));
-                self.poll_accept()?;
+                if let Err(error) = self.poll_accept() {
+                    self.close_endpoint();
+                    eprintln!("htmd: accepting UI client: {error}");
+                }
                 continue;
             }
             if let Err(error) = self.step() {
@@ -70,20 +49,21 @@ impl HtmServer {
                 self.close_endpoint();
             }
         }
-        self.close_endpoint();
         self.state.stop_all();
-        let _ = std::fs::remove_file(&self.path);
+        self.listener.retire()?;
+        self.close_endpoint();
         Ok(())
     }
 
     /// Accept a new UI client, replacing any existing one, then resend state.
     fn poll_accept(&mut self) -> io::Result<()> {
         match self.listener.accept() {
-            Ok((stream, _)) => {
+            Ok(stream) => {
                 if self.endpoint.is_some() {
                     self.close_endpoint();
                 }
-                stream.set_nonblocking(true)?;
+                stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+                stream.set_write_timeout(Some(Duration::from_secs(5)))?;
                 self.endpoint = Some(stream);
                 self.recover()
             }
@@ -115,17 +95,7 @@ impl HtmServer {
         let Some(endpoint) = self.endpoint.as_ref() else {
             return Ok(());
         };
-        let mut descriptors = [PollFd::new(
-            endpoint,
-            PollFlags::IN | PollFlags::HUP | PollFlags::ERR,
-        )];
-        poll(&mut descriptors, Some(&POLL_TIMEOUT)).map_err(io::Error::from)?;
-        let events = descriptors[0].revents();
-        if events.intersects(PollFlags::HUP | PollFlags::ERR) {
-            self.close_endpoint();
-            return Ok(());
-        }
-        if events.contains(PollFlags::IN) {
+        if transport::readable(endpoint)? {
             self.handle_message()?;
         }
         if let Some(mut endpoint) = self.endpoint.as_ref().and_then(|s| s.try_clone().ok()) {
@@ -140,19 +110,18 @@ impl HtmServer {
         };
         // Message bodies are read to completion, so block for the remainder
         // once the header byte is available.
-        stream.set_nonblocking(false)?;
         let mut reader = stream;
         let mut header = [0u8; 1];
         if reader.read_exact(&mut header).is_err() {
             self.close_endpoint();
             return Ok(());
         }
-        let length = framing::read_length(&mut reader)?;
-        let result = self.dispatch(header[0], length, &mut reader);
-        if let Some(endpoint) = self.endpoint.as_ref() {
-            endpoint.set_nonblocking(true)?;
+        if header[0] == codes::SESSION_END {
+            self.close_endpoint();
+            return Ok(());
         }
-        result
+        let length = framing::read_length(&mut reader)?;
+        self.dispatch(header[0], length, &mut reader)
     }
 
     fn dispatch(&mut self, header: u8, length: i32, reader: &mut impl Read) -> io::Result<()> {
@@ -234,17 +203,16 @@ impl HtmServer {
 impl Drop for HtmServer {
     fn drop(&mut self) {
         self.state.stop_all();
-        let _ = std::fs::remove_file(&self.path);
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 
     #[test]
     fn pipe_name_matches_upstream_shape() {
-        let path = pipe_name();
+        let path = pipe_name().unwrap();
         let name = path.file_name().unwrap().to_string_lossy().into_owned();
         assert!(name.starts_with("htm."));
         assert!(name.ends_with(".ipc"));

--- a/crates/et-htm/src/state.rs
+++ b/crates/et-htm/src/state.rs
@@ -100,7 +100,16 @@ impl MultiplexerState {
         let mut root = serde_json::Map::new();
         root.insert(
             "shell".to_owned(),
-            serde_json::Value::String(std::env::var("SHELL").unwrap_or_default()),
+            serde_json::Value::String({
+                #[cfg(unix)]
+                {
+                    std::env::var("SHELL").unwrap_or_default()
+                }
+                #[cfg(windows)]
+                {
+                    crate::terminal_handler::default_shell()
+                }
+            }),
         );
         let mut tabs = serde_json::Map::new();
         for (id, tab) in &self.tabs {

--- a/crates/et-htm/src/terminal_handler.rs
+++ b/crates/et-htm/src/terminal_handler.rs
@@ -35,8 +35,9 @@ impl TerminalHandler {
                 pixel_height: 0,
             })
             .map_err(std::io::Error::other)?;
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_owned());
+        let shell = default_shell();
         let mut command = CommandBuilder::new(&shell);
+        #[cfg(unix)]
         command.arg("-l");
         if let Some(home) = home_directory() {
             command.cwd(home);
@@ -163,8 +164,38 @@ impl TerminalHandler {
     }
 }
 
+/// Shell selection follows reviewed upstream HTM on each platform.
+pub(crate) fn default_shell() -> String {
+    if let Some(shell) = std::env::var("SHELL").ok().filter(|s| !s.is_empty()) {
+        return shell;
+    }
+    #[cfg(unix)]
+    {
+        "/bin/sh".to_owned()
+    }
+    #[cfg(windows)]
+    {
+        std::env::var("COMSPEC")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "cmd.exe".to_owned())
+    }
+}
+
+impl Drop for TerminalHandler {
+    fn drop(&mut self) {
+        if self.running {
+            self.stop();
+        }
+    }
+}
+
 fn home_directory() -> Option<std::path::PathBuf> {
-    std::env::var_os("HOME")
+    #[cfg(unix)]
+    let name = "HOME";
+    #[cfg(windows)]
+    let name = "USERPROFILE";
+    std::env::var_os(name)
         .map(std::path::PathBuf::from)
         .filter(|path| path.is_dir())
 }
@@ -209,7 +240,14 @@ mod tests {
         let pty = portable_pty::native_pty_system()
             .openpty(PtySize::default())
             .unwrap();
+        #[cfg(unix)]
         let mut command = CommandBuilder::new("true");
+        #[cfg(windows)]
+        let mut command = {
+            let mut command = CommandBuilder::new("cmd.exe");
+            command.args(["/C", "exit 0"]);
+            command
+        };
         command.env("HTM_TEST", "1");
         pty.slave.spawn_command(command).unwrap()
     }

--- a/crates/et-htm/src/transport.rs
+++ b/crates/et-htm/src/transport.rs
@@ -1,0 +1,88 @@
+//! HTM's local IPC boundary. Unix preserves the upstream socket path/mode.
+//! Windows uses et-net's authenticated loopback endpoint-file convention.
+
+#[cfg(windows)]
+#[path = "transport_windows.rs"]
+mod platform;
+#[cfg(windows)]
+pub use platform::{connect, pipe_name, readable, Listener, Stream};
+
+#[cfg(unix)]
+pub use std::os::unix::net::UnixStream as Stream;
+
+#[cfg(unix)]
+use std::io;
+#[cfg(unix)]
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+pub fn pipe_name() -> io::Result<PathBuf> {
+    Ok(std::env::temp_dir().join(format!("htm.{}.ipc", rustix::process::getuid().as_raw())))
+}
+
+#[cfg(unix)]
+pub fn connect(path: &Path) -> io::Result<Stream> {
+    Stream::connect(path)
+}
+
+#[cfg(unix)]
+pub struct Listener {
+    listener: std::os::unix::net::UnixListener,
+    path: Option<PathBuf>,
+}
+
+#[cfg(unix)]
+impl Listener {
+    pub fn bind(path: &Path) -> io::Result<Self> {
+        use std::os::unix::fs::PermissionsExt;
+        if path.exists() && Stream::connect(path).is_err() {
+            std::fs::remove_file(path)?;
+        }
+        let listener = Self {
+            listener: std::os::unix::net::UnixListener::bind(path)?,
+            path: Some(path.to_path_buf()),
+        };
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        listener.listener.set_nonblocking(true)?;
+        Ok(listener)
+    }
+
+    pub fn accept(&self) -> io::Result<Stream> {
+        self.listener.accept().map(|(stream, _)| stream)
+    }
+
+    pub fn retire(&mut self) -> io::Result<()> {
+        if let Some(path) = self.path.take() {
+            std::fs::remove_file(path)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+impl Drop for Listener {
+    fn drop(&mut self) {
+        if let Err(error) = self.retire() {
+            eprintln!("htmd: retiring IPC socket: {error}");
+        }
+    }
+}
+
+/// Wait for daemon input using upstream's 10ms output-drain cadence.
+#[cfg(unix)]
+pub fn readable(stream: &Stream) -> io::Result<bool> {
+    use rustix::event::{poll, PollFd, PollFlags, Timespec};
+    let mut descriptors = [PollFd::new(
+        stream,
+        PollFlags::IN | PollFlags::HUP | PollFlags::ERR,
+    )];
+    poll(
+        &mut descriptors,
+        Some(&Timespec {
+            tv_sec: 0,
+            tv_nsec: 10_000_000,
+        }),
+    )?;
+    // Read before reacting to HUP so a final complete message is not discarded.
+    Ok(!descriptors[0].revents().is_empty())
+}

--- a/crates/et-htm/src/transport_windows.rs
+++ b/crates/et-htm/src/transport_windows.rs
@@ -1,0 +1,183 @@
+//! Authenticated, loopback-only HTM IPC. The secret inherits the user's
+//! LOCALAPPDATA ACL, matching et-server's Windows router policy. Never put an
+//! endpoint in the shared temp directory or accept an unauthenticated UI.
+
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::net::{Ipv4Addr, TcpListener};
+use std::os::windows::fs::MetadataExt;
+use std::path::{Component, Path, PathBuf};
+use std::time::Duration;
+
+pub use std::net::TcpStream as Stream;
+
+pub fn pipe_name() -> io::Result<PathBuf> {
+    Ok(private_base()?.join("et-htm").join("htm.ipc"))
+}
+
+fn private_base() -> io::Result<PathBuf> {
+    let base = std::env::var_os("LOCALAPPDATA")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "LOCALAPPDATA must be an absolute user-private directory",
+            )
+        })?;
+    check_directory(&base)?;
+    Ok(base)
+}
+
+fn check_directory(path: &Path) -> io::Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if !metadata.is_dir() || metadata.file_attributes() & 0x400 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "HTM directory must not be a reparse point",
+        ));
+    }
+    Ok(())
+}
+
+/// Restrict even explicit --socket paths to the existing user-private tree.
+/// Reject parent traversal and every junction/symlink below LOCALAPPDATA.
+fn prepare_path(path: &Path) -> io::Result<()> {
+    let base = private_base()?;
+    let relative = path.strip_prefix(&base).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "HTM endpoint must be under LOCALAPPDATA",
+        )
+    })?;
+    if relative.components().count() < 2
+        || relative
+            .components()
+            .any(|part| !matches!(part, Component::Normal(_)))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "HTM endpoint requires a private subdirectory",
+        ));
+    }
+    let mut directory = base;
+    if let Some(parent) = relative.parent() {
+        for part in parent.components() {
+            directory.push(part);
+            match std::fs::create_dir(&directory) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error),
+            }
+            check_directory(&directory)?;
+        }
+    }
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if !metadata.is_file() || metadata.file_attributes() & 0x400 != 0 => {
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "HTM endpoint must be a regular file",
+            ))
+        }
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+pub fn connect(path: &Path) -> io::Result<Stream> {
+    prepare_path(path)?;
+    et_net::local::connect(path)
+}
+
+pub struct Listener {
+    listener: TcpListener,
+    token: String,
+    path: Option<PathBuf>,
+    lock: Option<File>,
+}
+
+impl Listener {
+    pub fn bind(path: &Path) -> io::Result<Self> {
+        prepare_path(path)?;
+        let mut lock_path = path.as_os_str().to_owned();
+        lock_path.push(".lock");
+        prepare_path(Path::new(&lock_path))?;
+        let lock = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(lock_path)?;
+        lock.try_lock().map_err(|error| match error {
+            std::fs::TryLockError::WouldBlock => {
+                io::Error::new(io::ErrorKind::AddrInUse, "htmd is already running")
+            }
+            std::fs::TryLockError::Error(error) => error,
+        })?;
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))?;
+        listener.set_nonblocking(true)?;
+        let result = Self {
+            listener,
+            token: et_net::local::new_token(),
+            path: Some(path.to_path_buf()),
+            lock: Some(lock),
+        };
+        // Only the lock owner can retire a stale endpoint or publish a new one.
+        // Files inherit the already-private parent ACL, as et-server's do.
+        std::fs::write(
+            path,
+            format!("{}\n{}\n", result.listener.local_addr()?, result.token),
+        )?;
+        Ok(result)
+    }
+
+    pub fn accept(&self) -> io::Result<Stream> {
+        let (mut stream, peer) = self.listener.accept()?;
+        // Winsock accepts inherit FIONBIO from the listener. Token and frame
+        // bodies use bounded blocking read_exact, including fragmented writes.
+        stream.set_nonblocking(false)?;
+        stream.set_read_timeout(Some(Duration::from_secs(1)))?;
+        if !peer.ip().is_loopback()
+            || et_net::local::accept_token(&mut stream, &self.token).is_err()
+        {
+            // No state, escape sequence, or pane output precedes authentication.
+            return Err(io::Error::from(io::ErrorKind::WouldBlock));
+        }
+        stream.set_nodelay(true)?;
+        Ok(stream)
+    }
+
+    pub fn retire(&mut self) -> io::Result<()> {
+        if let Some(path) = self.path.take() {
+            std::fs::remove_file(path)?;
+        }
+        // Leave the empty lock file in place: unlinking a lock creates races
+        // with another process that has already opened the same file.
+        self.lock.take();
+        Ok(())
+    }
+}
+
+impl Drop for Listener {
+    fn drop(&mut self) {
+        if let Err(error) = self.retire() {
+            eprintln!("htmd: retiring IPC endpoint: {error}");
+        }
+    }
+}
+
+pub fn readable(stream: &Stream) -> io::Result<bool> {
+    use filedescriptor::{poll, pollfd, AsRawSocketDescriptor, POLLIN};
+    let mut descriptors = [pollfd {
+        fd: stream.as_socket_descriptor(),
+        events: POLLIN,
+        revents: 0,
+    }];
+    poll(&mut descriptors, Some(Duration::from_millis(10))).map_err(io::Error::other)?;
+    Ok(descriptors[0].revents != 0)
+}
+
+#[cfg(test)]
+#[path = "transport_windows_tests.rs"]
+mod tests;

--- a/crates/et-htm/src/transport_windows_tests.rs
+++ b/crates/et-htm/src/transport_windows_tests.rs
@@ -1,0 +1,116 @@
+use super::*;
+use std::io::{Read, Write};
+
+struct Directory(PathBuf);
+impl Directory {
+    fn new() -> Self {
+        let path = private_base()
+            .unwrap()
+            .join(format!("et-htm-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir(&path).unwrap();
+        Self(path)
+    }
+    fn endpoint(&self) -> PathBuf {
+        self.0.join("htm.ipc")
+    }
+}
+impl Drop for Directory {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.0).unwrap();
+    }
+}
+
+#[test]
+fn invalid_token_receives_no_state_but_authenticated_client_connects() {
+    // Given a real private endpoint and bound loopback listener.
+    let directory = Directory::new();
+    let path = directory.endpoint();
+    let listener = Listener::bind(&path).unwrap();
+    let (address, _) = et_net::local::read_endpoint(&path).unwrap();
+    let mut intruder = Stream::connect(address).unwrap();
+    intruder
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    // When the peer presents an invalid token.
+    intruder.write_all(b"wrong\n").unwrap();
+    assert_eq!(
+        listener.accept().unwrap_err().kind(),
+        io::ErrorKind::WouldBlock
+    );
+    // Then no data can escape, and the listener remains usable.
+    assert_eq!(intruder.read(&mut [0; 1]).unwrap(), 0);
+    let mut client = connect(&path).unwrap();
+    client
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    let mut server = listener.accept().unwrap();
+    server.write_all(b"authenticated").unwrap();
+    let mut received = [0; 13];
+    client.read_exact(&mut received).unwrap();
+    assert_eq!(&received, b"authenticated");
+}
+
+#[test]
+fn lock_excludes_second_daemon_and_stale_endpoint_is_replaced() {
+    // Given a crashed daemon's endpoint file.
+    let directory = Directory::new();
+    let path = directory.endpoint();
+    std::fs::write(&path, b"stale").unwrap();
+    // When the daemon takes the exclusive lifetime lock.
+    let mut listener = Listener::bind(&path).unwrap();
+    let first = std::fs::read(&path).unwrap();
+    // Then a second bind neither replaces nor removes the live endpoint.
+    let error = match Listener::bind(&path) {
+        Ok(_) => panic!("duplicate bind"),
+        Err(error) => error,
+    };
+    assert_eq!(error.kind(), io::ErrorKind::AddrInUse);
+    assert_eq!(std::fs::read(&path).unwrap(), first);
+    listener.retire().unwrap();
+    let replacement = Listener::bind(&path).unwrap();
+    assert_ne!(std::fs::read(&path).unwrap(), first);
+    drop(listener);
+    assert!(
+        connect(&path).is_ok(),
+        "old generation removed the new endpoint"
+    );
+    drop(replacement);
+}
+
+#[test]
+fn endpoints_outside_private_tree_and_remote_addresses_are_rejected() {
+    // Given paths outside the user's private application directory.
+    let directory = Directory::new();
+    assert!(prepare_path(Path::new(r"C:\Windows\Temp\htm.ipc")).is_err());
+    assert!(prepare_path(&directory.0.join("..").join("escape.ipc")).is_err());
+    // When a private endpoint file advertises a remote address.
+    let path = directory.endpoint();
+    std::fs::write(
+        &path,
+        format!("192.0.2.1:1234\n{}\n", et_net::local::new_token()),
+    )
+    .unwrap();
+    // Then connect rejects it before trying the network.
+    assert_eq!(
+        connect(&path).unwrap_err().kind(),
+        io::ErrorKind::PermissionDenied
+    );
+}
+
+#[test]
+fn accepted_stream_uses_blocking_timeout_instead_of_inherited_would_block() {
+    // Given an authenticated accepted stream with no remaining client bytes.
+    let directory = Directory::new();
+    let path = directory.endpoint();
+    let listener = Listener::bind(&path).unwrap();
+    let _client = connect(&path).unwrap();
+    let mut accepted = listener.accept().unwrap();
+    // When a blocking read's configured timeout expires. Timeouts are the
+    // behavior under test here, not a sleep used to schedule another actor.
+    accepted
+        .set_read_timeout(Some(Duration::from_millis(20)))
+        .unwrap();
+    let error = accepted.read_exact(&mut [0]).unwrap_err();
+    // Then Windows returns WSAETIMEDOUT, not inherited nonblocking WSAEWOULDBLOCK.
+    assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+}


### PR DESCRIPTION
## Summary
- Enable native Windows htm/htmd with ConPTY panes and authenticated local IPC.
- Preserve Unix protocol behavior and add deterministic daemon startup, selected-daemon restart, resize and reattach coverage.
- Run HTM unit and real-role tests on Windows CI.

## Verification
- Lead independently ran native Windows artifacts: 16 unit tests and 3 real-role scenarios pass; no test-owned ET processes remained.
- Native accepted-socket regression failed WouldBlock versus TimedOut before fix and passed afterward.
- Unix tests, golden fixtures, targeted lint and builds pass.
- Hosted MSVC CI and independent gate review are required before merge.

## Compatibility
Protocol v6 and generated wire fixtures unchanged. HTM requires an HTM-capable terminal emulator; this adds no pane GUI. Local IPC follows existing private LOCALAPPDATA ACL assumptions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native Windows support for `htm`/`htmd`: sessions now use ConPTY panes and authenticated local IPC under `%LOCALAPPDATA%`, while Unix protocol and path behavior stay unchanged.

**Windows specifics**
- A new UI attaching closes the previous one even if it is still connected; `-x` does the same and starts a fresh daemon.
- When the host job denies breakaway, the daemon stays supervised by that job and cannot outlive it; otherwise it detaches and survives client exit.
- `htm -x` stops only the selected daemon, not unrelated `htmd` processes.
- The daemon binds an authenticated loopback endpoint; `--socket` selects an isolated endpoint that must stay under the user's `LOCALAPPDATA` tree.
- Shell selection falls back to `COMSPEC`/`cmd.exe`, and home resolves from `USERPROFILE`.
- The client relay is byte-for-byte; no pane GUI is added.

**Testing and compatibility**
- Adds `htm_runtime` integration tests covering pane creation, resize, reattach, auto-start/restart, attached takeover, and host-job survival on both platforms.
- Protocol v6 and wire fixtures are unchanged.
- Windows CI now runs HTM unit and role tests.

<sup>Written for commit 598dd0b862100631128f90bf28063e64386bbfc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

