### PR TITLE
feat(terminal): interrupt large unsent output queues

### DIFF
--- a/.github/upstream-ledger.yml
+++ b/.github/upstream-ledger.yml
@@ -10,10 +10,10 @@
 #   note: short string
 #   et_pr: optional upstream PR number
 #
-# Classified 2026-09-04. #798 marked ported in this et.rs PR.
+# Classified 2026-09-05. #804 is undergoing final port review.
 
 baseline_sha: 7656a32a5bc15c6746726a27a5a4ba1e468fab6e
-classified: "2026-09-04"
+classified: "2026-09-05"
 
 commits:
   - sha: f6cf43707bde07eb6d11495586a35b9f2d64b032
@@ -107,3 +107,9 @@ commits:
     status: skip
     note: "#792 disable SO_LINGER. et.rs never sets SO_LINGER and has no globalMutex-on-close; default linger-off already matches."
     et_pr: 792
+  - sha: cd7319020edce131fbd6f21b1a87e07f4ac41cdb
+    date: "2026-09-05"
+    kind: product
+    status: porting
+    note: "#804 interruptible unsent terminal output, tmux control preservation and priority, bounded socket buffers. Rust implementation under final review; protocol remains 6."
+    et_pr: 804

--- a/.github/upstream-pin.yml
+++ b/.github/upstream-pin.yml
@@ -10,8 +10,8 @@ upstream_repo: EternalTerminal
 reviewed_release_tag: et-v7.0.0
 reviewed_release_sha: 7656a32a5bc15c6746726a27a5a4ba1e468fab6e
 reviewed_default_branch: master
-reviewed_default_branch_sha: 584a68b4b54c74de7035e6108f49151ebce6a191
-reviewed_date: "2026-09-04"
+reviewed_default_branch_sha: cd7319020edce131fbd6f21b1a87e07f4ac41cdb
+reviewed_date: "2026-09-05"
 
 # et.rs still claims protocol v6. ET product is v7.0.0; ET wire is still v6.
 et_rs_protocol_version: 6

--- a/crates/et-bin/src/client_output.rs
+++ b/crates/et-bin/src/client_output.rs
@@ -1,4 +1,7 @@
-//! Bounded, nonblocking local console-output worker for opt-in flow control.
+//! Bounded, interruptible local console output, including default sessions.
+
+#[path = "client_output_interrupt.rs"]
+mod output_interrupt;
 
 use std::collections::VecDeque;
 #[cfg(unix)]
@@ -35,6 +38,8 @@ struct State {
     cursor_reports: usize,
     worker_done: bool,
     worker_progress: usize,
+    stream: et_core::output_interrupt::TerminalStream,
+    skip_until_newline: bool,
 }
 
 struct Shared {
@@ -56,8 +61,6 @@ pub(crate) struct ConsoleOutput {
     capacity_wake: LocalStream,
     #[cfg(unix)]
     status_wake: LocalStream,
-    #[cfg(unix)]
-    _idle_signals: Option<(LocalStream, LocalStream)>,
     cancel: Option<Box<dyn FnOnce() + Send>>,
     graceful_finish: Option<Box<dyn FnOnce() -> io::Result<()> + Send>>,
     worker: Option<thread::JoinHandle<()>>,
@@ -65,14 +68,6 @@ pub(crate) struct ConsoleOutput {
 
 impl ConsoleOutput {
     pub(crate) fn stdout(mode: FlowControlMode) -> io::Result<Self> {
-        if mode == FlowControlMode::None {
-            return Self::new_with_lifecycle(
-                mode,
-                Box::new(io::stdout()),
-                Box::new(|| {}),
-                Box::new(|| Ok(())),
-            );
-        }
         #[cfg(unix)]
         {
             let file = File::from(rustix::io::dup(io::stdout().lock().as_fd())?);
@@ -170,24 +165,6 @@ impl ConsoleOutput {
             signal.set_nonblocking(true)?;
             (wake, signal)
         };
-        match mode {
-            FlowControlMode::None => {
-                return Ok(Self {
-                    mode,
-                    shared: None,
-                    #[cfg(unix)]
-                    capacity_wake,
-                    #[cfg(unix)]
-                    status_wake,
-                    #[cfg(unix)]
-                    _idle_signals: Some((capacity_signal, status_signal)),
-                    cancel: None,
-                    graceful_finish: None,
-                    worker: None,
-                });
-            }
-            FlowControlMode::Backpressure | FlowControlMode::Discard => {}
-        }
         let shared = Arc::new(Shared {
             state: Mutex::new(State {
                 queue: VecDeque::new(),
@@ -197,6 +174,8 @@ impl ConsoleOutput {
                 cursor_reports: 0,
                 worker_done: false,
                 worker_progress: 0,
+                stream: et_core::output_interrupt::TerminalStream::default(),
+                skip_until_newline: false,
             }),
             wake: Condvar::new(),
         });
@@ -221,8 +200,6 @@ impl ConsoleOutput {
             capacity_wake,
             #[cfg(unix)]
             status_wake,
-            #[cfg(unix)]
-            _idle_signals: None,
             cancel: Some(cancel),
             graceful_finish: Some(graceful_finish),
             worker: Some(worker),
@@ -246,13 +223,13 @@ impl ConsoleOutput {
             terminal_modes.observe(bytes);
             return Ok(true);
         };
-        if self.mode == FlowControlMode::Backpressure && bytes.len() > OUTPUT_BYTES {
+        if self.mode != FlowControlMode::Discard && bytes.len() > OUTPUT_BYTES {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "terminal output packet exceeds console queue capacity",
             ));
         }
-        let retained = if bytes.len() > OUTPUT_BYTES {
+        let mut retained = if bytes.len() > OUTPUT_BYTES {
             &bytes[bytes.len() - OUTPUT_BYTES..]
         } else {
             bytes
@@ -270,15 +247,20 @@ impl ConsoleOutput {
                 "console output stopped",
             ));
         }
+        if state.skip_until_newline {
+            let Some(newline) = retained.iter().position(|byte| *byte == b'\n') else {
+                return Ok(true);
+            };
+            retained = &retained[newline + 1..];
+        }
         match self.mode {
-            FlowControlMode::None => unreachable!("none has no shared output queue"),
-            FlowControlMode::Backpressure
+            FlowControlMode::None | FlowControlMode::Backpressure
                 if state.bytes.saturating_add(retained.len()) > OUTPUT_BYTES
                     || state.queue.len() >= OUTPUT_PACKETS =>
             {
                 return Ok(false);
             }
-            FlowControlMode::Backpressure => {}
+            FlowControlMode::None | FlowControlMode::Backpressure => {}
             FlowControlMode::Discard => {
                 while state.bytes.saturating_add(retained.len()) > OUTPUT_BYTES
                     || state.queue.len() >= OUTPUT_PACKETS
@@ -290,6 +272,9 @@ impl ConsoleOutput {
                 }
             }
         }
+        // Only commit the terminator after admission; a held packet must
+        // retry with the same skip state when the queue is still full.
+        state.skip_until_newline = false;
         state.bytes += retained.len();
         state.queue.push_back(OutputEntry {
             bytes: retained.to_vec(),
@@ -493,6 +478,7 @@ fn run_writer(
                 return;
             };
             state.bytes -= bytes.bytes.len();
+            state.stream.observe(&bytes.bytes);
             bytes
         };
         #[cfg(unix)]
@@ -773,3 +759,7 @@ fn signal_capacity(signal: &mut LocalStream) {
 #[cfg(test)]
 #[path = "client_output_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "client_output_interrupt_tests.rs"]
+mod interrupt_tests;

--- a/crates/et-bin/src/client_output_interrupt.rs
+++ b/crates/et-bin/src/client_output_interrupt.rs
@@ -1,0 +1,42 @@
+//! Filtering never touches the chunk already owned by the console writer.
+
+use std::io;
+
+use super::ConsoleOutput;
+
+impl ConsoleOutput {
+    pub(crate) fn interrupt(&self) -> io::Result<usize> {
+        let Some(shared) = &self.shared else {
+            return Ok(0);
+        };
+        let mut state = shared
+            .state
+            .lock()
+            .map_err(|_| io::Error::other("console output worker unavailable"))?;
+        if state.bytes < et_core::output_interrupt::FLUSH_THRESHOLD {
+            return Ok(0);
+        }
+        let bytes: Vec<u8> = state
+            .queue
+            .iter()
+            .flat_map(|entry| entry.bytes.iter().copied())
+            .collect();
+        let filtered = state.stream.filter(&bytes);
+        state.skip_until_newline |= filtered.skip_until_newline;
+        let mut remaining = filtered.kept.as_slice();
+        state.queue.retain_mut(|entry| {
+            let count = remaining.len().min(entry.bytes.len());
+            if count == 0 {
+                return false;
+            }
+            entry.bytes.clear();
+            entry.bytes.extend_from_slice(&remaining[..count]);
+            remaining = &remaining[count..];
+            true
+        });
+        state.bytes = filtered.kept.len();
+        drop(state);
+        shared.wake.notify_all();
+        Ok(filtered.dropped)
+    }
+}

--- a/crates/et-bin/src/client_output_interrupt_tests.rs
+++ b/crates/et-bin/src/client_output_interrupt_tests.rs
@@ -1,0 +1,185 @@
+use super::*;
+use crate::client_terminal::TerminalModeState;
+
+struct RecordedOutput(Arc<Mutex<Vec<u8>>>);
+
+impl Write for RecordedOutput {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn output_interrupt_default_console_delivers_small_output_to_its_writer() {
+    // Given: a default console with an observable output sink.
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let output = ConsoleOutput::new(
+        FlowControlMode::None,
+        Box::new(RecordedOutput(Arc::clone(&bytes))),
+    )
+    .unwrap();
+    // When: a terminal packet is admitted and remote completion drains it.
+    assert!(output
+        .try_write(b"ET_SMALL_OUTPUT_OK", &TerminalModeState::default())
+        .unwrap());
+    output
+        .complete(ConsoleCompletion::RemoteSessionEnded)
+        .unwrap();
+    // Then: the configured writer, not an unrelated process stdout, receives
+    // the exact small output. This is a byte assertion, not a worker flag.
+    assert_eq!(*bytes.lock().unwrap(), b"ET_SMALL_OUTPUT_OK");
+}
+
+struct GatedOutput {
+    bytes: Arc<Mutex<Vec<u8>>>,
+    entered: std::sync::mpsc::Sender<()>,
+    release: Option<std::sync::mpsc::Receiver<()>>,
+}
+
+impl Write for GatedOutput {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        if let Some(release) = self.release.take() {
+            self.entered.send(()).map_err(io::Error::other)?;
+            release
+                .recv_timeout(Duration::from_secs(3))
+                .map_err(io::Error::other)?;
+        }
+        self.bytes.lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+type ConsoleGate = (
+    ConsoleOutput,
+    Arc<Mutex<Vec<u8>>>,
+    std::sync::mpsc::Sender<()>,
+);
+
+#[test]
+fn output_interrupt_preserves_console_output_below_the_flush_threshold() {
+    // Given unsent output below upstream's 64 KiB interrupt threshold.
+    for size in [6, 64 * 1024 - 1] {
+        let (output, bytes, release) = gated_output(FlowControlMode::None, b"prefix\n");
+        let pending = vec![b'x'; size];
+        assert!(output
+            .try_write(&pending, &TerminalModeState::default())
+            .unwrap());
+        // When the user interrupts while the writer still owns the prefix.
+        output.interrupt().unwrap();
+        release.send(()).unwrap();
+        output
+            .complete(ConsoleCompletion::RemoteSessionEnded)
+            .unwrap();
+        // Then small output remains byte-exact.
+        assert_eq!(
+            *bytes.lock().unwrap(),
+            [b"prefix\n".as_slice(), &pending].concat()
+        );
+    }
+}
+
+fn gated_output(mode: FlowControlMode, prefix: &[u8]) -> ConsoleGate {
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let (entered, entering) = std::sync::mpsc::channel();
+    let (release, releasing) = std::sync::mpsc::channel();
+    let output = ConsoleOutput::new(
+        mode,
+        Box::new(GatedOutput {
+            bytes: Arc::clone(&bytes),
+            entered,
+            release: Some(releasing),
+        }),
+    )
+    .unwrap();
+    assert!(output
+        .try_write(prefix, &TerminalModeState::default())
+        .unwrap());
+    entering.recv_timeout(Duration::from_secs(3)).unwrap();
+    (output, bytes, release)
+}
+
+#[test]
+fn output_interrupt_saturated_console_delivers_prefix_then_new_prompt() {
+    for mode in [
+        FlowControlMode::None,
+        FlowControlMode::Backpressure,
+        FlowControlMode::Discard,
+    ] {
+        // Given: a writer-owned prefix and an exactly full unsent console queue.
+        let (output, bytes, release) = gated_output(mode, b"prefix\n");
+        let modes = TerminalModeState::default();
+        assert!(output.try_write(&vec![b'x'; OUTPUT_BYTES], &modes).unwrap());
+        // When: interrupt discards the queued flood, then a new prompt arrives.
+        output.interrupt().unwrap();
+        assert!(output.try_write(b"ET_CTRL_C_OK", &modes).unwrap());
+        release.send(()).unwrap();
+        output
+            .complete(ConsoleCompletion::RemoteSessionEnded)
+            .unwrap();
+        // Then: assert actual sink bytes, not queue/worker implementation state.
+        assert_eq!(*bytes.lock().unwrap(), b"prefix\nET_CTRL_C_OK");
+    }
+}
+
+#[test]
+fn output_interrupt_console_finishes_in_flight_tmux_line_and_keeps_layout() {
+    // Given: the transport writer already owns a partial tmux output line.
+    let prefix = b"%extended-output %0 0 : ";
+    let (output, bytes, release) = gated_output(FlowControlMode::None, prefix);
+    let modes = TerminalModeState::default();
+    let queued = format!(
+        "tail\n%output %0 {}\n%layout-change @1 layout\n",
+        "x".repeat(64 * 1024 - b"tail\n%output %0 \n%layout-change @1 layout\n".len())
+    );
+    assert!(output.try_write(queued.as_bytes(), &modes).unwrap());
+    // When: queued pane output is interrupted before the first write completes.
+    output.interrupt().unwrap();
+    release.send(()).unwrap();
+    output
+        .complete(ConsoleCompletion::RemoteSessionEnded)
+        .unwrap();
+    // Then: the existing line terminates and control notifications stay intact.
+    assert_eq!(
+        *bytes.lock().unwrap(),
+        b"%extended-output %0 0 : tail\n%layout-change @1 layout\n"
+    );
+}
+
+#[test]
+fn output_interrupt_console_skips_only_the_dropped_tmux_continuation() {
+    // Given: an incomplete pane line is wholly unsent behind a notification.
+    let prefix = b"%session-changed $1 test\n";
+    let (output, bytes, release) = gated_output(FlowControlMode::None, prefix);
+    let modes = TerminalModeState::default();
+    assert!(output
+        .try_write(
+            format!(
+                "%output %0 {}",
+                "x".repeat(64 * 1024 - b"%output %0 ".len())
+            )
+            .as_bytes(),
+            &modes
+        )
+        .unwrap());
+    // When: an interrupt is followed by more of that line and a notification.
+    output.interrupt().unwrap();
+    assert!(output.try_write(b"more-pane-data", &modes).unwrap());
+    assert!(output.try_write(b"\n%window-add @2\n", &modes).unwrap());
+    release.send(()).unwrap();
+    output
+        .complete(ConsoleCompletion::RemoteSessionEnded)
+        .unwrap();
+    // Then: no orphan pane fragment or lost notification reaches the sink.
+    assert_eq!(
+        *bytes.lock().unwrap(),
+        b"%session-changed $1 test\n%window-add @2\n"
+    );
+}

--- a/crates/et-bin/src/client_output_tests.rs
+++ b/crates/et-bin/src/client_output_tests.rs
@@ -341,6 +341,8 @@ fn partial_writes_report_progress_before_completion_and_drain_every_byte() {
             cursor_reports: 0,
             worker_done: false,
             worker_progress: 0,
+            stream: et_core::output_interrupt::TerminalStream::default(),
+            skip_until_newline: false,
         }),
         wake: Condvar::new(),
     });

--- a/crates/et-bin/src/client_terminal_loop.rs
+++ b/crates/et-bin/src/client_terminal_loop.rs
@@ -128,6 +128,7 @@ where
     // queue. Keep exact ownership and stop reading the ordered server stream,
     // while stdin, outbound forwarding, keepalive, and recovery stay live.
     let mut pending_output: Option<et_core::packet::Packet> = None;
+    let mut interrupt_input = et_core::output_interrupt::InterruptInput::default();
     let forward_wake = forwarder
         .wake()
         .map_err(|error| terminal_text(error.to_string()))?;
@@ -310,7 +311,12 @@ where
                 }
             }
         }
-        while pending_forward.len() < FORWARD_BACKLOG_CAPACITY && pending_output.is_none() {
+        // Ready input gets the interrupt onto the wire before another flood
+        // batch is read. Output remains bounded even with --flow-control none.
+        while !input.contains(PollFlags::IN)
+            && pending_forward.len() < FORWARD_BACKLOG_CAPACITY
+            && pending_output.is_none()
+        {
             match connection.try_read_packet() {
                 Ok(Some(packet)) => {
                     last_received = Instant::now();
@@ -428,6 +434,11 @@ where
                 return console_output
                     .complete(ConsoleCompletion::LocalInputClosed)
                     .map_err(|error| terminal_io("stopping terminal output", error));
+            }
+            if interrupt_input.feed(&bytes[..count]) {
+                console_output
+                    .interrupt()
+                    .map_err(|error| terminal_io("interrupting console output", error))?;
             }
             let payload = encoded_buffer(&bytes[..count]);
             match write_owned(

--- a/crates/et-bin/src/client_terminal_windows.rs
+++ b/crates/et-bin/src/client_terminal_windows.rs
@@ -62,6 +62,7 @@ where
     }
     let mut pending_forward = VecDeque::new();
     let mut pending_output: Option<et_core::packet::Packet> = None;
+    let mut interrupt_input = et_core::output_interrupt::InterruptInput::default();
     loop {
         console_output
             .check_error()
@@ -134,6 +135,11 @@ where
                         let bytes = key_bytes(&key);
                         if bytes.is_empty() {
                             continue;
+                        }
+                        if interrupt_input.feed(&bytes) {
+                            console_output.interrupt().map_err(|error| {
+                                terminal_io("interrupting console output", error)
+                            })?;
                         }
                         let payload = encoded_buffer(&bytes);
                         match write_owned_recovering(

--- a/crates/et-bin/src/terminal_jump.rs
+++ b/crates/et-bin/src/terminal_jump.rs
@@ -66,15 +66,11 @@ where
         .flowcontrol
         .and_then(|value| FlowControlMode::try_from(value).ok())
         .unwrap_or(FlowControlMode::None);
-    let bounded_output = match flow_control {
-        FlowControlMode::None => false,
-        FlowControlMode::Backpressure | FlowControlMode::Discard => true,
-    };
-    if bounded_output {
-        // Destination output enters the jumphost router through this terminal-
-        // side sender. Keep pressure in the server's bounded application lanes.
-        et_net::local::minimize_terminal_output_buffering(&router)
-            .map_err(|error| format!("could not bound jumphost output buffering: {error}"))?;
+    match flow_control {
+        FlowControlMode::None | FlowControlMode::Backpressure | FlowControlMode::Discard => {
+            et_net::local::minimize_terminal_output_buffering(&router)
+                .map_err(|error| format!("could not bound jumphost output buffering: {error}"))?
+        }
     }
     // The destination runs a real terminal, so the relayed payload must not
     // ask it to start another jumphost.
@@ -218,10 +214,11 @@ where
         .and_then(|value| FlowControlMode::try_from(value).ok())
         .unwrap_or(FlowControlMode::None)
     {
-        FlowControlMode::None => {}
-        FlowControlMode::Backpressure | FlowControlMode::Discard => connection
-            .minimize_output_buffering()
-            .map_err(|error| format!("could not bound destination output buffering: {error}"))?,
+        FlowControlMode::None | FlowControlMode::Backpressure | FlowControlMode::Discard => {
+            connection
+                .minimize_output_buffering()
+                .map_err(|error| format!("could not bound destination output buffering: {error}"))?
+        }
     }
     observe_before_payload(&connection)?;
     connection

--- a/crates/et-bin/src/terminal_jump_tests.rs
+++ b/crates/et-bin/src/terminal_jump_tests.rs
@@ -29,6 +29,16 @@ fn malformed_downstream_initial_response_fails_closed() {
 
 #[test]
 fn jumphost_clamps_destination_before_typed_initial_payload() {
+    for flow_control in [
+        None,
+        Some(FlowControlMode::Backpressure as i32),
+        Some(FlowControlMode::Discard as i32),
+    ] {
+        assert_destination_clamped(flow_control);
+    }
+}
+
+fn assert_destination_clamped(flow_control: Option<i32>) {
     // Given: a destination requiring proof of the clamp before it accepts
     // INITIAL_PAYLOAD and starts terminal output.
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
@@ -58,10 +68,7 @@ fn jumphost_clamps_destination_before_typed_initial_payload() {
         let packet = connection.read_packet().unwrap();
         assert_eq!(packet.header(), EtPacketType::InitialPayload as u8);
         let payload = InitialPayload::decode(packet.payload()).unwrap();
-        assert_eq!(
-            payload.flowcontrol,
-            Some(FlowControlMode::Backpressure as i32)
-        );
+        assert_eq!(payload.flowcontrol, flow_control);
         assert_eq!(payload.jumphost, Some(false));
         connection
             .write_packet(
@@ -72,7 +79,7 @@ fn jumphost_clamps_destination_before_typed_initial_payload() {
     });
     let payload = InitialPayload {
         jumphost: Some(false),
-        flowcontrol: Some(FlowControlMode::Backpressure as i32),
+        flowcontrol: flow_control,
         ..Default::default()
     };
 

--- a/crates/et-bin/src/terminal_pty.rs
+++ b/crates/et-bin/src/terminal_pty.rs
@@ -55,11 +55,12 @@ where
     F: FnOnce(&mut LocalStream) -> Result<(), String>,
 {
     let initialization = read_initialization(&mut router)?;
-    if initialization.flow_control != FlowControlMode::None {
-        // Keep terminal output in the server's bounded application queue,
-        // rather than a large opaque local-socket queue (upstream PR #730).
-        et_net::local::minimize_terminal_output_buffering(&router)
-            .map_err(|error| format!("could not bound terminal output buffering: {error}"))?;
+    // Default sessions now also retain interruptible output in userspace.
+    match initialization.flow_control {
+        FlowControlMode::None | FlowControlMode::Backpressure | FlowControlMode::Discard => {
+            et_net::local::minimize_terminal_output_buffering(&router)
+                .map_err(|error| format!("could not bound terminal output buffering: {error}"))?
+        }
     }
     #[cfg(unix)]
     let motd = crate::terminal_motd::load_startup_prefix();

--- a/crates/et-bin/tests/output_interrupt_tty_qa.rs
+++ b/crates/et-bin/tests/output_interrupt_tty_qa.rs
@@ -1,0 +1,189 @@
+#![cfg(unix)]
+#![forbid(unsafe_code)]
+
+mod flow_control_tty_support;
+
+use std::fs;
+use std::io::{self, Read, Write};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use flow_control_tty_support::{
+    Stack, ThrottleProxy, MAX_PROMPT_LATENCY, SATURATION_BYTES, THROTTLE_BYTES_PER_SECOND,
+};
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+
+struct Transcript {
+    receiver: mpsc::Receiver<Vec<u8>>,
+    bytes: Vec<u8>,
+}
+
+impl Transcript {
+    fn until(&mut self, marker: &[u8], deadline: Instant) -> Result<(), String> {
+        while !self.bytes.windows(marker.len()).any(|part| part == marker) {
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .ok_or_else(|| format!("terminal marker deadline expired: {marker:?}"))?;
+            self.bytes.extend(
+                self.receiver
+                    .recv_timeout(remaining)
+                    .map_err(|error| format!("waiting for terminal marker {marker:?}: {error}"))?,
+            );
+        }
+        Ok(())
+    }
+}
+
+#[test]
+fn default_output_flood_interrupt_allows_a_subsequent_command() {
+    // Given: native ET client/server processes and actual PTYs, with a slow
+    // encrypted TCP path. The only SSH replacement is local bootstrap execution;
+    // it does not emulate ET transport, terminal output, or Ctrl+C handling.
+    let stack = Stack::start();
+    let proxy = ThrottleProxy::start(stack.port, THROTTLE_BYTES_PER_SECOND, SATURATION_BYTES);
+    let pair = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 800,
+            pixel_height: 480,
+        })
+        .unwrap();
+    let mut writer = pair.master.take_writer().unwrap();
+    let mut reader = pair.master.try_clone_reader().unwrap();
+    let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_et"));
+    command.args([
+        "--flow-control",
+        "none",
+        "--terminal-path",
+        stack.terminal.to_str().unwrap(),
+        "--serverfifo",
+        stack.router.to_str().unwrap(),
+        "-p",
+        &proxy.port.to_string(),
+        "127.0.0.1",
+    ]);
+    command.env(
+        "PATH",
+        format!(
+            "{}:{}",
+            stack.directory.display(),
+            std::env::var("PATH").unwrap()
+        ),
+    );
+    command.env("TERM", "xterm-256color");
+    let mut child = pair.slave.spawn_command(command).unwrap();
+    drop(pair.slave);
+    let (sender, receiver) = mpsc::sync_channel(32);
+    let reader_thread = thread::spawn(move || -> io::Result<()> {
+        let mut bytes = [0_u8; 8192];
+        loop {
+            match reader.read(&mut bytes) {
+                Ok(0) => return Ok(()),
+                Ok(count) => {
+                    if sender.send(bytes[..count].to_vec()).is_err() {
+                        return Ok(());
+                    }
+                }
+                // Unix PTY masters report EIO when the last slave closes.
+                Err(error) if error.raw_os_error() == Some(5) => return Ok(()),
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+                Err(error) => return Err(error),
+            }
+        }
+    });
+    let mut transcript = Transcript {
+        receiver,
+        bytes: Vec::new(),
+    };
+    let mut latency = Duration::ZERO;
+    let result = (|| -> Result<(), String> {
+        writeln!(
+            writer,
+            "interrupted=; trap 'interrupted=1; printf \"\\nET_INT%s\\n\" ERRUPTED' INT; \
+             printf 'ET_FLOOD_%s\\n' START; IFS= read -r gate; \
+             while [ -z \"$interrupted\" ]; do \
+             printf '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'; \
+             done; trap - INT; printf 'ET_FLOOD_%s\\n' STOPPED"
+        )
+        .map_err(|error| error.to_string())?;
+        writer.flush().map_err(|error| error.to_string())?;
+        transcript.until(
+            b"ET_FLOOD_START\r\n",
+            Instant::now() + Duration::from_secs(10),
+        )?;
+        writer
+            .write_all(b"RELEASE\n")
+            .map_err(|error| error.to_string())?;
+        writer.flush().map_err(|error| error.to_string())?;
+        // Subscribe to the proxy's exact transfer event, not a guessed delay.
+        // Rate limiting is the time behavior under test; no correctness sleeps.
+        proxy
+            .wait_saturated(Duration::from_secs(40))
+            .map_err(|error| error.to_string())?;
+
+        // When: send actual Ctrl+C through the client's raw input PTY.
+        let interrupted = Instant::now();
+        let deadline = interrupted + MAX_PROMPT_LATENCY;
+        writer
+            .write_all(b"\x03")
+            .map_err(|error| error.to_string())?;
+        writer.flush().map_err(|error| error.to_string())?;
+        transcript.until(b"ET_INTERRUPTED\r\n", deadline)?;
+        transcript.until(b"ET_FLOOD_STOPPED\r\n", deadline)?;
+        writer
+            .write_all(b"printf 'ET_CTRL_C_%s\\n' OK\n")
+            .map_err(|error| error.to_string())?;
+        writer.flush().map_err(|error| error.to_string())?;
+        transcript.until(b"ET_CTRL_C_OK\r\n", deadline)?;
+        latency = interrupted.elapsed();
+        Ok(())
+    })();
+
+    // Cleanup is performed before any behavioral assertion, including failures.
+    let killed = child.kill();
+    drop(writer);
+    let reaped = child.wait();
+    let Transcript { receiver, bytes } = transcript;
+    drop(receiver);
+    let reader_result = reader_thread.join();
+    let proxy_result = proxy.finish();
+    let directory = stack.directory.clone();
+    drop(stack);
+
+    if let Some(evidence) = std::env::var_os("ET_INTERRUPT_QA_EVIDENCE_DIR") {
+        let evidence = std::path::PathBuf::from(evidence);
+        fs::create_dir_all(&evidence).unwrap();
+        fs::write(evidence.join("default-output.ansi"), &bytes).unwrap();
+        fs::write(
+            evidence.join("default-output.txt"),
+            format!(
+                "surface=native Unix ET client/server + PTYs\nbootstrap=local SSH adapter\n\
+             mode=none\nrate_bytes_per_second={}\nsaturation_bytes={}\n\
+             ctrl_c_prompt_millis={}\nscenario={result:?}\n\
+             client_kill={killed:?}\nclient_reaped={reaped:?}\n\
+             proxy_cleanup={proxy_result:?}\nstack_removed={}\n",
+                THROTTLE_BYTES_PER_SECOND,
+                SATURATION_BYTES,
+                latency.as_millis(),
+                !directory.exists(),
+            ),
+        )
+        .unwrap();
+    }
+
+    // Then: the actual terminal displays output from a subsequent command.
+    killed.unwrap();
+    reaped.unwrap();
+    reader_result.unwrap().unwrap();
+    proxy_result.unwrap();
+    assert!(
+        result.is_ok(),
+        "native flood/Ctrl+C/subsequent command failed: {result:?}"
+    );
+    assert!(bytes
+        .windows(b"ET_CTRL_C_OK\r\n".len())
+        .any(|part| part == b"ET_CTRL_C_OK\r\n"));
+    assert!(latency <= MAX_PROMPT_LATENCY);
+}

--- a/crates/et-core/src/flow_control.rs
+++ b/crates/et-core/src/flow_control.rs
@@ -32,6 +32,10 @@ pub struct OutputQueue {
     terminal: VecDeque<Packet>,
     control: VecDeque<Packet>,
     prefer_terminal: bool,
+    stream: crate::output_interrupt::TerminalStream,
+    before_take: Option<crate::output_interrupt::TerminalStream>,
+    skip_until_newline: bool,
+    promotion_pending: bool,
 }
 
 impl OutputQueue {
@@ -46,6 +50,10 @@ impl OutputQueue {
             terminal: VecDeque::new(),
             control: VecDeque::new(),
             prefer_terminal: true,
+            stream: crate::output_interrupt::TerminalStream::default(),
+            before_take: None,
+            skip_until_newline: false,
+            promotion_pending: false,
         }
     }
 
@@ -58,6 +66,21 @@ impl OutputQueue {
     }
 
     fn push_terminal(&mut self, mut packet: Packet) -> Result<(), QueuePushError> {
+        if self.skip_until_newline {
+            if let Ok(mut message) = TerminalBuffer::decode(packet.payload()) {
+                if let Some(bytes) = &mut message.buffer {
+                    let Some(newline) = bytes.iter().position(|byte| *byte == b'\n') else {
+                        return Ok(());
+                    };
+                    self.skip_until_newline = false;
+                    bytes.drain(..=newline);
+                    if bytes.is_empty() {
+                        return Ok(());
+                    }
+                    packet = Packet::new(packet.header(), message.encode_to_vec());
+                }
+            }
+        }
         if packet_cost(&packet) > self.limit {
             if self.mode == FlowControlMode::Backpressure {
                 return Err(QueuePushError::Oversized(packet));
@@ -83,6 +106,7 @@ impl OutputQueue {
         self.terminal_bytes += wanted;
         self.terminal_packets += 1;
         self.terminal.push_back(packet);
+        self.promotion_pending = true;
         Ok(())
     }
 
@@ -103,6 +127,7 @@ impl OutputQueue {
     }
 
     pub fn take(&mut self) -> Option<Packet> {
+        self.promote_terminal_control();
         let packet = if self.prefer_terminal {
             self.terminal
                 .pop_front()
@@ -113,6 +138,13 @@ impl OutputQueue {
                 .or_else(|| self.terminal.pop_front())
         }?;
         self.prefer_terminal = !self.prefer_terminal;
+        if is_terminal_output(&packet) {
+            self.before_take = Some(self.stream.clone());
+            if let Ok(message) = TerminalBuffer::decode(packet.payload()) {
+                self.stream
+                    .observe(message.buffer.as_deref().unwrap_or_default());
+            }
+        }
         Some(packet)
     }
 
@@ -128,6 +160,9 @@ impl OutputQueue {
 
     pub fn restore_front(&mut self, packet: Packet) {
         if is_terminal_output(&packet) {
+            if let Some(stream) = self.before_take.take() {
+                self.stream = stream;
+            }
             self.terminal.push_front(packet);
         } else {
             self.control.push_front(packet);
@@ -157,6 +192,86 @@ impl OutputQueue {
 
     pub fn bytes(&self) -> usize {
         self.terminal_bytes + self.control_bytes
+    }
+
+    /// Drop only unsequenced terminal bytes. In-flight reservations and the
+    /// independent control lane are untouched, so replay stays contiguous.
+    pub fn flush_terminal_on_interrupt(&mut self) -> usize {
+        let mut bytes = Vec::new();
+        let mut lengths = Vec::new();
+        for packet in &self.terminal {
+            // An opaque/malformed packet is not permission to discard data.
+            let Ok(message) = TerminalBuffer::decode(packet.payload()) else {
+                return 0;
+            };
+            let Some(body) = message.buffer else { return 0 };
+            lengths.push(body.len());
+            bytes.extend(body);
+        }
+        if bytes.len() < crate::output_interrupt::FLUSH_THRESHOLD {
+            return 0;
+        }
+        let result = self.stream.filter(&bytes);
+        self.skip_until_newline |= result.skip_until_newline;
+        let mut remaining = result.kept.as_slice();
+        let mut retained = VecDeque::new();
+        for length in lengths {
+            let Some(packet) = self.terminal.pop_front() else {
+                break;
+            };
+            self.terminal_bytes -= packet_cost(&packet);
+            self.terminal_packets -= 1;
+            let count = remaining.len().min(length);
+            if count == 0 {
+                continue;
+            }
+            let body = TerminalBuffer {
+                buffer: Some(remaining[..count].to_vec()),
+            };
+            let packet = Packet::new(packet.header(), body.encode_to_vec());
+            self.terminal_bytes += packet_cost(&packet);
+            self.terminal_packets += 1;
+            retained.push_back(packet);
+            remaining = &remaining[count..];
+        }
+        self.terminal = retained;
+        result.dropped
+    }
+
+    fn promote_terminal_control(&mut self) {
+        if !self.promotion_pending || self.terminal_bytes < crate::output_interrupt::FLUSH_THRESHOLD
+        {
+            return;
+        }
+        self.promotion_pending = false;
+        let mut bytes = Vec::new();
+        let mut lengths = Vec::new();
+        for packet in &self.terminal {
+            let Ok(message) = TerminalBuffer::decode(packet.payload()) else {
+                return;
+            };
+            let Some(body) = message.buffer else { return };
+            lengths.push(body.len());
+            bytes.extend(body);
+        }
+        let Some(promoted) = self.stream.promote_control(&bytes) else {
+            return;
+        };
+        let mut remaining = promoted.as_slice();
+        for (packet, length) in self.terminal.iter_mut().zip(lengths) {
+            self.terminal_bytes -= packet_cost(packet);
+            let body = TerminalBuffer {
+                buffer: Some(remaining[..length].to_vec()),
+            };
+            *packet = Packet::new(packet.header(), body.encode_to_vec());
+            self.terminal_bytes += packet_cost(packet);
+            remaining = &remaining[length..];
+        }
+    }
+
+    /// Adjust admission after a connection state change without evicting data.
+    pub fn set_limit(&mut self, limit: usize) {
+        self.limit = limit;
     }
 }
 

--- a/crates/et-core/src/lib.rs
+++ b/crates/et-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod flow_control;
 pub mod framing;
 pub mod keepalive;
 pub mod keys;
+pub mod output_interrupt;
 pub mod packet;
 pub mod proto;
 

--- a/crates/et-core/src/output_interrupt.rs
+++ b/crates/et-core/src/output_interrupt.rs
@@ -1,0 +1,181 @@
+//! Interrupt recognition and loss-aware filtering of unsent terminal bytes.
+
+pub const FLUSH_THRESHOLD: usize = 64 * 1024;
+
+/// Client input may split a tmux control-mode command across transport packets.
+#[derive(Default)]
+pub struct InterruptInput {
+    carry: Vec<u8>,
+    overlong: bool,
+}
+
+impl InterruptInput {
+    pub fn feed(&mut self, bytes: &[u8]) -> bool {
+        let mut interrupt = bytes.iter().any(|byte| matches!(byte, 3 | 26 | 28));
+        for &byte in bytes {
+            if matches!(byte, b'\n' | b'\r') {
+                interrupt |= !self.overlong && command_requests_interrupt(&self.carry);
+                self.carry.clear();
+                self.overlong = false;
+            } else if !self.overlong {
+                if self.carry.len() == 4096 {
+                    self.carry.clear();
+                    self.overlong = true;
+                } else {
+                    self.carry.push(byte);
+                }
+            }
+        }
+        interrupt || (!self.overlong && command_requests_interrupt(&self.carry))
+    }
+}
+
+fn command_requests_interrupt(bytes: &[u8]) -> bool {
+    let Ok(line) = std::str::from_utf8(bytes) else {
+        return false;
+    };
+    let mut tokens = line.split_ascii_whitespace();
+    if !matches!(tokens.next(), Some("send-keys" | "send")) {
+        return false;
+    }
+    let mut hex = false;
+    let mut literal = false;
+    while let Some(token) = tokens.next() {
+        if let Some(flags) = token.strip_prefix('-') {
+            if flags.contains('H') {
+                hex = true;
+                literal = false;
+            } else if flags.contains('l') {
+                literal = true;
+                hex = false;
+            }
+            if flags.chars().any(|flag| matches!(flag, 't' | 'c' | 'N')) {
+                tokens.next();
+            }
+            continue;
+        }
+        if literal {
+            continue;
+        }
+        let number = token
+            .strip_prefix("0x")
+            .or_else(|| token.strip_prefix("0X"));
+        if hex || number.is_some() {
+            let number = number.unwrap_or(token);
+            if (1..=2).contains(&number.len())
+                && matches!(u8::from_str_radix(number, 16), Ok(3 | 26 | 28))
+            {
+                return true;
+            }
+        } else if ["C-c", "^C", "C-z", "^Z", "C-\\", "C-|"]
+            .iter()
+            .any(|key| token.eq_ignore_ascii_case(key))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// State of the prefix already handed to the transport/console writer.
+/// Never truncate a line whose prefix a tmux client has already received.
+#[derive(Clone, Default)]
+pub struct TerminalStream {
+    token: Vec<u8>,
+    token_done: bool,
+    midline: bool,
+    control: bool,
+    block: bool,
+}
+
+impl TerminalStream {
+    pub fn observe(&mut self, bytes: &[u8]) {
+        for &byte in bytes {
+            if !self.midline && byte == b'%' {
+                self.control = true;
+            }
+            if byte == b'\n' {
+                match self.token.as_slice() {
+                    b"%begin" => self.block = true,
+                    b"%end" | b"%error" => self.block = false,
+                    _ => {}
+                }
+                self.token.clear();
+                self.token_done = false;
+                self.midline = false;
+            } else {
+                self.midline = true;
+                if byte.is_ascii_whitespace() {
+                    self.token_done = true;
+                }
+                if !self.token_done && self.token.len() < 32 {
+                    self.token.push(byte);
+                }
+            }
+        }
+    }
+
+    /// Filter a contiguous unsent suffix; the caller owns any trailing skip.
+    pub fn filter(&self, bytes: &[u8]) -> FilteredOutput {
+        self.partition(bytes, false)
+    }
+
+    /// Make command responses available before pane floods without losing bytes.
+    pub fn promote_control(&self, bytes: &[u8]) -> Option<Vec<u8>> {
+        if !self.control
+            && !bytes
+                .split(|byte| *byte == b'\n')
+                .any(|line| line.starts_with(b"%output ") || line.starts_with(b"%extended-output "))
+        {
+            return None;
+        }
+        let mut result = self.partition(bytes, true);
+        if result.kept.is_empty() || result.droppable.is_empty() {
+            return None;
+        }
+        result.kept.extend(result.droppable);
+        Some(result.kept)
+    }
+
+    fn partition(&self, bytes: &[u8], retain_droppable: bool) -> FilteredOutput {
+        let mut state = self.clone();
+        let mut kept = Vec::new();
+        let mut droppable = Vec::new();
+        let mut skip_until_newline = false;
+        for line in bytes.split_inclusive(|byte| *byte == b'\n') {
+            let token = line
+                .split(|byte| byte.is_ascii_whitespace())
+                .next()
+                .unwrap_or_default();
+            let pane = matches!(token, b"%output" | b"%extended-output");
+            let keep = state.block
+                || (state.control && state.midline)
+                || (token.starts_with(b"%") && !pane)
+                || (state.control && token.is_empty());
+            if keep {
+                kept.extend_from_slice(line);
+            } else {
+                if retain_droppable {
+                    droppable.extend_from_slice(line);
+                }
+                if pane && !line.ends_with(b"\n") {
+                    skip_until_newline = true;
+                }
+            }
+            state.observe(line);
+        }
+        FilteredOutput {
+            dropped: bytes.len() - kept.len(),
+            kept,
+            skip_until_newline,
+            droppable,
+        }
+    }
+}
+
+pub struct FilteredOutput {
+    pub kept: Vec<u8>,
+    pub dropped: usize,
+    pub skip_until_newline: bool,
+    droppable: Vec<u8>,
+}

--- a/crates/et-core/tests/output_interrupt.rs
+++ b/crates/et-core/tests/output_interrupt.rs
@@ -1,0 +1,210 @@
+#![forbid(unsafe_code)]
+
+use et_core::flow_control::{FlowControlMode, OutputQueue};
+use et_core::output_interrupt::InterruptInput;
+use et_core::packet::Packet;
+use et_core::proto::{TerminalBuffer, TerminalPacketType};
+use prost::Message;
+
+fn terminal(bytes: &[u8]) -> Packet {
+    Packet::new(
+        TerminalPacketType::TerminalBuffer as u8,
+        TerminalBuffer {
+            buffer: Some(bytes.to_vec()),
+        }
+        .encode_to_vec(),
+    )
+}
+
+fn queue() -> OutputQueue {
+    OutputQueue::new(FlowControlMode::Backpressure, 1024 * 1024)
+}
+
+fn drain(queue: &mut OutputQueue) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    while let Some(packet) = queue.pop() {
+        bytes.extend(
+            TerminalBuffer::decode(packet.payload())
+                .unwrap()
+                .buffer
+                .unwrap(),
+        );
+    }
+    bytes
+}
+
+#[test]
+fn prompt_is_next_when_large_unsent_flood_is_interrupted() {
+    // Given: an unsent flood, with no encryption sequence assigned.
+    let mut queue = queue();
+    queue.push(terminal(&vec![b'x'; 200 * 1024])).unwrap();
+    // When: an interrupt flushes it, followed by new shell output.
+    assert_eq!(queue.flush_terminal_on_interrupt(), 200 * 1024);
+    queue.push(terminal(b"ET_CTRL_C_OK")).unwrap();
+    // Then: the prompt is next and all queue reservations are released.
+    assert_eq!(drain(&mut queue), b"ET_CTRL_C_OK");
+    assert_eq!(queue.bytes(), 0);
+}
+
+#[test]
+fn small_output_is_preserved_when_interrupted() {
+    for size in [0, 1, 64 * 1024 - 1] {
+        // Given: output below the upstream 64KiB threshold.
+        let mut queue = queue();
+        let bytes = vec![b'x'; size];
+        queue.push(terminal(&bytes)).unwrap();
+        // When / Then: an interrupt leaves it byte-exact.
+        assert_eq!(queue.flush_terminal_on_interrupt(), 0);
+        assert_eq!(drain(&mut queue), bytes);
+    }
+}
+
+#[test]
+fn in_flight_and_control_packets_survive_when_unsent_terminal_is_flushed() {
+    // Given: one taken packet and independently queued control traffic.
+    let mut queue = queue();
+    queue.push(terminal(b"already replay owned\n")).unwrap();
+    let in_flight = queue.take().unwrap();
+    let keepalive = Packet::new(TerminalPacketType::KeepAlive as u8, b"ack".as_slice());
+    let forward = Packet::new(
+        TerminalPacketType::PortForwardData as u8,
+        b"data".as_slice(),
+    );
+    queue.push(keepalive.clone()).unwrap();
+    queue.push(terminal(&vec![b'x'; 64 * 1024])).unwrap();
+    queue.push(forward.clone()).unwrap();
+    // When: only pending terminal output is flushed.
+    assert_eq!(queue.flush_terminal_on_interrupt(), 64 * 1024);
+    queue.complete(&in_flight);
+    // Then: control order and in-flight capacity accounting remain valid.
+    assert_eq!(queue.pop(), Some(keepalive));
+    assert_eq!(queue.pop(), Some(forward));
+    assert_eq!(queue.bytes(), 0);
+}
+
+#[test]
+fn tmux_control_and_response_blocks_survive_when_pane_flood_is_flushed() {
+    // Given: pane output split across packets, with a command response block.
+    let mut queue = queue();
+    queue.push(terminal(b"%out")).unwrap();
+    queue
+        .push(terminal(
+            format!("put %0 {}\n%begin 1 2\n", "x".repeat(70 * 1024)).as_bytes(),
+        ))
+        .unwrap();
+    queue
+        .push(terminal(
+            b"%output is response text\nplain response\n%end 1 2\n%layout-change @1 layout\n",
+        ))
+        .unwrap();
+    // When: the large unsent pane stream is interrupted.
+    assert!(queue.flush_terminal_on_interrupt() >= 70 * 1024);
+    // Then: notifications and every response byte remain intact.
+    assert_eq!(drain(&mut queue), b"%begin 1 2\n%output is response text\nplain response\n%end 1 2\n%layout-change @1 layout\n");
+}
+
+#[test]
+fn partial_tmux_line_is_finished_when_its_prefix_was_already_taken() {
+    // Given: a prefix already owned by the transport.
+    let mut queue = queue();
+    queue.push(terminal(b"%extended-output %0 0 : ")).unwrap();
+    let sent = queue.take().unwrap();
+    queue
+        .push(terminal(
+            format!(
+                "{}\n%output %0 {}\n%window-add @1\n",
+                "y".repeat(1024),
+                "z".repeat(70 * 1024)
+            )
+            .as_bytes(),
+        ))
+        .unwrap();
+    // When: interrupt cannot remove the prefix or its line continuation.
+    assert!(queue.flush_terminal_on_interrupt() >= 70 * 1024);
+    queue.complete(&sent);
+    // Then: finish that line before the next notification.
+    assert_eq!(
+        drain(&mut queue),
+        format!("{}\n%window-add @1\n", "y".repeat(1024)).as_bytes()
+    );
+}
+
+#[test]
+fn incomplete_dropped_tmux_line_is_skipped_until_its_newline() {
+    // Given: the final pane line is incomplete at the interrupt.
+    let mut queue = queue();
+    queue
+        .push(terminal(
+            format!("%output %0 {}", "z".repeat(70 * 1024)).as_bytes(),
+        ))
+        .unwrap();
+    // When: drop it, including a continuation arriving later.
+    assert!(queue.flush_terminal_on_interrupt() > 0);
+    queue.push(terminal(b"continuation")).unwrap();
+    queue.push(terminal(b"\n%window-add @2\n")).unwrap();
+    // Then: no orphan pane fragment leaks into the control stream.
+    assert_eq!(drain(&mut queue), b"%window-add @2\n");
+}
+
+#[test]
+fn response_block_is_preserved_when_begin_was_already_delivered() {
+    // Given: a split response to a tmux control command.
+    let mut queue = queue();
+    queue.push(terminal(b"%begin 1 2\n")).unwrap();
+    queue.pop().unwrap();
+    let rest = format!("{}\n%end 1 2\n", "r".repeat(70 * 1024));
+    queue.push(terminal(rest.as_bytes())).unwrap();
+    // When / Then: response text is never treated as pane output.
+    assert_eq!(queue.flush_terminal_on_interrupt(), 0);
+    assert_eq!(drain(&mut queue), rest.as_bytes());
+}
+
+#[test]
+fn interrupts_are_recognized_when_raw_or_split_tmux_commands_arrive() {
+    // Given / When / Then: supported raw and tmux encodings request a flush.
+    for input in [
+        b"\x03".as_slice(),
+        b"\x1a",
+        b"\x1c",
+        b"send-keys C-c\n",
+        b"send -Ht %0 03\n",
+        b"send -t %0 0x1a\r",
+        b"send-keys ^C\n",
+        b"send-keys C-\\\n",
+    ] {
+        assert!(InterruptInput::default().feed(input), "{input:?}");
+    }
+    let mut input = InterruptInput::default();
+    assert!(!input.feed(b"send-keys -t %0 -H "));
+    assert!(input.feed(b"03\n"));
+}
+
+#[test]
+fn ordinary_input_is_preserved_when_it_mentions_interrupt_spellings() {
+    // Given / When / Then: literal keys, target arguments and output are not interrupts.
+    for input in [
+        b"hello".as_slice(),
+        b"send-keys -l C-c\n",
+        b"send-keys 3\n",
+        b"send-keys -t C-c hello\n",
+        b"%output %0 send-keys -H 3\n",
+        b"send-keys -H 41\n",
+    ] {
+        assert!(!InterruptInput::default().feed(input), "{input:?}");
+    }
+}
+
+#[test]
+fn tmux_responses_precede_queued_pane_flood_without_dropping_bytes() {
+    // Given a saturated tmux stream with a response behind pane output.
+    let mut queue = queue();
+    let pane = format!("%output %0 {}\n", "x".repeat(70 * 1024));
+    queue.push(terminal(pane.as_bytes())).unwrap();
+    let response = b"%begin 1 2\nresponse\n%end 1 2\n";
+    queue.push(terminal(response)).unwrap();
+    // When the writer resumes before any interrupt can be issued by the UI.
+    let bytes = drain(&mut queue);
+    // Then the command response is available first; all pane bytes still follow.
+    assert_eq!(bytes, [response.as_slice(), pane.as_bytes()].concat());
+    assert_eq!(queue.bytes(), 0);
+}

--- a/crates/et-server/src/session.rs
+++ b/crates/et-server/src/session.rs
@@ -2,7 +2,7 @@ use et_net::local::LocalStream;
 use std::io;
 use std::net::{Shutdown, TcpStream};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::time::Duration;
 
 use et_core::backed_writer::{
@@ -23,6 +23,9 @@ use et_net::connection::{ConnError, Connection};
 const RECOVERY_LOCK_TIMEOUT: Duration = et_net::connection::DEFAULT_RECOVERY_TIMEOUT;
 const FLOW_CONTROL_BUFFER_BYTES: usize = 64 * 1024;
 
+#[cfg(test)]
+#[path = "session_output_interrupt_test.rs"]
+mod output_interrupt_tests;
 #[path = "session_flow.rs"]
 mod session_flow;
 #[cfg(test)]
@@ -65,6 +68,7 @@ pub(crate) struct ActiveSession {
     >,
     connection_generation: AtomicU64,
     flow_control: Option<Arc<FlowControl>>,
+    default_output: OnceLock<Arc<FlowControl>>,
     flow_writer: Mutex<Option<std::thread::JoinHandle<()>>>,
     bridge_generation: Mutex<u64>,
     bridge_changed: Condvar,
@@ -130,11 +134,9 @@ impl ActiveSession {
         flow_control: Option<i32>,
     ) -> Result<Self, SessionError> {
         let queue_mode = queue_mode(flow_control);
-        if queue_mode.is_some() {
-            connection
-                .minimize_output_buffering()
-                .map_err(SessionError::Connection)?;
-        }
+        connection
+            .minimize_output_buffering()
+            .map_err(SessionError::Connection)?;
         let control = connection
             .try_clone_stream()
             .map_err(SessionError::Connection)?;
@@ -156,6 +158,7 @@ impl ActiveSession {
             recover_admission_hook: Mutex::new(None),
             connection_generation: AtomicU64::new(0),
             flow_control: queue_mode.map(|mode| Arc::new(FlowControl::new(mode))),
+            default_output: OnceLock::new(),
             flow_writer: Mutex::new(None),
             bridge_generation: Mutex::new(0),
             bridge_changed: Condvar::new(),
@@ -163,14 +166,23 @@ impl ActiveSession {
     }
 
     pub(crate) fn start_flow_writer(self: &Arc<Self>) {
-        let Some(state) = self.flow_control.clone() else {
-            return;
-        };
+        // Bootstrap/control handshakes remain synchronous. Once the terminal
+        // bridge starts, even default sessions stage output before replay.
+        let state = Arc::clone(self.flow_control.as_ref().unwrap_or_else(|| {
+            self.default_output
+                .get_or_init(|| Arc::new(FlowControl::new_default()))
+        }));
         let session = Arc::downgrade(self);
         let handle = std::thread::spawn(move || session_flow::run_writer(session, state));
         if let Ok(mut writer) = self.flow_writer.lock() {
             *writer = Some(handle);
         }
+    }
+
+    fn output_flow(&self) -> Option<&Arc<FlowControl>> {
+        self.flow_control
+            .as_ref()
+            .or_else(|| self.default_output.get())
     }
 
     #[cfg(test)]
@@ -224,7 +236,10 @@ impl ActiveSession {
     where
         W: FnMut(&mut Connection, u8, &[u8]) -> Result<(), et_net::connection::WritePacketError>,
     {
-        if let Some(state) = &self.flow_control {
+        if let Some(state) = self.output_flow().filter(|_| {
+            self.flow_control.is_some()
+                || header == et_core::proto::TerminalPacketType::TerminalBuffer as u8
+        }) {
             return state
                 .enqueue(Packet::new(header, payload))
                 .map_err(SessionWriteError::BeforeReplay);
@@ -367,7 +382,7 @@ impl ActiveSession {
     }
 
     fn join_flow_writer(&self, graceful: bool) -> Result<(), SessionError> {
-        if let Some(state) = &self.flow_control {
+        if let Some(state) = self.output_flow() {
             if graceful {
                 state.stop_gracefully();
             } else {
@@ -384,8 +399,7 @@ impl ActiveSession {
         }
         if graceful
             && self
-                .flow_control
-                .as_ref()
+                .output_flow()
                 .is_some_and(|state| state.unrecoverable())
         {
             return Err(SessionError::Connection(ConnError::Io(io::Error::new(
@@ -397,7 +411,7 @@ impl ActiveSession {
     }
 
     fn stop_flow_writer(&self) {
-        if let Some(state) = &self.flow_control {
+        if let Some(state) = self.output_flow() {
             state.stop_hard();
         }
     }

--- a/crates/et-server/src/session_flow.rs
+++ b/crates/et-server/src/session_flow.rs
@@ -6,6 +6,9 @@ use et_net::connection::ConnError;
 
 use super::{ActiveSession, SessionError, FLOW_CONTROL_BUFFER_BYTES};
 
+const CONNECTED_OUTPUT_BYTES: usize = 16 * 1024 * 1024;
+const DISCONNECTED_OUTPUT_BYTES: usize = 64 * 1024 * 1024;
+
 #[cfg(test)]
 #[path = "session_flow_hook.rs"]
 mod test_hook;
@@ -29,6 +32,21 @@ struct WriterState {
     reader_waiting: bool,
     stop: StopMode,
     unrecoverable: bool,
+    default_buffering: bool,
+    input: et_core::output_interrupt::InterruptInput,
+}
+
+impl WriterState {
+    fn set_connected(&mut self, connected: bool) {
+        self.connected = connected;
+        if self.default_buffering {
+            self.queue.set_limit(if connected {
+                CONNECTED_OUTPUT_BYTES
+            } else {
+                DISCONNECTED_OUTPUT_BYTES
+            });
+        }
+    }
 }
 
 pub(super) struct FlowControl {
@@ -40,15 +58,25 @@ pub(super) struct FlowControl {
 
 impl FlowControl {
     pub(super) fn new(mode: FlowControlMode) -> Self {
+        Self::with_limit(mode, FLOW_CONTROL_BUFFER_BYTES)
+    }
+
+    pub(super) fn new_default() -> Self {
+        Self::with_limit(FlowControlMode::Backpressure, CONNECTED_OUTPUT_BYTES)
+    }
+
+    fn with_limit(mode: FlowControlMode, limit: usize) -> Self {
         Self {
             state: Mutex::new(WriterState {
-                queue: OutputQueue::new(mode, FLOW_CONTROL_BUFFER_BYTES),
+                queue: OutputQueue::new(mode, limit),
                 connected: true,
                 paused: false,
                 in_flight: false,
                 reader_waiting: false,
                 stop: StopMode::Running,
                 unrecoverable: false,
+                default_buffering: limit == CONNECTED_OUTPUT_BYTES,
+                input: et_core::output_interrupt::InterruptInput::default(),
             }),
             wake: Condvar::new(),
             #[cfg(test)]
@@ -78,6 +106,17 @@ impl FlowControl {
         }
     }
 
+    pub(super) fn observe_input(&self, bytes: &[u8]) -> Result<usize, SessionError> {
+        let mut state = self.state.lock().map_err(|_| SessionError::Unavailable)?;
+        let dropped = if state.input.feed(bytes) {
+            state.queue.flush_terminal_on_interrupt()
+        } else {
+            0
+        };
+        self.wake.notify_all();
+        Ok(dropped)
+    }
+
     pub(super) fn can_accept_terminal(&self, bytes: usize) -> Result<bool, SessionError> {
         let state = self.state.lock().map_err(|_| SessionError::Unavailable)?;
         Ok(state.stop == StopMode::Running && state.queue.can_accept_terminal(bytes))
@@ -100,7 +139,7 @@ impl FlowControl {
 
     pub(super) fn resume(&self, connected: bool) {
         if let Ok(mut state) = self.state.lock() {
-            state.connected = connected;
+            state.set_connected(connected);
             state.paused = false;
             if !connected && state.stop == StopMode::Graceful {
                 state.unrecoverable = true;
@@ -112,7 +151,7 @@ impl FlowControl {
 
     pub(super) fn disconnected(&self) {
         if let Ok(mut state) = self.state.lock() {
-            state.connected = false;
+            state.set_connected(false);
             self.wake.notify_all();
         }
     }
@@ -234,7 +273,7 @@ impl FlowControl {
             return false;
         };
         state.in_flight = false;
-        state.connected = connected;
+        state.set_connected(connected);
         match result {
             writer::FlowWriteResult::Delivered => {
                 state.queue.complete(&packet);
@@ -245,7 +284,7 @@ impl FlowControl {
             }
             writer::FlowWriteResult::BeforeReplay(_error) => {
                 state.queue.restore_front(packet);
-                state.connected = false;
+                state.set_connected(false);
                 if state.stop == StopMode::Graceful {
                     state.unrecoverable = true;
                     state.stop = StopMode::Hard;
@@ -253,7 +292,7 @@ impl FlowControl {
             }
             writer::FlowWriteResult::ReplayOwned(_error) => {
                 state.queue.complete(&packet);
-                state.connected = false;
+                state.set_connected(false);
                 if state.stop == StopMode::Graceful {
                     state.unrecoverable = true;
                     state.stop = StopMode::Hard;

--- a/crates/et-server/src/session_io.rs
+++ b/crates/et-server/src/session_io.rs
@@ -33,17 +33,35 @@ impl ActiveSession {
     }
 
     pub(crate) fn try_read_packet(&self) -> Result<Option<et_core::packet::Packet>, SessionError> {
-        if let Some(flow) = &self.flow_control {
+        if let Some(flow) = self.output_flow() {
             flow.set_reader_waiting(true);
         }
         let result = (|| {
-            self.connection
+            let packet = self
+                .connection
                 .lock()
                 .map_err(|_| SessionError::Unavailable)?
                 .try_read_packet()
-                .map_err(SessionError::Connection)
+                .map_err(SessionError::Connection)?;
+            if let (Some(flow), Some(packet)) = (self.output_flow(), packet.as_ref()) {
+                if packet.header() == et_core::proto::TerminalPacketType::TerminalBuffer as u8 {
+                    use prost::Message;
+                    let input = et_core::proto::TerminalBuffer::decode(packet.payload()).map_err(
+                        |error| {
+                            SessionError::Io(std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                error,
+                            ))
+                        },
+                    )?;
+                    if let Some(bytes) = input.buffer {
+                        flow.observe_input(&bytes)?;
+                    }
+                }
+            }
+            Ok(packet)
         })();
-        if let Some(flow) = &self.flow_control {
+        if let Some(flow) = self.output_flow() {
             flow.set_reader_waiting(false);
         }
         result
@@ -117,7 +135,7 @@ impl ActiveSession {
             return Ok(false);
         }
         connection.disconnect();
-        if let Some(state) = &self.flow_control {
+        if let Some(state) = self.output_flow() {
             state.disconnected();
         }
         Ok(true)
@@ -144,7 +162,7 @@ impl ActiveSession {
     }
 
     pub(crate) fn can_buffer_write(&self, bytes: i64) -> Result<bool, SessionError> {
-        if let Some(state) = &self.flow_control {
+        if let Some(state) = self.output_flow() {
             let bytes = usize::try_from(bytes).map_err(|_| SessionError::Unavailable)?;
             return state.can_accept_terminal(bytes);
         }

--- a/crates/et-server/src/session_output_interrupt_test.rs
+++ b/crates/et-server/src/session_output_interrupt_test.rs
@@ -1,0 +1,148 @@
+#![cfg(unix)]
+
+use std::net::{Ipv4Addr, TcpListener, TcpStream};
+use std::sync::{mpsc, Arc};
+use std::time::{Duration, Instant};
+
+use et_core::packet::Packet;
+use et_core::proto::{TerminalBuffer, TerminalPacketType};
+use et_net::connection::Connection;
+use prost::Message;
+use rustix::event::{poll, PollFd, PollFlags};
+
+use super::ActiveSession;
+
+const TIMEOUT: Duration = Duration::from_secs(3);
+
+fn terminal(bytes: &[u8]) -> Packet {
+    Packet::new(
+        TerminalPacketType::TerminalBuffer as u8,
+        TerminalBuffer {
+            buffer: Some(bytes.to_vec()),
+        }
+        .encode_to_vec(),
+    )
+}
+
+#[test]
+fn output_interrupt_default_runtime_flushes_only_unsent_packets() {
+    // Given / When: a large unsequenced flood and Ctrl+C traverse a native
+    // encrypted session; the recovery admission permit is only a queue gate.
+    let packets = output_after_interrupt(&vec![b'x'; 128 * 1024]);
+    // Then: the client decrypts control and the subsequent prompt, not flood.
+    assert_eq!(
+        packets,
+        vec![control(), terminal(b"ET_CTRL_C_OK")],
+        "interrupted unsent flood reached the encrypted client"
+    );
+}
+
+#[test]
+fn output_interrupt_preserves_small_terminal_output() {
+    // Given / When: the same real transport path with less than 64KiB pending.
+    let packets = output_after_interrupt(b"small output\n");
+    // Then: terminal bytes survive exactly; the control packet also survives.
+    let mut bytes = Vec::new();
+    let mut controls = Vec::new();
+    for packet in packets {
+        if packet.header() == TerminalPacketType::TerminalBuffer as u8 {
+            bytes.extend(
+                TerminalBuffer::decode(packet.payload())
+                    .unwrap()
+                    .buffer
+                    .unwrap(),
+            );
+        } else {
+            controls.push(packet);
+        }
+    }
+    assert_eq!(bytes, b"small output\nET_CTRL_C_OK");
+    assert_eq!(controls, vec![control()]);
+}
+
+fn control() -> Packet {
+    Packet::new(TerminalPacketType::KeepAlive as u8, b"control".as_slice())
+}
+
+fn output_after_interrupt(bytes: &[u8]) -> Vec<Packet> {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+    let (server, _) = listener.accept().unwrap();
+    let mut client = Connection::new_client(client, &[7; 32]);
+    client.set_io_timeout(Some(TIMEOUT)).unwrap();
+    let (terminal_socket, _peer) = et_net::local::wake_pair().unwrap();
+    let session = Arc::new(
+        ActiveSession::new(
+            Connection::new_server(server, &[7; 32]),
+            &terminal_socket,
+            None,
+        )
+        .unwrap(),
+    );
+    session.start_flow_writer();
+    let first = terminal(b"replay prefix\n");
+    session
+        .send_packet(first.header(), first.payload())
+        .unwrap();
+    assert_eq!(client.read_packet().unwrap(), first);
+
+    // Existing recovery admission deterministically retains output before any
+    // sequence is assigned. No socket timing or writer callback is asserted.
+    let permit = session.try_begin_recover().unwrap();
+    for chunk in bytes.chunks(16 * 1024) {
+        let packet = terminal(chunk);
+        session
+            .send_packet(packet.header(), packet.payload())
+            .unwrap();
+    }
+    let control = control();
+    session
+        .send_packet(control.header(), control.payload())
+        .unwrap();
+
+    let interrupt = terminal(b"\x03");
+    client
+        .write_packet(interrupt.header(), interrupt.payload())
+        .unwrap();
+    let (stream, _) = session.try_clone_stream().unwrap();
+    let deadline = Instant::now() + TIMEOUT;
+    let input = loop {
+        if let Some(packet) = session.try_read_packet().unwrap() {
+            break packet;
+        }
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .expect("encrypted interrupt was not readable before deadline");
+        let timeout = rustix::time::Timespec::try_from(remaining).unwrap();
+        let mut descriptors = [PollFd::new(&stream, PollFlags::IN)];
+        match poll(&mut descriptors, Some(&timeout)) {
+            Ok(_) => {}
+            Err(rustix::io::Errno::INTR) => {}
+            Err(error) => panic!("interrupt readiness failed: {error}"),
+        }
+    };
+    assert_eq!(input, interrupt);
+    let prompt = terminal(b"ET_CTRL_C_OK");
+    session
+        .send_packet(prompt.header(), prompt.payload())
+        .unwrap();
+
+    let (done_tx, done_rx) = mpsc::sync_channel(1);
+    let reader = std::thread::spawn(move || {
+        let mut packets = Vec::new();
+        loop {
+            let packet = client.read_packet().unwrap();
+            let done = packet == prompt;
+            packets.push(packet);
+            if done {
+                break;
+            }
+        }
+        done_tx.send(packets).unwrap();
+    });
+    drop(permit);
+    let packets = done_rx.recv_timeout(TIMEOUT).unwrap();
+    reader.join().unwrap();
+    session.shutdown().unwrap();
+    packets
+}

--- a/crates/et-server/src/session_recovery.rs
+++ b/crates/et-server/src/session_recovery.rs
@@ -40,7 +40,7 @@ impl ActiveSession {
                 return Err(SessionError::RecoverBusy);
             }
         }
-        if let Some(flow) = &self.flow_control {
+        if let Some(flow) = self.output_flow() {
             if let Err(error) = flow.pause() {
                 self.recovering.store(false, Ordering::Release);
                 return Err(error);
@@ -81,7 +81,7 @@ impl ActiveSession {
         candidate
             .authenticate_peer(DEFAULT_RECOVERY_TIMEOUT)
             .map_err(SessionError::Connection)?;
-        if self.flow_control.is_some() {
+        if self.output_flow().is_some() {
             candidate
                 .minimize_output_buffering()
                 .map_err(SessionError::Connection)?;
@@ -201,7 +201,7 @@ impl Drop for RecoverPermit<'_> {
         // Catch anything that observed `recovering` and queued after the first
         // flush but before the flag cleared (re-check is under the hold lock).
         let _ = self.session.flush_recover_hold();
-        if let Some(state) = &self.session.flow_control {
+        if let Some(state) = self.session.output_flow() {
             let connected = self
                 .session
                 .connection

--- a/docs/upstream-pin.md
+++ b/docs/upstream-pin.md
@@ -10,7 +10,7 @@ Canonical machine files:
 - Ledger (every `master` commit after baseline):
   [`.github/upstream-ledger.yml`](../.github/upstream-ledger.yml)
 
-Recorded 2026-08-21 from GitHub (`gh` / REST). Ledger classified 2026-09-04.
+Recorded 2026-08-21 from GitHub (`gh` / REST). Ledger classified 2026-09-05.
 `#784` marked `ported` after et.rs [#31](https://github.com/minpeter/et.rs/pull/31) / `906a7ca86691f00a82f88b99b21d7afceb07bf97`.
 `#798` marked `ported` after et.rs [#77](https://github.com/minpeter/et.rs/pull/77).
 
@@ -20,13 +20,13 @@ Recorded 2026-08-21 from GitHub (`gh` / REST). Ledger classified 2026-09-04.
 | Baseline / latest release tag | [`et-v7.0.0`](https://github.com/MisterTea/EternalTerminal/releases/tag/et-v7.0.0) |
 | Baseline / release commit | [`7656a32a5bc15c6746726a27a5a4ba1e468fab6e`](https://github.com/MisterTea/EternalTerminal/commit/7656a32a5bc15c6746726a27a5a4ba1e468fab6e) |
 | Default branch | `master` |
-| Pin tip (last classified) | [`584a68b4b54c74de7035e6108f49151ebce6a191`](https://github.com/MisterTea/EternalTerminal/commit/584a68b4b54c74de7035e6108f49151ebce6a191) (`#792`, 2026-09-03; reviewed 2026-09-04) |
+| Pin tip (last classified) | [`cd7319020edce131fbd6f21b1a87e07f4ac41cdb`](https://github.com/MisterTea/EternalTerminal/commit/cd7319020edce131fbd6f21b1a87e07f4ac41cdb) (`#804`, 2026-09-05) |
 | et.rs wire version | **protocol v6** (`PROTOCOL_VERSION = 6` in `crates/et-core/src/lib.rs`, README) |
 | ET wire version at this pin | still **protocol v6** (`PROTOCOL_VERSION = 6` in `src/base/Headers.hpp` on both `et-v7.0.0` and `master`) |
 
-`7656a32...master` is `ahead_by` 16. All 16 are classified. Unclassified would be drift.
+The reviewed `7656a32...cd731902` range contains 17 classified commits. Unclassified commits would be drift.
 
-## Ledger (classified 2026-09-04)
+## Ledger (classified 2026-09-05)
 
 | sha | date | kind | status | note |
 | --- | --- | --- | --- | --- |
@@ -48,6 +48,14 @@ Recorded 2026-08-21 from GitHub (`gh` / REST). Ledger classified 2026-09-04.
 | [`584a68b`](https://github.com/MisterTea/EternalTerminal/commit/584a68b4b54c74de7035e6108f49151ebce6a191) | 2026-09-03 | security | skip | #792 disable SO_LINGER. et.rs never sets SO_LINGER and has no globalMutex-on-close; default linger-off already matches. |
 
 ## Ported and residual
+
+[`cd731902`](https://github.com/MisterTea/EternalTerminal/commit/cd7319020edce131fbd6f21b1a87e07f4ac41cdb)
+(`#804`) is `status: porting` pending final review. Rust stages terminal output
+before assigning replay sequences, flushes unsent floods at the 64 KiB threshold,
+preserves small output and tmux response/control lines, and prioritizes tmux
+responses ahead of queued pane output. Native socket buffers remain small.
+The implementation reuses Rust's existing bounded queues and cancellation rather
+than copying the C++ event loop. Protocol v6 and generated wire fixtures are unchanged.
 
 [`69b3353`](https://github.com/MisterTea/EternalTerminal/commit/69b33537ab12f324cf619aca04dc483728dc30c3) (`#784`) is `status: ported`.
 It landed in et.rs via [#31](https://github.com/minpeter/et.rs/pull/31) /
@@ -81,7 +89,7 @@ this pin as a green light to bump `PROTOCOL_VERSION` or land a v7 port.
 default linger-off already matches the C++ fix).
 
 et.rs still claims **protocol v6**. EternalTerminal’s latest product release is
-**v7.0.0**, and `master` is sixteen classified commits past that tag.
+**v7.0.0**, and the reviewed tip is seventeen classified commits past that tag.
 
 Review ports against the conflict policy in
 [`docs/upstream-factory.md`](upstream-factory.md). Gate any later port with


### PR DESCRIPTION
## Summary
- Stage default terminal output before replay ownership and flush unsent floods on interrupt at 64 KiB.
- Preserve small output, in-flight/control packets and tmux responses; prioritize tmux response blocks ahead of queued pane floods.
- Bound terminal/jumphost socket buffers and retain existing default nonterminal recovery ordering.
- Classify upstream #804 as porting pending final review; protocol v6 and golden fixtures unchanged.

## Verification
- Full workspace formatting, clippy, serialized tests and build passed before clean main integration.
- Behavioral RED/GREEN for encrypted server output, local console output, threshold boundary and tmux response priority.
- Existing 12 runtime recovery tests pass after correcting default generic packet routing.
- Real ET client/server PTY flood at 100 KiB/s: Ctrl+C followed by next command marker in 1544 ms; processes/proxy/private directory cleaned.
- Integrated real-surface check, hosted CI and independent gate review required before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Interrupting a terminal session now flushes large unsent output so Ctrl+C returns to a usable prompt promptly, including with `--flow-control none`. Previously default output bypassed the bounded console queue and could stay stuck behind a flood; now unsent output is staged and floods are dropped at 64 KiB.

**Behavior**
- Small output, in-flight/control packets, and tmux control responses survive; complete tmux response blocks are delivered ahead of queued pane output, and incomplete tmux records remain ordering barriers.
- Terminal and jumphost socket buffers are bounded for all flow-control modes.
- Queued terminal and synchronous control writes are serialized so encrypted frames keep their assigned order.
- Nonterminal packet ordering through recovery is unchanged.
- Upstream #804 is marked as porting pending final review; protocol v6 and wire fixtures are unchanged.

<sup>Written for commit f40b1bae1c5bf20a9bff8afebd1bed2fe28dea43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/et.rs/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

